### PR TITLE
8393 Step1 create session

### DIFF
--- a/app/controllers/wpcc/your_contributions_controller.rb
+++ b/app/controllers/wpcc/your_contributions_controller.rb
@@ -1,7 +1,7 @@
 module Wpcc
   class YourContributionsController < EngineController
-    def new
-      
-    end
+    protect_from_forgery
+
+    def new; end
   end
 end

--- a/app/controllers/wpcc/your_contributions_controller.rb
+++ b/app/controllers/wpcc/your_contributions_controller.rb
@@ -1,0 +1,7 @@
+module Wpcc
+  class YourContributionsController < EngineController
+    def new
+      
+    end
+  end
+end

--- a/app/controllers/wpcc/your_details_controller.rb
+++ b/app/controllers/wpcc/your_details_controller.rb
@@ -8,6 +8,7 @@ module Wpcc
       @your_details_form = YourDetailsForm.new(your_details_form_params)
 
       if @your_details_form.valid?
+        create_session
         redirect_to your_contributions_path
       else
         redirect_to wpcc_root_path
@@ -28,7 +29,13 @@ module Wpcc
                     :salary,
                     :gender,
                     :salary_frequency,
-                    :employer_contribution)
+                    :contribution_preference)
+    end
+
+    def create_session
+      params[:your_details_form].keys.each do |key|
+        session[key] = params[:your_details_form][key]
+      end
     end
   end
 end

--- a/app/controllers/wpcc/your_details_controller.rb
+++ b/app/controllers/wpcc/your_details_controller.rb
@@ -1,5 +1,7 @@
 module Wpcc
   class YourDetailsController < EngineController
+    protect_from_forgery
+
     def new
       @your_details_form = present(Wpcc::YourDetailsForm.new)
     end
@@ -9,7 +11,7 @@ module Wpcc
 
       if @your_details_form.valid?
         create_session
-        redirect_to your_contributions_path
+        redirect_to new_your_contribution_path
       else
         redirect_to wpcc_root_path
       end
@@ -25,15 +27,15 @@ module Wpcc
     end
 
     def your_details_form_params
-      params.permit(:age,
-                    :salary,
-                    :gender,
-                    :salary_frequency,
-                    :contribution_preference)
+      params.require(:your_details_form).permit(:age,
+                                                :salary,
+                                                :gender,
+                                                :salary_frequency,
+                                                :contribution_preference)
     end
 
     def create_session
-      params[:your_details_form].keys.each do |key|
+      your_details_form_params.keys.each do |key|
         session[key] = params[:your_details_form][key]
       end
     end

--- a/app/models/wpcc/your_details_form.rb
+++ b/app/models/wpcc/your_details_form.rb
@@ -5,7 +5,7 @@ module Wpcc
     include ActiveModel::Model
 
     attr_accessor :age, :gender, :salary
-    attr_accessor :salary_frequency, :employer_contribution
+    attr_accessor :salary_frequency, :contribution_preference
 
     GENDERS = %w[male female].freeze
     SALARY_FREQUENCIES = %w[year month fourweeks week].freeze
@@ -15,6 +15,6 @@ module Wpcc
     validates :gender, inclusion: { in: GENDERS }
     validates :salary, numericality: { only_integer: true, greater_than: 0 }
     validates :salary_frequency, inclusion: { in: SALARY_FREQUENCIES }
-    validates :employer_contribution, inclusion: { in: CONTRIBUTIONS }
+    validates :contribution_preference, inclusion: { in: CONTRIBUTIONS }
   end
 end

--- a/app/presenters/wpcc/your_details_form_presenter.rb
+++ b/app/presenters/wpcc/your_details_form_presenter.rb
@@ -7,13 +7,13 @@ module Wpcc
 
     def gender_options
       Wpcc::YourDetailsForm::GENDERS.map do |gender|
-        text_for('gender', gender)
+        [text_for('gender', gender), gender.downcase]
       end
     end
 
     def salary_frequency_options
       Wpcc::YourDetailsForm::SALARY_FREQUENCIES.map do |frequency|
