### PR TITLE
Remove active model require all over the place

### DIFF
--- a/app/controllers/wpcc/your_details_controller.rb
+++ b/app/controllers/wpcc/your_details_controller.rb
@@ -1,4 +1,3 @@
-require 'active_model'
 module Wpcc
   class YourDetailsController < EngineController
     protect_from_forgery

--- a/app/models/wpcc/contribution_calculator.rb
+++ b/app/models/wpcc/contribution_calculator.rb
@@ -1,5 +1,3 @@
-require 'active_model'
-
 module Wpcc
   class ContributionCalculator
     include ActiveModel::Model

--- a/app/models/wpcc/full_contribution_calculator.rb
+++ b/app/models/wpcc/full_contribution_calculator.rb
@@ -1,5 +1,3 @@
-require 'active_model'
-
 module Wpcc
   class FullContributionCalculator < ContributionCalculator
     def eligible_salary

--- a/app/models/wpcc/minimum_contribution_calculator.rb
+++ b/app/models/wpcc/minimum_contribution_calculator.rb
@@ -1,5 +1,3 @@
-require 'active_model'
-
 class Wpcc::MinimumContributionCalculator < Wpcc::ContributionCalculator
   def eligible_salary
     return upper_less_lower_limit if salary > upper_earnings_threshold

--- a/app/models/wpcc/your_contributions_form.rb
+++ b/app/models/wpcc/your_contributions_form.rb
@@ -1,5 +1,3 @@
-require 'active_model'
-
 module Wpcc
   class YourContributionsForm
     include ActiveModel::Model

--- a/app/models/wpcc/your_details_form.rb
+++ b/app/models/wpcc/your_details_form.rb
@@ -1,5 +1,3 @@
-require 'active_model'
-
 module Wpcc
   class YourDetailsForm
     include ActiveModel::Model


### PR DESCRIPTION
The active model require is unnecessary since we are requiring
the active model on the main file lib/wpcc.rb there is the
first file to be load when the gem is added in any project as you can see here:

https://github.com/moneyadviceservice/wpcc/blob/master/lib/wpcc.rb#L1