### PR TITLE
8319 Reduce Contribution table results

### DIFF
--- a/app/models/wpcc/contributions_calendar.rb
+++ b/app/models/wpcc/contributions_calendar.rb
@@ -6,7 +6,7 @@ module Wpcc
                 :employer_percent
 
     PERIODS_FILE = Wpcc::Engine.root.join('config', 'contribution_periods.yml')
-    PERIODS = YAML.load_file(PERIODS_FILE)
+    PERIODS = HashWithIndifferentAccess.new(YAML.load_file(PERIODS_FILE))
 
     def initialize(eligible_salary:,
                    employee_percent:,
@@ -21,7 +21,6 @@ module Wpcc
 
     def schedule
       periods_above_user_contributions.map do |period, percents|
-        percents.symbolize_keys!
         employee_percentage = percents[:employee_percent] || employee_percent
         employer_percentage = percents[:employer_percent] || employer_percent
 
@@ -41,8 +40,8 @@ module Wpcc
     def periods_above_user_contributions
       periods.select do |_, percents|
         percents[:employee_percent].blank? ||
-        percents[:employee_percent] > employee_percent &&
-        percents[:employer_percent] > employer_percent
+          percents[:employee_percent] > employee_percent &&
+            percents[:employer_percent] > employer_percent
       end
     end
 

--- a/app/models/wpcc/contributions_calendar.rb
+++ b/app/models/wpcc/contributions_calendar.rb
@@ -20,7 +20,7 @@ module Wpcc
     end
 
     def schedule
-      periods.map do |period, percents|
+      periods_above_user_contributions.map do |period, percents|
         percents.symbolize_keys!
         employee_percentage = percents[:employee_percent] || employee_percent
         employer_percentage = percents[:employer_percent] || employer_percent
@@ -37,6 +37,14 @@ module Wpcc
     end
 
     private
+
+    def periods_above_user_contributions
+      periods.select do |_, percents|
+        percents[:employee_percent].blank? ||
+        percents[:employee_percent] > employee_percent &&
+        percents[:employer_percent] > employer_percent
+      end
+    end
 
     def periods
       PERIODS

--- a/app/models/wpcc/contributions_calendar.rb
+++ b/app/models/wpcc/contributions_calendar.rb
@@ -39,10 +39,18 @@ module Wpcc
 
     def periods_above_user_contributions
       periods.select do |_, percents|
-        percents[:employee_percent].blank? ||
-          percents[:employee_percent] > employee_percent &&
-            percents[:employer_percent] > employer_percent
+        current_period?(percents) ||
+          contribution_below_legal_minimum?(percents)
       end
+    end
+
+    def current_period?(percents)
+      percents[:employee_percent].blank?
+    end
+
+    def contribution_below_legal_minimum?(percents)
+      employee_percent < percents[:employee_percent] ||
+        employer_percent < percents[:employer_percent]
     end
 
     def periods

--- a/app/models/wpcc/contributions_calendar.rb
+++ b/app/models/wpcc/contributions_calendar.rb
@@ -20,21 +20,19 @@ module Wpcc
     end
 
     def schedule
-      periods.map do |period, period_percents|
-        period_percents.symbolize_keys!
-        if period_percents[:employee_percent] &&
-           period_percents[:employer_percent]
+      periods.map do |period, percents|
+        percents.symbolize_keys!
+        employee_percentage = percents[:employee_percent] || employee_percent
+        employer_percentage = percents[:employer_percent] || employer_percent
 
-          calculate_contribution(period,
-                                 period_percents[:employee_percent],
-                                 period_percents[:employer_percent],
-                                 period_percents[:tax_relief_percent])
-        else
-          calculate_contribution(period,
-                                 employee_percent,
-                                 employer_percent,
-                                 period_percents[:tax_relief_percent])
-        end
+        Wpcc::PeriodContributionCalculator.new(
+          name: period.to_s,
+          employee_percent: employee_percentage,
+          employer_percent: employer_percentage,
+          eligible_salary: eligible_salary,
+          salary_frequency: salary_frequency,
+          tax_relief_percent: percents[:tax_relief_percent]
+        ).contribution
       end
     end
 
@@ -42,21 +40,6 @@ module Wpcc
 
     def periods
       PERIODS
-    end
-
-    def calculate_contribution(period,
-                               employee_percent,
-                               employer_percent,
-                               tax_relief_percent)
-      period_args = {
-        name: period.to_s,
-        employee_percent: employee_percent,
-        employer_percent: employer_percent,
-        tax_relief_percent: tax_relief_percent
-      }
-      Wpcc::PeriodContributionCalculator.new(eligible_salary,
-                                             salary_frequency,
-                                             period_args).contribution
     end
   end
 end

--- a/app/models/wpcc/period_contribution_calculator.rb
+++ b/app/models/wpcc/period_contribution_calculator.rb
@@ -1,20 +1,13 @@
 module Wpcc
   class PeriodContributionCalculator
-    attr_reader :eligible_salary,
-                :salary_frequency,
-                :employee_percent,
-                :employer_percent,
-                :tax_relief_percent,
-                :name
+    include ActiveModel::Model
 
-    def initialize(eligible_salary, salary_frequency, period_args)
-      @name = period_args[:name]
-      @eligible_salary = eligible_salary
-      @salary_frequency = salary_frequency
-      @employee_percent = period_args[:employee_percent]
-      @employer_percent = period_args[:employer_percent]
-      @tax_relief_percent = period_args[:tax_relief_percent]
-    end
+    attr_accessor :eligible_salary,
+                  :salary_frequency,
+                  :employee_percent,
+                  :employer_percent,
+                  :tax_relief_percent,
+                  :name
 
     def contribution
       PeriodContribution.new(

--- a/spec/models/contributions_calendar_spec.rb
+++ b/spec/models/contributions_calendar_spec.rb
@@ -82,7 +82,7 @@ describe Wpcc::ContributionsCalendar, type: :model do
         end
       end
 
-      context 'when the user employee percent and employer percent is greatersor equal than the period percents' do
+      context 'when contribution periods less than user percents' do
         let(:next_period) do
           {
             current: {
@@ -98,7 +98,7 @@ describe Wpcc::ContributionsCalendar, type: :model do
         let(:employee_percent) { 3 }
         let(:employer_percent) { 4 }
 
-        it 'ignores period percents less than user percents' do
+        it 'excludes lower contribution periods' do
           expect(schedule.size).to eq(1)
         end
       end

--- a/spec/models/contributions_calendar_spec.rb
+++ b/spec/models/contributions_calendar_spec.rb
@@ -81,6 +81,27 @@ describe Wpcc::ContributionsCalendar, type: :model do
           schedule
         end
       end
+
+      context 'when the user employee percent and employer percent is greatersor equal than the period percents' do
+        let(:next_period) do
+          {
+            current: {
+              tax_relief_percent: 20
+            },
+            some_period: {
+              tax_relief_percent: 20,
+              employee_percent: 3,
+              employer_percent: 4
+            }
+          }
+        end
+        let(:employee_percent) { 3 }
+        let(:employer_percent) { 4 }
+
+        it 'ignores period percents less than user percents' do
+          expect(schedule.size).to eq(1)
+        end
+      end
     end
   end
 end

--- a/spec/models/contributions_calendar_spec.rb
+++ b/spec/models/contributions_calendar_spec.rb
@@ -42,11 +42,11 @@ describe Wpcc::ContributionsCalendar, type: :model do
         it 'calls the PeriodContribution with the user provided percents' do
           expect(Wpcc::PeriodContributionCalculator)
             .to receive(:new)
-            .with(eligible_salary,
-                  salary_frequency,
-                  name: current_period.keys.first.to_s,
+            .with(name: current_period.keys.first.to_s,
                   employee_percent: employee_percent,
                   employer_percent: employer_percent,
+                  eligible_salary: eligible_salary,
+                  salary_frequency: salary_frequency,
                   tax_relief_percent: 20)
             .and_return(period_contribution_calculator)
           expect(period_contribution_calculator).to receive(:contribution)
@@ -70,11 +70,11 @@ describe Wpcc::ContributionsCalendar, type: :model do
         it 'calls the PeriodContribution with the percents from the yml file' do
           expect(Wpcc::PeriodContributionCalculator)
             .to receive(:new)
-            .with(eligible_salary,
-                  salary_frequency,
-                  name: next_period.keys.first.to_s,
+            .with(name: next_period.keys.first.to_s,
                   employee_percent: 3,
                   employer_percent: 4,
+                  eligible_salary: eligible_salary,
+                  salary_frequency: salary_frequency,
                   tax_relief_percent: 20)
             .and_return(period_contribution_calculator)
           expect(period_contribution_calculator).to receive(:contribution)

--- a/spec/models/contributions_calendar_spec.rb
+++ b/spec/models/contributions_calendar_spec.rb
@@ -92,14 +92,37 @@ describe Wpcc::ContributionsCalendar, type: :model do
               tax_relief_percent: 20,
               employee_percent: 3,
               employer_percent: 4
+            },
+            period_onwards: {
+              tax_relief_percent: 20,
+              employee_percent: 5,
+              employer_percent: 4
             }
           }
         end
-        let(:employee_percent) { 3 }
-        let(:employer_percent) { 4 }
 
-        it 'excludes lower contribution periods' do
-          expect(schedule.size).to eq(1)
+        before do
+          allow(contributions_calendar)
+            .to receive(:periods)
+            .and_return(next_period)
+        end
+
+        context 'when one period is less than user percents' do
+          let(:employee_percent) { 3 }
+          let(:employer_percent) { 4 }
+
+          it 'excludes lower contribution period' do
+            expect(schedule.size).to eq(2)
+          end
+        end
+
+        context 'when two periods is less than user percents' do
+          let(:employee_percent) { 10 }
+          let(:employer_percent) { 10 }
+
+          it 'excludes lower contribution periods' do
+            expect(schedule.size).to eq(1)
+          end
         end
       end
     end

--- a/spec/models/period_contribution_calculator_spec.rb
+++ b/spec/models/period_contribution_calculator_spec.rb
@@ -1,19 +1,13 @@
 describe Wpcc::PeriodContributionCalculator, type: :model do
   let(:period_contribution_calculator) do
     described_class.new(
-      eligible_salary,
-      salary_frequency,
-      period_args
-    )
-  end
-
-  let(:period_args) do
-    {
       name: 'some period',
       employee_percent: employee_percent,
       employer_percent: employer_percent,
-      tax_relief_percent: 20
-    }
+      tax_relief_percent: 20,
+      eligible_salary: eligible_salary,
+      salary_frequency: salary_frequency
+    )
   end
 
   describe '#contribution' do


### PR DESCRIPTION
This PR addresses https://moneyadviceservice.tpondemand.com/entity/8319

When a user inputs contributions higher than the minimum in future periods then those tables should not appear.