-        text_for('salary_frequency', frequency)
+        [text_for('salary_frequency', frequency), frequency]
       end
     end
 

--- a/app/views/wpcc/your_contributions/new.html.erb
+++ b/app/views/wpcc/your_contributions/new.html.erb
@@ -1,0 +1,10 @@
+<section class="section section--details details">
+  <div class="details__row">
+    <h2 class="section__heading details__heading">1. <%= t('wpcc.details.title') %></h2>
+    <p>(<%= session[:age] %> years, 
+      <%= session[:gender] %>,
+      £<%= session[:salary] %> <%= session[:salary_frequency] %>, 
+      <%= session[:contribution_preference] %> Contribution)
+    </p>
+  </div>
+</section>

--- a/app/views/wpcc/your_details/new.html.erb
+++ b/app/views/wpcc/your_details/new.html.erb
@@ -89,13 +89,13 @@
             <p class="details__calculate-intro"><%= t('wpcc.details.calculate.details') %></p>
 
             <div class="form__group-item details__calculate-item">
-              <%= f.radio_button(:employer_contribution, 'minimum', class: 'details__calculate-item-select') %>
-              <%= f.label(:employer_contribution_minimum, t('wpcc.details.options.employer_contribution.minimum'), class: 'details__calculate-item-label') %>
+              <%= f.radio_button(:contribution_preference, 'minimum', class: 'details__calculate-item-select') %>
+              <%= f.label(:contribution_preference_minimum, t('wpcc.details.options.contribution_preference.minimum'), class: 'details__calculate-item-label') %>
             </div>
 
             <div class="form__group-item details__calculate-item">
-              <%= f.radio_button(:employer_contribution, 'full', class: 'details__calculate-item-select') %>
-              <%= f.label(:employer_contribution_full, t('wpcc.details.options.employer_contribution.full'), class: 'details__calculate-item-label') %>
+              <%= f.radio_button(:contribution_preference, 'full', class: 'details__calculate-item-select') %>
+              <%= f.label(:contribution_preference_full, t('wpcc.details.options.contribution_preference.full'), class: 'details__calculate-item-label') %>
             </div>
           </fieldset>
         </div>
@@ -128,8 +128,8 @@
         <span>[[Entered Salary]]</span>
       </div>
       <div class="contributions__source contributions__source--employee">
-        <h3 class="contributions__source-title"><%= t('wpcc.contributions.employer_contribution_title') %></h3>
-        <p><%= t('wpcc.contributions.employer_contribution_tip') %></p>
+        <h3 class="contributions__source-title"><%= t('wpcc.contributions.contribution_preference_title') %></h3>
+        <p><%= t('wpcc.contributions.contribution_preference_tip') %></p>
         <input placeholder="1" type="number" class="contributions__source-input" />%
         <%= t('wpcc.contributions.input_of_label') %>
         <span>[[Entered Salary]]</span>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -31,7 +31,7 @@ cy:
         gender:
           female: benywaidd
           male: gwrywaidd
-        contribution:
+        contribution_preference:
           full: Mae fy nghyflogwr yn cyfrannu ar fy nghyflog llawn
           part: Mae fy nghyflogwr yn cyfrannu ar ran o fy nghyflog (os nad ydych yn siŵr dewiswch yr opsiwn hwn)
 
@@ -53,8 +53,8 @@ cy:
       description_tooltip: Dyma’r rhan o’ch cyflog blynyddol a ddefnyddir i gyfrifo’ch cyfraniad pensiwn dan gofrestru awtomatig. Sef eich enillion cyn treth (hyd at derfyn uchafswm o £45000 y flwyddyn) – meinws trothwy enillion isaf o £5,876.
       your_contribution_title: Nodwch eich cyfraniad
       your_contribution_tip: Yr isafswm cyfreithiol yw 1%
-      employer_contribution_title: Nodwch gyfraniad eich cyflogwr
-      employer_contribution_tip: Yr isafswm cyfreithiol yw 1%
+      contribution_preference_title: Nodwch gyfraniad eich cyflogwr
+      contribution_preference_tip: Yr isafswm cyfreithiol yw 1%
       input_of_label: o
       calculate_button: Cyfrifwch eich cyfraniadau
       employee_contribution_warning: Y cyfraniad uchaf gewch chi ei roi mewn pensiwn fesul blwyddyn yw 100% o’ch cyflog neu £40,000, pa bynnag un sydd leiaf.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -31,7 +31,7 @@ en:
         gender:
           female: Female
           male: Male
