### PR TITLE
[DEV APPROVED] 8440 add security scanner

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ group :development, :test do
 end
 
 group :test do
+  gem 'brakeman', require: false
   gem 'capybara'
   gem 'cucumber-rails', require: false
   gem 'simplecov', require: false

--- a/app/controllers/wpcc/engine_controller.rb
+++ b/app/controllers/wpcc/engine_controller.rb
@@ -3,5 +3,24 @@ module Wpcc
     protect_from_forgery
 
     layout 'wpcc/engine'
+    before_action :log_session
+    after_action :log_session
+
+    private
+
+    def log_session
+      Rails.logger.info("Session: #{session_information}")
+    end
+
+    def session_information
+      session.to_hash.slice(
+        'salary',
+        'salary_frequency',
+        'contribution_preference',
+        'employee_percent',
+        'employer_percent',
+        'eligible_salary'
+      )
+    end
   end
 end

--- a/test.sh
+++ b/test.sh
@@ -7,6 +7,7 @@ export BUNDLE_WITHOUT=development
 
 npm install
 bundle install
+bundle exec brakeman -z
 bundle exec rubocop .
 bundle exec bowndler install
 


### PR DESCRIPTION
TP: https://moneyadviceservice.tpondemand.com/entity/8440

Since we're manipulating the session on the wpcc tool, it is necessary to add a security scanner to our tool.
 
On the ruby community one that is common used is brakeman: https://github.com/presidentbeef/brakeman
 