### PR TITLE
8287 - Edit your contributions page (step 2)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem 'sass-rails'
 gem 'turbolinks'
 
 group :development, :test do
+  gem 'launchy'
   gem 'pry-rails'
   gem 'rspec-rails', '~> 3.5'
   gem 'shoulda-matchers', '~> 3.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,6 +97,8 @@ GEM
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
     json (2.1.0)
+    launchy (2.4.3)
+      addressable (~> 2.3)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
     mail (2.6.6)
@@ -222,6 +224,7 @@ DEPENDENCIES
   capybara
   cucumber-rails
   jquery-rails
+  launchy
   pry-rails
   rails (~> 4.2.7)
   rspec-rails (~> 3.5)

--- a/app/controllers/wpcc/your_contributions_controller.rb
+++ b/app/controllers/wpcc/your_contributions_controller.rb
@@ -3,17 +3,15 @@ require_dependency 'wpcc/engine_controller'
 module Wpcc
   class YourContributionsController < EngineController
     protect_from_forgery
+    after_action :store_eligible_salary, :store_percentages, only: :new
 
     def new
       @contribution = Wpcc::CalculatorDelegator.delegate(
         session[:salary].to_i, session[:contribution_preference]
       )
 
-      store_eligible_salary
-
       @your_contributions_form = Wpcc::YourContributionsForm.new(
-        employee_percent: @contribution.employee_percent,
-        employer_percent: @contribution.employer_percent
+        contribution_percentages
       )
     end
 
@@ -50,6 +48,23 @@ module Wpcc
 
     def store_eligible_salary
       session[:eligible_salary] = @contribution.eligible_salary
+    end
+
+    def store_percentages
+      session[:employee_percent] = @your_contributions_form.employee_percent
+      session[:employer_percent] = @your_contributions_form.employer_percent
+    end
+
+    def contribution_percentages
+      employee_percent = session[:employee_percent] ||
+                         @contribution.employee_percent
+      employer_percent = session[:employer_percent] ||
+                         @contribution.employer_percent
+
+      {
+        employee_percent: employee_percent,
+        employer_percent: employer_percent
+      }
     end
   end
 end

--- a/app/views/wpcc/your_contributions/new.html.erb
+++ b/app/views/wpcc/your_contributions/new.html.erb
@@ -47,7 +47,7 @@
       <div class="callout">
         <p><%= t('wpcc.contributions.employee_contribution_warning') %></p>
       </div>
-      <button class="button button--primary"><%= t('wpcc.contributions.calculate_button') %></button>
+      <%= f.submit t('wpcc.contributions.calculate_button'), class: 'button button--primary' %>
     </div>
   <% end %>
 </section>

--- a/app/views/wpcc/your_results/index.html.erb
+++ b/app/views/wpcc/your_results/index.html.erb
@@ -13,6 +13,9 @@
     <span class="section__heading-summary">
       (You: <%= session[:employee_percent] %>%, Your employer: <%= session[:employee_percent] %>%)
     </span>
+      <span>
+        <%= link_to(t('wpcc.edit'), new_your_contribution_path) %>
+      </span>
   </h2>
 </section>
 

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -2,6 +2,7 @@ cy:
   wpcc:
     title: Cyfrifiannell cyfraniadau pensiwn gweithle
     intro: Mae’n gyfraith erbyn hyn y dylai’r rhan fwyaf o gyflogeion gael eu cofrestru ar gynllun pensiwn gweithle gan eu cyflogwr. Mae’n ofynnol i chi a’ch cyflogwr gyfrannu. Bydd y gyfrifiannell hon yn cyfrifo swm y cyfraniadau.
+    edit: Golygu
 
     details:
       title: Eich manylion

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2,6 +2,7 @@ en:
   wpcc:
     title: Workplace pension contribution calculator
     intro: It is now law that most employees must be enrolled into a workplace pension scheme by their employer. Both you and your employer are required to make contributions. This calculator will work out the amount of contributions.
+    edit: Edit
 
     details:
       title: Your details

--- a/features/edit_your_contributions.feature
+++ b/features/edit_your_contributions.feature
@@ -1,0 +1,27 @@
+Feature:
+  As a user
+  I want to see my information that I filled on the step two
+  So I can confirm my inputs are correct as I progress through the tool
+
+  Background:
+    Given I am on the YourDetailsPage
+    When I enter my age as 35
+    And I enter my gender as female
+    And my salary per year is greater than the upper earnings threshold of £45,000
+    And I select per Year salary frequency
+    And I select the minimum contribution
+    And I press next
+
+  Scenario Outline:
+    Given my employee contribution is "<employee_percent>"
+    And my employer contribution is "<employer_percent>"
+    When I move on to the results page
+    And I click to edit my contributions
+    Then the employee percent input should be "<employee_percent>"
+    And the employer percent input should be "<employer_percent>"
+
+  Examples:
+    | employee_percent | employer_percent |
+    | 1                | 2                |
+    | 2                | 3                |
+    | 1                | 0                |

--- a/features/step_definitions/your_contributions_steps.rb
+++ b/features/step_definitions/your_contributions_steps.rb
@@ -21,3 +21,23 @@ Then(/^I should see my details in the form fields$/) do
   expect(page).to have_css("input[value='35000']")
   expect(page).to have_css("input[value='minimum']")
 end