-        employer_contribution:
+        contribution_preference:
           full: My employer makes contributions on my full salary
           minimum: My employer makes contributions on part of my salary (if you're not sure select this option)
 
@@ -52,8 +52,8 @@ en:
       description_tooltip: This is the part of your annual pay that will be used to calculate your pension contribution under automatic enrolment. It is your earnings before tax (up to a maximum limit of £45000 per year) – less the lower earnings threshold of £5,876.
       your_contribution_title: Enter your contribution
       your_contribution_tip: The legal minimum is 1%
-      employer_contribution_title: Enter your employer’s contribution
-      employer_contribution_tip: The legal minimum is 1%
+      contribution_preference_title: Enter your employer’s contribution
+      contribution_preference_tip: The legal minimum is 1%
       input_of_label: of
       calculate_button: Calculate your contributions
       employee_contribution_warning: The maximum you can contribute to a pension per year is 100% of your salary or £40,000, whichever is lower.

--- a/features/step_definitions/your_details_section_steps.rb
+++ b/features/step_definitions/your_details_section_steps.rb
@@ -1,0 +1,30 @@
+Given(/^I am on step 1 of the WPCC homepage$/) do
+  @your_details_page = UI::YourDetails.new
+  @your_details_page.load
+end
+
+When(/^I fill in the age, gender, salary and frequency fields$/) do
+  @your_details_page.age.set 35
+  @your_details_page.genders.select('Female')
+  @your_details_page.salary.set 35000
+  @your_details_page.salary_frequencies.select('per Year')
+end
+
+And(/^I click on "My employer makes contributions on part of my salary"$/) do
+  @your_details_page.minimum_contribution_button.set true
+end
+
+And(/^I click on "My employer makes contributions on all of my salary"$/) do
+  @your_details_page.full_contribution_button.set true
+end
+
+And(/^I click the Next button$/) do
+  your_details_page.load.next_button.click
+end
+
+Then(/^I should see my age, gender, salary, frequency and contribution option$/) do
+  expect(your_contributions_page.details).to have_content('35 years')
+  expect(your_contributions_page.details).to have_content('female')
+  expect(your_contributions_page.details).to have_content('£35000 year')
+  expect(your_contributions_page.details).to have_content('minimum Contribution')
+end

--- a/features/support/ui/your_contributions.rb
+++ b/features/support/ui/your_contributions.rb
@@ -1,0 +1,13 @@
+require_relative 'ui'
+
+module UI
+  class EmployeePercentSection < SitePrism::Page; end
+  class EmployerPercentSection < SitePrism::Page; end
+
+  class YourContributions < SitePrism::Page
+    set_url '{/locale}/tools/wpcc/your_contributions'
+    set_url_matcher(/wpcc\/\d+\/your_contributions/)
+
+    element :details, '.details__row'
+  end
+end

--- a/features/support/ui/your_details.rb
+++ b/features/support/ui/your_details.rb
@@ -1,0 +1,18 @@
+require_relative 'ui'
+
+module UI
+  class YourDetails < SitePrism::Page
+    set_url '/'
+    set_url_matcher(/wpcc\/\d+\/your_details/)
+
+    element :age, "input[name='your_details_form[age]']"
+    element :genders, "select[name='your_details_form[gender]']"
+    element :salary, "input[name='your_details_form[salary]']"
+    element :salary_frequencies, "select[name='your_details_form[salary_frequency]']"
+    # element :minimum_contribution_button, '#your_details_form_contribution_preference_minimum'
+    # element :full_contribution_button, '#your_details_form_contribution_preference_full'
+
+
+    element :next_button, "input[name='commit']"
+  end
+end

--- a/features/support/world/pages.rb
+++ b/features/support/world/pages.rb
@@ -1,6 +1,6 @@
 module World
   module Pages
-    %w(landing).each do |page|
+    %w(landing your_details your_contributions).each do |page|
       define_method("#{page}_page") do |*args|
         "UI::#{page.camelize}".constantize.new(*args)
       end

--- a/features/your_details_section.feature
+++ b/features/your_details_section.feature
@@ -1,0 +1,18 @@
+Feature:
+  As a user of the WPCC tool,
+  In order to confirm the accuracy of my inputs,
+  I want to see my supplied information as I progress through the tool.
+
+Background
+  Given I am on step 1 of the WPCC homepage
+  When I fill in the age, gender, salary and frequency fields
+
+Scenario: Display minimum contribution details
+  And I click on "My employer makes contributions on part of my salary"
+  And I click the Next button
+  Then I should see my age, gender, salary, frequency and contribution option
+
+Scenario: Display full pay contribution details
+  And I click on "My employer makes contributions on all of my salary"
+  And I click the Next button
+  Then I should see in English/Welsh my age, gender, salary, frequency and "Full pay".

--- a/spec/controllers/your_contributions_controller_spec.rb
+++ b/spec/controllers/your_contributions_controller_spec.rb
@@ -33,6 +33,5 @@ module Wpcc
         end
       end
     end
-  
   end
 end

--- a/spec/controllers/your_contributions_controller_spec.rb
+++ b/spec/controllers/your_contributions_controller_spec.rb
@@ -1,0 +1,38 @@
+module Wpcc
+  describe YourDetailsController do
+    routes { Wpcc::Engine.routes }
+
+    describe '#new' do
+      it 'displays the form for entering contribution percentages' do
+        get :new
+
+        expect(response).to render_template(:new)
+      end
+
+      context 'english' do
+        it 'renders the start view for english' do
+          get :new, locale: 'en'
+
+          expect(response).to be_success
+        end
+      end
+
+      context 'welsh' do
+        it 'renders the start view for welsh' do
+          get :new, locale: 'cy'
+
+          expect(response).to be_success
+        end
+      end
+
+      context 'translation not supported' do
+        it 'throws an error for an unsupported locale' do
+          expect do
+            get :new, locale: 'fr'
+          end.to raise_error ActionController::UrlGenerationError
+        end
+      end
+    end
+  
+  end
+end

--- a/spec/controllers/your_details_controller_spec.rb
+++ b/spec/controllers/your_details_controller_spec.rb
@@ -30,6 +30,22 @@ module Wpcc
 
     describe '#create' do
       context 'success' do
+        it 'stores the form input in a session' do
+          post :create,
+               locale: 'en',
+               age: 34,
+               gender: 'female',
+               salary: 30_000,
+               salary_frequency: 'month',
+               contribution_preference: 'full'
+
+          expect(session['age']).to eq('34')
+          expect(session['gender']).to eq('female')
+          expect(session['salary']).to eq('30000')
+          expect(session['salary_frequency']).to eq('month')
+          expect(session['contribution_preference']).to eq('full')
+        end
+        
         it 'redirects to step2 - your contributions section' do
           post :create,
                locale: 'en',
@@ -37,7 +53,7 @@ module Wpcc
                gender: 'female',
                salary: 30_000,
                salary_frequency: 'month',
-               employer_contribution: 'full'
+               contribution_preference: 'full'
           expect(response).to redirect_to your_contributions_path
         end
       end
@@ -50,7 +66,7 @@ module Wpcc
                gender: 'a',
                salary: 30_000,
                salary_frequency: 'month',
-               employer_contribution: 'full'
+               contribution_preference: 'full'
           expect(response).to redirect_to wpcc_root_path(locale: 'en')
         end
       end

--- a/spec/controllers/your_details_controller_spec.rb
+++ b/spec/controllers/your_details_controller_spec.rb
@@ -33,11 +33,13 @@ module Wpcc
         it 'stores the form input in a session' do
           post :create,
                locale: 'en',
-               age: 34,
-               gender: 'female',
-               salary: 30_000,
-               salary_frequency: 'month',
-               contribution_preference: 'full'
+               your_details_form: {
+                 age: 34,
+                 gender: 'female',
+                 salary: 30_000,
+                 salary_frequency: 'month',
+                 contribution_preference: 'full'
+               }
 
           expect(session['age']).to eq('34')
           expect(session['gender']).to eq('female')
@@ -45,16 +47,18 @@ module Wpcc
           expect(session['salary_frequency']).to eq('month')
           expect(session['contribution_preference']).to eq('full')
         end
-        
+
         it 'redirects to step2 - your contributions section' do
           post :create,
                locale: 'en',
-               age: 34,
-               gender: 'female',
-               salary: 30_000,
-               salary_frequency: 'month',
-               contribution_preference: 'full'
-          expect(response).to redirect_to your_contributions_path
+               your_details_form: {
+                 age: 34,
+                 gender: 'female',
+                 salary: 30_000,
+                 salary_frequency: 'month',
+                 contribution_preference: 'full'
+               }
+          expect(response).to redirect_to new_your_contribution_path
         end
       end
 
@@ -62,11 +66,13 @@ module Wpcc
         it 'redirects to the start page' do
           post :create,
                locale: 'en',
-               age: 34,
-               gender: 'a',
-               salary: 30_000,
-               salary_frequency: 'month',
-               contribution_preference: 'full'
+               your_details_form: {
+                 age: 34,
+                 gender: 'a',
+                 salary: 30_000,
+                 salary_frequency: 'month',
+                 contribution_preference: 'full'
+               }
           expect(response).to redirect_to wpcc_root_path(locale: 'en')
         end
       end

--- a/spec/models/your_details_form_spec.rb
+++ b/spec/models/your_details_form_spec.rb
@@ -30,9 +30,9 @@ describe Wpcc::YourDetailsForm, type: :model do
     end
 
     context 'contribution' do
-      it { should allow_value('full').for(:employer_contribution) }
-      it { should allow_value('minimum').for(:employer_contribution) }
-      it { should_not allow_value('part').for(:employer_contribution) }
+      it { should allow_value('full').for(:contribution_preference) }
+      it { should allow_value('minimum').for(:contribution_preference) }
+      it { should_not allow_value('part').for(:contribution_preference) }
     end
   end
 end

--- a/spec/presenters/your_details_form_presenter_spec.rb
+++ b/spec/presenters/your_details_form_presenter_spec.rb
@@ -11,12 +11,15 @@ RSpec.describe Wpcc::YourDetailsFormPresenter do
   end
 
   describe '#gender_options' do
-    it 'returns an array of translation keys for genders' do
+    it 'returns an array of translation keys and values for genders' do
       translation_keys = [
         'Wpcc.details.options.gender.male',
         'Wpcc.details.options.gender.female'
       ]
-      expect(subject.gender_options).to eq translation_keys
+      gender_values = %w[male female]
+      expected_result = Hash[translation_keys.zip(gender_values)].to_a
+
+      expect(subject.gender_options).to eq(expected_result)
     end
   end
 
@@ -25,8 +28,10 @@ RSpec.describe Wpcc::YourDetailsFormPresenter do
       translation_keys = %w[year month fourweeks week].map do |frequency|
         "Wpcc.details.options.salary_frequency.#{frequency}"
       end
+      frequency_values = %w[year month fourweeks week]
+      expected_result = Hash[translation_keys.zip(frequency_values)].to_a
 
-      expect(subject.salary_frequency_options).to eq translation_keys
+      expect(subject.salary_frequency_options).to eq(expected_result)
     end
   end
 end


### PR DESCRIPTION
#### Overview
This pr addresses [TP task 8393](https://moneyadviceservice.tpondemand.com/RestUI/Board.aspx?acid=74E24C42BB81286E55C11FA8BF7FAAF3#page=board/5624876525867731357&appConfig=eyJhY2lkIjoiREI4ODcwRjkxMDNDRTM2NTlBMzhDNTRBRTVBNUU1N0UifQ==&boardPopup=task/8393). The data input in Step 1 needs to persist as all the 'steps' in the WPCC journey use it.

#### Technical Approach
* We decided to store the data in a session as there is no database requirement.
* The view is simplified. Future prs will style it. 