### PR TITLE
Fix namespacing of wpcc module

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 PATH
   remote: .
   specs:
-    wpcc (1.0.0)
+    wpcc (1.1.0)
       dough-ruby
       rails (>= 4, < 5)
 

--- a/app/models/wpcc/minimum_contribution_calculator.rb
+++ b/app/models/wpcc/minimum_contribution_calculator.rb
@@ -1,28 +1,26 @@
 require 'active_model'
 
-module Wpcc
-  class MinimumContributionCalculator < ContributionCalculator
-    def eligible_salary
-      return upper_less_lower_limit if salary > upper_earnings_threshold
-      return salary_less_lower_limit if salary <= upper_earnings_threshold
-    end
+class Wpcc::MinimumContributionCalculator < Wpcc::ContributionCalculator
+  def eligible_salary
+    return upper_less_lower_limit if salary > upper_earnings_threshold
+    return salary_less_lower_limit if salary <= upper_earnings_threshold
+  end
 
-    def employee_percent
-      1
-    end
+  def employee_percent
+    1
+  end
 
-    def employer_percent
-      1
-    end
+  def employer_percent
+    1
+  end
 
-    private
+  private
 
-    def upper_less_lower_limit
-      upper_earnings_threshold - lower_earnings_threshold
-    end
+  def upper_less_lower_limit
+    upper_earnings_threshold - lower_earnings_threshold
+  end
 
-    def salary_less_lower_limit
-      salary - lower_earnings_threshold
-    end
+  def salary_less_lower_limit
+    salary - lower_earnings_threshold
   end
 end


### PR DESCRIPTION
Wrapping 
`class MinimumContributionCalculator < ContributionCalculator`
in `module Wpcc`
threw an error on the frontend mount 
```
TypeError - superclass must be a Class (Module given):
.../wpcc/minimum_contribution_calculator.rb:4:in <module:Wpcc>
.../wpcc/minimum_contribution_calculator.rb:3:in <top (required)>
```

Thanks to @Tr4pSt3R for quickly thinking of the solution. 
`class Wpcc::MinimumContributionCalculator < Wpcc::ContributionCalculator`