### PR TITLE
Adds Rubocop to 'build' and 'development' group

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,6 @@ group :test do
   gem 'site_prism'
 end
 
-group :build do
-  gem 'rubocop'
+group :build, :development do
+  gem 'rubocop', '~> 0.49.1', require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -225,7 +225,7 @@ DEPENDENCIES
   pry-rails
   rails (~> 4.2.7)
   rspec-rails (~> 3.5)
-  rubocop
+  rubocop (~> 0.49.1)
   sass-rails
   shoulda-matchers (~> 3.1)
   simplecov

--- a/README.md
+++ b/README.md
@@ -120,6 +120,19 @@ This value will be displayed at the end of your Rspec tests.
 
 To view the coverage output open `coverage/index.html` in your browser.
 
+## Code Quality
+### Rubocop
+The build script has been set up to fail if the code quality does not meet expectations as set out in the standard Rubocop file. The code quality standards have been set out in this file`.rubocop.yml`, which is within this project.
+
+#### Run Rubocop on all applicable files
+Run Rubocop locally with this command, `$ bundle exec rubocop .`
+
+#### Run Rubocop on a single file
+`$ bundle exec rubocop app/models/wpcc/your_details_form.rb`
+
+#### Run Rubocop over a directory
+`$ bundle exec rubocop app/`
+
 ## License
 
 The gem is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).


### PR DESCRIPTION
This PR alters Rubocop from being available to the _build_ group only. It adds it to the _development_ group too. It ensures that the version of Rubocop that runs for the build group is the same version(`~> 0.49.1`) for running Rubocop locally in development mode.