### PR TITLE
[DEV APPROVED] 8393 - Adds style to the summary in the title of step 1

### DIFF
--- a/app/assets/stylesheets/wpcc/base/_section.scss
+++ b/app/assets/stylesheets/wpcc/base/_section.scss
@@ -9,6 +9,17 @@
   margin-top: $baseline-unit*2;
 }
 
+.section__heading-summary {
+  display: block;
+  font-weight: normal;
+  font-size: 1rem;
+  color: $color-grey-medium;
+
+  @include respond-to($mq-m) {
+    display: inline;
+  }
+}
+
 .section--details {
   border-top: 1px solid $color-grey-concrete;
 }

--- a/app/views/wpcc/your_contributions/new.html.erb
+++ b/app/views/wpcc/your_contributions/new.html.erb
@@ -1,10 +1,11 @@
 <section class="section section--details details">
   <div class="details__row">
-    <h2 class="section__heading details__heading">1. <%= t('wpcc.details.title') %></h2>
-    <p>(<%= session[:age] %> years, 
-      <%= session[:gender] %>,
-      £<%= session[:salary] %> <%= session[:salary_frequency] %>, 
-      <%= session[:contribution_preference] %> Contribution)
-    </p>
+    <h2 class="section__heading details__heading">1. <%= t('wpcc.details.title') %>
+      <span class="section__heading-summary">(<%= session[:age] %> years, 
+        <%= session[:gender] %>,
+        £<%= session[:salary] %> <%= session[:salary_frequency] %>, 
+        <%= session[:contribution_preference] %> Contribution)
+      </span>
+    </h2>
   </div>
 </section>


### PR DESCRIPTION
Task #8294 of [TP User Story 8284](https://moneyadviceservice.tpondemand.com/RestUI/Board.aspx?acid=74E24C42BB81286E55C11FA8BF7FAAF3#page=board/5624876525867731357&appConfig=eyJhY2lkIjoiREI4ODcwRjkxMDNDRTM2NTlBMzhDNTRBRTVBNUU1N0UifQ==&boardPopup=userstory/8284) - Adds style to the summary in the title of step 1

Adds style to the summary in the title of step 1 when the user has completed the step

Relates to PR:
https://github.com/moneyadviceservice/wpcc/pull/23

![image](https://user-images.githubusercontent.com/13165846/27908900-03cef0c4-6246-11e7-81ec-aa3136c54abb.png)
