### PR TITLE
[DEV APPROVED] Move shared markup into a partial

### DIFF
--- a/app/views/wpcc/shared/_your_details.html.erb
+++ b/app/views/wpcc/shared/_your_details.html.erb
@@ -1,0 +1,14 @@
+<section class="section section--details details">
+  <h2 class="section__heading details__heading">1. <%= t('wpcc.details.title') %>
+  <span class="section__heading-summary">
+    (<%= session[:age] %> years,
+      <%= session[:gender] %>,
+      £<%= session[:salary] %> 
+      <%= session[:salary_frequency] %>,
+      <%= session[:contribution_preference] %> <%= t('wpcc.details.options.contribution_preference.descriptor') %>)
+    </span>
+    <span>
+      <%= link_to(t('wpcc.edit'), new_your_detail_path) %>
+    </span>
+  </h2>
+</section>

--- a/app/views/wpcc/your_contributions/new.html.erb
+++ b/app/views/wpcc/your_contributions/new.html.erb
@@ -1,18 +1,4 @@
-<section class="section section--details details">
-  <div class="details__row">
-    <h2 class="section__heading details__heading">1. <%= t('wpcc.details.title') %>
-    <span class="section__heading-summary">
-      (<%= session[:age] %> years,
-        <%= session[:gender] %>,
-        £<%= session[:salary] %> <%= session[:salary_frequency] %>,
-        <%= session[:contribution_preference] %> Contribution)
-      </span>
-      <span>
-        <%= link_to('edit', new_your_detail_path) %>
-      </span>
-    </h2>
-  </div>
-</section>
+<%= render 'wpcc/shared/your_details' %>
 
 <section class="contributions">
   <h2 class="wpcc__heading">2. <%= t('wpcc.contributions.title') %></h2>

--- a/app/views/wpcc/your_results/index.html.erb
+++ b/app/views/wpcc/your_results/index.html.erb
@@ -1,21 +1,13 @@
-<section class="section section--details">
-  <h2 class="section__heading details__heading">1. <%= t('wpcc.details.title') %>
-    <span class="section__heading-summary">(<%= session[:age] %> years,
-      <%= session[:gender] %>,
-      £<%= session[:salary] %> <%= session[:salary_frequency] %>,
-      <%= session[:contribution_preference] %> Contribution)
-    </span>
-  </h2>
-</section>
+<%= render 'wpcc/shared/your_details' %>
 
 <section class="section section--contributions">
   <h2 class="section__heading contributions__heading">2. <%= t('wpcc.contributions.title') %>
     <span class="section__heading-summary">
       (You: <%= session[:employee_percent] %>%, Your employer: <%= session[:employer_percent] %>%)
     </span>
-      <span>
-        <%= link_to(t('wpcc.edit'), new_your_contribution_path) %>
-      </span>
+    <span>
+      <%= link_to(t('wpcc.edit'), new_your_contribution_path) %>
+    </span>
   </h2>
 </section>
 

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -33,6 +33,7 @@ cy:
           female: benywaidd
           male: gwrywaidd
         contribution_preference:
+          descriptor: Cyfraniad
           full: Mae fy nghyflogwr yn cyfrannu ar fy nghyflog llawn
           minimum: Mae fy nghyflogwr yn cyfrannu ar ran o fy nghyflog (os nad ydych yn siŵr dewiswch yr opsiwn hwn)
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -33,6 +33,7 @@ en:
           female: Female
           male: Male
         contribution_preference:
+          descriptor: Contribution
           full: My employer makes contributions on my full salary
           minimum: My employer makes contributions on part of my salary (if you're not sure select this option)
 

--- a/features/step_definitions/your_contributions_steps.rb
+++ b/features/step_definitions/your_contributions_steps.rb
@@ -9,7 +9,7 @@ Given(/^I complete the first step and move on to second step$/) do
 end
 
 When(/^I click edit on the first step section$/) do
-  find_link('edit').click
+  your_contributions_page.edit_link.click
 end
 
 Then(/^I should return to the first step$/) do

--- a/features/support/ui/your_contributions.rb
+++ b/features/support/ui/your_contributions.rb
@@ -12,5 +12,6 @@ module UI
     element :contributions_description, '.t-contributions_description'
     element :percent_input, '.contributions__source-input'
     element :calculate_your_contributions_button, 'input[type="submit"]'
+    element :edit_link, '.details__heading a'
   end
 end


### PR DESCRIPTION
There was duplicate code for the your details section on the Your Contributions view and the Your Results view. This pr moves the duplicated code into its own partial.