### PR TITLE
8380 : add tooltips

### DIFF
--- a/app/assets/javascripts/wpcc/require_config.js.erb
+++ b/app/assets/javascripts/wpcc/require_config.js.erb
@@ -5,6 +5,7 @@
 // MAS
 //= depend_on_asset dough/assets/js/lib/componentLoader
 //= depend_on_asset dough/assets/js/components/DoughBaseComponent
+//= depend_on_asset dough/assets/js/components/PopupTip
 //= depend_on_asset wpcc/components/ConditionalMessaging
 
 <%
@@ -17,6 +18,9 @@
       DoughBaseComponent: requirejs_path('dough/assets/js/components/DoughBaseComponent'),
       jquery: requirejs_path('jquery/dist/jquery'),
       rsvp: requirejs_path('rsvp/rsvp.js'),
+
+      # Dough Components
+      PopupTip: requirejs_path('dough/assets/js/components/PopupTip'),
 
       # Non Dough Component
       ConditionalMessaging: requirejs_path('wpcc/components/ConditionalMessaging')

--- a/app/assets/stylesheets/wpcc/application.scss
+++ b/app/assets/stylesheets/wpcc/application.scss
@@ -31,6 +31,7 @@ $responsive: true;
 @import 'yeast/assets/components/dough_theme/button/button';
 @import 'yeast/assets/components/dough_theme/callout/settings';
 @import 'yeast/assets/components/dough_theme/callout/callout';
+@import 'yeast/assets/components/dough_theme/popup_tip/all';
 
 @import 'base/all';
 @import 'section/all';

--- a/app/assets/stylesheets/wpcc/components/_all.scss
+++ b/app/assets/stylesheets/wpcc/components/_all.scss
@@ -1,1 +1,1 @@
-@import 'tooltip';
+@import 'popup-tip';

--- a/app/assets/stylesheets/wpcc/components/_popup-tip.scss
+++ b/app/assets/stylesheets/wpcc/components/_popup-tip.scss
@@ -1,0 +1,16 @@
+.popup-tip__content {
+  @include respond-to($mq-m) {
+    padding: $baseline-unit;
+  }
+}
+
+.popup-tip__close {
+  .icon,
+  .svg-icon {
+    width: 15px;
+    height: 15px;
+    position: absolute;
+    top: $baseline-unit;
+    left: $baseline-unit;
+  }
+}

--- a/app/assets/stylesheets/wpcc/components/_tooltip.scss
+++ b/app/assets/stylesheets/wpcc/components/_tooltip.scss
@@ -1,6 +1,0 @@
-.tooltip__content-container {
-  
-  @include respond-to($mq-m) {
-    padding: $baseline-unit*2;
-  }
-}

--- a/app/assets/stylesheets/wpcc/section/_details.scss
+++ b/app/assets/stylesheets/wpcc/section/_details.scss
@@ -1,14 +1,15 @@
-.details__content {
-
-}
-
 .details__row {
   @extend %clearfix;
+  position: relative;
   clear: both;
 
   @include respond-to($mq-l) {
     @include column(8);
     margin: 0;
+  }
+  
+  .form__label-heading {
+    display: inline;
   }
 }
 
@@ -40,9 +41,13 @@
 
 .details__helper {
   @include column(12);
-
+  
   @include respond-to($mq-m) {
     @include column(8);
+    
+    .js & {
+      margin-top: $baseline-unit*6;
+    }
   }
 }
 

--- a/app/views/wpcc/shared/_popup_tip_close.html.erb
+++ b/app/views/wpcc/shared/_popup_tip_close.html.erb
@@ -1,0 +1,10 @@
+<button data-dough-popup-close type="button" class="popup-tip__close">
+  <span aria-hidden="true">
+    <svg xmlns="http://www.w3.org/2000/svg" class="svg-icon svg-icon--mobile-close-box">
+      <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#svg-icon--mobile-close-box"></use>
+    </svg>
+  </span>
+  <span class="visually-hidden">
+    <%= t('wpcc.details.tooltip_hide') %>
+  </span>
+</button>

--- a/app/views/wpcc/your_details/new.html.erb
+++ b/app/views/wpcc/your_details/new.html.erb
@@ -2,44 +2,42 @@
   <%= form_for(@your_details_form, url: your_details_path) do |f| %>
     <h2 class="section__heading details__heading">1. <%= t('wpcc.details.title') %></h2>
     <div class="details__content">
