### PR TITLE
Version documentation

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,0 +1,15 @@
+## 1.3.0
+
+* TP-8411: Add Karma to WPCC
+* TP-8207: Update markup and styles for 3rd view
+* TP-8287: Return to Step 2 to edit your contributions
+* TP-8286: Fix contribution values '(You: x%, Your employer: x%)' information
+* Format the period date to be readable
+
+Refactors:
+* Remove active model require all over the place
+* Remove your details session fetch & Assign to form object
+
+## 1.2.0
+
+* Publish first working version of gem

--- a/README.md
+++ b/README.md
@@ -19,6 +19,20 @@ $ bundle
 $ bowndler install
 ```
 
+## Versioning
+When a new version of the gem is ready to be published:
+- Create your feature branch
+- Make a commit updating the following:
+  - version number in `lib/wpcc/version.rb` - for reference see the [semver documentation](semver.org)
+  - Add what changes have been made between current and the new version in `history.md`
+- Create a PR for review
+- Once approved, merge the PR into master
+- On `master` branch, tag the repo with the latest version number
+  - `git tag 'v1.2.0'`
+- Push the tag to github
+  - `git push origin master --tags`
+- check the [wpcc](https://go.dev.mas.local/go/tab/pipeline/history/wpcc) Go build completes
+
 ## Mounting the engine
 
 The application that mounts this engine requires a controller to be the parent
@@ -142,7 +156,7 @@ The gem is available as open source under the terms of the [MIT License](http://
 #### For the initial demo - 11th July, 2017:
 
 - [x] Happy path journey through all the steps
-- [x] Display conditional messages for salary 
+- [x] Display conditional messages for salary
 - [x] Ability to edit Step 1, Your Details
 
 #### For stakeholder demo - 20th July, 2017:

--- a/lib/wpcc/version.rb
+++ b/lib/wpcc/version.rb
@@ -1,7 +1,7 @@
 module Wpcc
   module Version
     MAJOR = 1
-    MINOR = 2
+    MINOR = 3
     PATCH = 0
 
     STRING = [MAJOR, MINOR, PATCH].join('.')


### PR DESCRIPTION
This PR updates the version to 1.3.0 and also addresses documentation for the process of publishing the latest version to GO.

Paired with @tomas-stefano !! :)

Easy to read view of README update:
<img width="817" alt="banners_and_alerts_and_wpcc_readme_md_at_00090238395a481e92576d875604f4237487b22f_ _moneyadviceservice_wpcc" src="https://user-images.githubusercontent.com/7126705/28215844-53540fbe-68a7-11e7-9c0d-84738fb391a3.png">
