### PR TITLE
[DEV APPROVED] Expire session after 30 minutes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,7 @@ group :test do
   gem 'cucumber-rails', require: false
   gem 'simplecov', require: false
   gem 'site_prism'
+  gem 'timecop'
 end
 
 group :build, :development do

--- a/app/controllers/wpcc/engine_controller.rb
+++ b/app/controllers/wpcc/engine_controller.rb
@@ -3,7 +3,7 @@ module Wpcc
     protect_from_forgery
 
     layout 'wpcc/engine'
-    before_action :log_session
+    before_action :log_session, :check_session
     after_action :log_session
 
     private
@@ -21,6 +21,18 @@ module Wpcc
         'employer_percent',
         'eligible_salary'
       )
+    end
+
+    def check_session
+      session_expired? ? reset_session : update_session_expiry
+    end
+
+    def session_expired?
+      session[:expires_at] && session[:expires_at] <= Time.current
+    end
+
+    def update_session_expiry
+      session[:expires_at] = Time.current + 30.minutes
     end
   end
 end


### PR DESCRIPTION
### Objectives
* addresses [TP user story 8443](https://moneyadviceservice.tpondemand.com/restui/board.aspx?acid=ddd7f3a626844ab8d1bee3f06ec28efa#page=board/5624876525867731357&appConfig=eyJhY2lkIjoiREI4ODcwRjkxMDNDRTM2NTlBMzhDNTRBRTVBNUU1N0UifQ==&boardPopup=userstory/8443/silent).
* ensures the session expires after 30 minutes if there has been no engagement with the tool.

### Considerations
A wpcc specific expiry session key is used to determine whether or not the session should be cleared. This approach ensures that the wpcc session does not conflict with or reset session expiry time which a user coming from the frontend site may be bringing. Refer to @tomas-stefano's comment below.