-      <div class="details__row">
+      <div class="details__row" data-dough-component="PopupTip">
         <div class="details__field">
+          <div class="details__field-label">
+            <%= f.label :age, t('wpcc.details.age.label'), class: 'form__label-heading' %>
+            <button type="button" class="popup-tip__button" data-dough-popup-trigger>
+              <span aria-hidden="true">i</span>
+              <span class="visually-hidden"><%= t('wpcc.details.tooltip_show') %></span>
+            </button>
+          </div>
           <div class="form__row">
-             <%= f.label :age, t('wpcc.details.age.label'), class: 'form__label-heading details__field-label' %>
              <%= f.text_field :age, 'data-dough-age-field': true %>
           </div>
         </div>
-
-        <div class="details__helper">
-          <div class="field-help-text">
-            <div class="tooltip__content-container">
-              <p><%= t('wpcc.details.age.tooltip') %></p>
-            </div>
-          </div>
+        <div data-dough-popup-content class="popup-tip__content details__helper">
+          <p><%= t('wpcc.details.age.tooltip') %></p>
+          <%= render 'wpcc/shared/popup_tip_close' %>
         </div>
       </div>
-
-      <div class="details__row">
+      <div class="details__row" data-dough-component="PopupTip">
         <div class="details__field">
+          <div class="details__field-label">
+            <%= f.label :gender, t('wpcc.details.gender.label'), class: 'form__label-heading' %>
+            <button type="button" class="popup-tip__button" data-dough-popup-trigger>
+              <span aria-hidden="true">i</span>
+              <span class="visually-hidden"><%= t('wpcc.details.tooltip_show') %></span>
+            </button>
+          </div>
           <div class="form__row">
-            <%= f.label :gender, t('wpcc.details.gender.label'),
-                class: 'form__label-heading details__field-label' %>
-            <%= f.select :gender,
-                options_for_select(@your_details_form.gender_options, @your_details_form.gender),
-                                   { prompt: t('wpcc.details.prompt') },
-                                   'data-dough-gender-select': true %>
+            <%= f.select :gender, options_for_select(@your_details_form.gender_options, selected: @gender), {prompt: t('wpcc.details.prompt')}, 'data-dough-gender-select': true%>
           </div>
         </div>
-
-        <div class="details__helper">
-          <div class="field-help-text">
-            <div class="tooltip__content-container">
-              <p><%= t('wpcc.details.gender.tooltip') %></p>
-            </div>
-          </div>
+        <div data-dough-popup-content class="popup-tip__content details__helper">
+          <p><%= t('wpcc.details.gender.tooltip') %></p>
+          <%= render 'wpcc/shared/popup_tip_close' %>
         </div>
       </div>
-
       <div class="details__row">
         <div class="details__callouts">
           <div class="form__row details__callout details__callout--inactive" data-dough-callout-lt16>
@@ -47,13 +45,11 @@
               <p><%= t('wpcc.details.callout__lt16') %></p>
             </div>
           </div>
-
           <div class="form__row details__callout details__callout--inactive" data-dough-callout-optIn>
             <div class="callout">
               <p><%= t('wpcc.details.callout__optIn') %></p>
             </div>
           </div>
-
           <div class="form__row details__callout details__callout--inactive" data-dough-callout-gt74>
             <div class="callout">
               <p><%= t('wpcc.details.callout__gt74') %></p>
@@ -61,42 +57,39 @@
           </div>
         </div>
       </div>
-
-      <div class="details__row">
+      <div class="details__row" data-dough-component="PopupTip">
         <div class="details__field">
           <div class="form__row details__salary">
+            <div class="details__field-label">
+              <%= f.label :salary, t('wpcc.details.salary.label'), class: 'form__label-heading' %>
+              <button type="button" class="popup-tip__button" data-dough-popup-trigger>
+                <span aria-hidden="true">i</span>
+                <span class="visually-hidden"><%= t('wpcc.details.tooltip_show') %></span>
+              </button>
+            </div>
             <div class="details__salary-amount">
-              <%= f.label :salary, t('wpcc.details.salary.label'), class: 'form__label-heading details__field-label' %>
               <%= f.text_field :salary %>
             </div>
             <div class="details__salary-frequency">