+
+Given(/^my employee contribution is "([^"]*)"$/) do |employee_percent|
+  your_contributions_page.employee_percent.set(employee_percent)
+end
+
+Given(/^my employer contribution is "([^"]*)"$/) do |employer_percent|
+  your_contributions_page.employer_percent.set(employer_percent)
+end
+
+When(/^I click to edit my contributions$/) do
+  your_results_page.your_contributions_edit.click
+end
+
+Then(/^the employee percent input should be "([^"]*)"$/) do |employee_percent|
+  expect(your_contributions_page.employee_percent.value).to eq(employee_percent)
+end
+
+Then(/^the employer percent input should be "([^"]*)"$/) do |employer_percent|
+  expect(your_contributions_page.employer_percent.value).to eq(employer_percent)
+end

--- a/features/step_definitions/your_details_section_steps.rb
+++ b/features/step_definitions/your_details_section_steps.rb
@@ -3,18 +3,18 @@ Given(/^I am on step 1 of the WPCC homepage$/) do
 end
 
 When(/^I fill in the age, gender, salary and frequency fields$/) do
-  your_details_page.age.set 35
+  your_details_page.age.set(35)
   your_details_page.genders.select('Female')
-  your_details_page.salary.set 35000
+  your_details_page.salary.set(35000)
   your_details_page.salary_frequencies.select('per Year')
 end
 
 And(/^I click on "My employer makes contributions on part of my salary"$/) do
-  your_details_page.minimum_contribution_button.set true
+  your_details_page.minimum_contribution_button.set(true)
 end
 
 And(/^I click on "My employer makes contributions on all of my salary"$/) do
-  your_details_page.full_contribution_button.set true
+  your_details_page.full_contribution_button.set(true)
 end
 
 And(/^I click the Next button$/) do

--- a/features/support/ui/your_contributions.rb
+++ b/features/support/ui/your_contributions.rb
@@ -1,18 +1,16 @@
 require_relative 'ui'
 
 module UI
-  class EmployeePercentSection < SitePrism::Page; end
-  class EmployerPercentSection < SitePrism::Page; end
-
   class YourContributionsPage < SitePrism::Page
     set_url '{/locale}/tools/wpcc/your_contributions'
     set_url_matcher(/wpcc\/\d+\/your_contributions/)
 
-    section :employee_percent,   EmployeePercentSection, '.contributions__source--employee'
-    section :employer_percent,   EmployerPercentSection, '.contributions__source--employer'
-    
+    element :employee_percent, 'input[name="your_contributions_form[employee_percent]"]'
+    element :employer_percent, 'input[name="your_contributions_form[employer_percent]"]'
+
     element :details, '.details__row'
     element :contributions_description, '.t-contributions_description'
     element :percent_input, '.contributions__source-input'
+    element :calculate_your_contributions_button, 'input[type="submit"]'
   end
 end

--- a/features/support/ui/your_results.rb
+++ b/features/support/ui/your_results.rb
@@ -1,12 +1,12 @@
 require_relative 'ui'
 
 module UI
-
   class YourResultsPage < SitePrism::Page
     set_url '{/locale}/tools/wpcc/your_results'
-    
+
     element :details, '.details__row'
     element :contributions_summary, '.details__heading'
     element :percent_input, '.contributions__source-input'
+    element :your_contributions_edit, '.contributions__heading a'
   end
 end

--- a/features/support/world/pages.rb
+++ b/features/support/world/pages.rb
@@ -1,6 +1,6 @@
 module World
   module Pages
-    %w(landing your_details your_contributions).each do |page|
+    %w(landing your_details your_contributions your_results).each do |page|
       define_method("#{page}_page") do |*args|
         page_name = "#{page}_page".capitalize.camelize
         "UI::#{page_name}".constantize.new(*args)

--- a/spec/controllers/your_contributions_controller_spec.rb
+++ b/spec/controllers/your_contributions_controller_spec.rb
@@ -53,18 +53,27 @@ module Wpcc
           .to receive(:delegate)
           .with(salary, contribution_preference)
           .and_return(your_contribution)
-
-        expect(your_contribution).to receive(:eligible_salary)
-
         get_new('en')
+
+        expect(session[:eligible_salary]).to eq(eligible_salary)
       end
 
-      it 'instantiates the YourContributions form' do
-        expect(Wpcc::YourContributionsForm)
-          .to receive(:new)
-          .with(employee_percent: 1, employer_percent: 1)
+      context 'when returning to your contributions path' do
+        let(:your_contributions_form) do
+          assigns(:your_contributions_form)
+        end
 
-        get_new('en')
+        it 'sets employee & employer percent previously added' do
+          get :new,
+              nil,
+              employee_percent: 10,
+              employer_percent: 40,
+              salary: salary,
+              contribution_preference: contribution_preference
+
+          expect(your_contributions_form.employee_percent).to eq(10)
+          expect(your_contributions_form.employer_percent).to eq(40)
+        end
       end
     end
 


### PR DESCRIPTION
This PR refers to https://moneyadviceservice.tpondemand.com/entity/8287

Now it possible to be on the third step and return to the step 2.

So as the other step, the **form object should know how to render the inputs**.

Some notes that I added on this PR:

* Added the launchy gem to help when we are creating the cucumber specs. Because it is annoying to save_and_open_page and not open due to the gem not be in the project.
* Changed the button on step 2 to be an input submit of the form.
* Use a generic "edit" link since this name is too generic (but that's what the user story is asking to).