### PR TITLE
Fix karma specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ $ bundle
 $ bowndler install
 ```
 
+Install npm modules:
+
+```sh
+npm install
+```
+
 ## Versioning
 When a new version of the gem is ready to be published:
 - Create your feature branch
@@ -129,6 +135,13 @@ spec/dummy/app/views/layouts/application.html.erb
 ```
 
 ## Tests
+
+To run the tests (rspec, cucumber and karma), just run:
+
+```
+./test.sh
+```
+
 When running Rspec, SimpleCov will also measure the code coverage with a minimum requirement of 85% coverage.
 This value will be displayed at the end of your Rspec tests.
 

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "bower": "^1.7.9",
     "chai": "^4.0.2",
     "chai-jquery": "^2.0.0",
+    "karma": "^1.7.0",
+    "karma-cli": "^1.0.1",
     "karma-chai": "^0.1.0",
     "karma-html2js-preprocessor": "^1.1.0",
     "karma-mocha": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "karma-chai": "^0.1.0",
     "karma-html2js-preprocessor": "^1.1.0",
     "karma-mocha": "^1.3.0",
+    "karma-phantomjs-launcher": "^1.0.4",
     "karma-requirejs": "~0.2.0",
     "karma-sinon": "^1.0.5",
     "mocha": "^3.4.2",

--- a/test.sh
+++ b/test.sh
@@ -5,6 +5,7 @@ set -e -x
 export RAILS_ENV=test
 export BUNDLE_WITHOUT=development
 
+npm install
 bundle install
 bundle exec rubocop .
 bundle exec bowndler install
@@ -12,4 +13,4 @@ bundle exec bowndler install
 bundle exec rspec
 bundle exec cucumber
 
-# karma start spec/javascripts/karma.conf.js --single-run
+./node_modules/karma/bin/karma start spec/javascripts/karma.conf.js --single-run


### PR DESCRIPTION
Some errors were raising before AND on this PR it is fixed. This are the problems that were raising:

1) When you run the karma tests using:

`karma start spec/javascripts/karma.conf.js --single-run`

The results:

`"Cannot load browser "PhantomJS": it is not registered! Perhaps you are missing some plugin?"`

Add the phantom js launcher to package json solves the issue.

2) The karma command was not running at all. Add karma and karma cli to the project instead relying on global packages. Before the code was expecting for the karma & karma-cli to be installed globally. Seting up for the project local specific makes the karma command to run using the right libraries from node_modules dir.  

I Added to the Readme the instructions to run the tests and install npm.