-              <%= f.label :salary_frequency, t('wpcc.details.salary.frequency.label'), class: 'form__label-heading details__field-label' %>
-              <%= f.select(:salary_frequency, options_for_select(@your_details_form.salary_frequency_options, @your_details_form.salary_frequency)) %>
+              <%= f.label :salary_frequency, t('wpcc.details.salary.frequency.label'), class: 'form__label-heading details__field-label visually-hidden' %>
+              <%= f.select(:salary_frequency, options_for_select(@your_details_form.salary_frequency_options, @salary_frequency)) %>
             </div>
           </div>
         </div>
-
-        <div class="details__helper">
-          <div class="field-help-text">
-            <div class="tooltip__content-container">
-              <p><%= t('wpcc.details.salary.tooltip') %></p>
-            </div>
-          </div>
+        <div data-dough-popup-content class="popup-tip__content details__helper">
+          <p><%= t('wpcc.details.salary.tooltip') %></p>
+          <%= render 'wpcc/shared/popup_tip_close' %>
         </div>
       </div>
-
       <div class="details__row">
         <div class="form__row">
           <fieldset>
             <legend class="details__calculate-heading"><%= t('wpcc.details.calculate.legend') %></legend>
-
             <p class="details__calculate-intro"><%= t('wpcc.details.calculate.details') %></p>
-
             <div class="form__group-item details__calculate-item">
               <%= f.radio_button(:contribution_preference, 'minimum', class: 'details__calculate-item-select') %>
               <%= f.label(:contribution_preference_minimum, t('wpcc.details.options.contribution_preference.minimum'), class: 'details__calculate-item-label') %>
             </div>
-
             <div class="form__group-item details__calculate-item">
               <%= f.radio_button(:contribution_preference, 'full', class: 'details__calculate-item-select') %>
               <%= f.label(:contribution_preference_full, t('wpcc.details.options.contribution_preference.full'), class: 'details__calculate-item-label') %>
@@ -104,7 +97,6 @@
           </fieldset>
         </div>
       </div>
-
       <div class="details__row">
         <div class="details__field">
           <div class="form__row">

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -45,6 +45,9 @@ cy:
       next: Next
       prompt: os gwelwch yn dda dewiswch
 
+      tooltip_show: sioe help
+      tooltip_hide: cuddio cymorth
+
       callout__lt16: Rydych yn rhy ifanc i ymuno â phensiwn gweithle. Pan gyrhaeddwch 16 oed gallwch ofyn i’ch cyflogwr eich cofrestru. Os felly, bydd eich cyflogwr yn gwneud cyfraniadau.
       callout__optIn: Ni fydd eich cyflogwr yn eich cofrestru yn awtomatig am bensiwn, ond gallwch ddewis ymuno. Os felly, bydd eich cyflogwr yn gwneud cyfraniadau.
       callout__gt74: Nid ydych yn gymwys i ymuno â phensiwn gweithle gan eich bod yn hŷn na’r uchafswm oed.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -44,6 +44,9 @@ en:
       next: Next
       prompt: Please choose
 
+      tooltip_show: show help
+      tooltip_hide: hide help
+
       callout__lt16: You are too young to join a workplace pension. When you reach the age of 16 you may ask your employer to enrol you. If you do so, your employer will make contributions.
       callout__optIn: Your employer will not automatically enrol you into a pension but you can choose to join. If you do so, your employer will make contributions.
       callout__gt74: You are not eligible to join a workplace pension because you are above the maximum age.


### PR DESCRIPTION
## Adds tooltips to details section

Ticket [8380](https://moneyadviceservice.tpondemand.com/entity/8380)

This PR adds the tooltips component to the your details section of the tool.

- Popup tooltip component is added to dough
- MAS styles have been added to Yeast

Please note that the SVG icon for close wont appear using the dummy app, as they exist in frontend, so mount the app to see them.

| Screenshot |
|-------------|
|<img src="https://user-images.githubusercontent.com/13165846/28206760-14d0e1fe-687f-11e7-8fce-90916b9b4104.png" width="400" />|

### No Js version

| Screenshot |
|------------|
|![image](https://user-images.githubusercontent.com/13165846/28206867-864a050e-687f-11e7-946b-cbd07a086b1f.png)|

