### PR TITLE
[DEV APPROVED] TP8435  - Add all the steps to load all the javascript wpcc components

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,20 @@ implement internationalisation.
   end
 ```
 
-The main application.js requies the component loader to be present in order to
-load the dough components
+The main app require_config.js should have the wpccConfig on the path.
+An example:
+
+```
+  requirejs_config = {
+    paths: {
+      wpccConfig: requirejs_path('wpcc/require_config')
+    }
+  }
+```
+
+Obs.: This "wpccConfig" name should be required using the "require" clause of
+the require js. The main application also requires the component loader to
+be present in order to load the dough components and the wpcc components:
 
 ```
 require(['wpccConfig'], function() {

--- a/app/views/layouts/wpcc/engine.html.erb
+++ b/app/views/layouts/wpcc/engine.html.erb
@@ -7,7 +7,7 @@
 <% end %>
 
 <% content_for(:engine_content) do %>
-  <div class="l-constrained">
+  <div class="l-constrained" data-engine="wpcc">
     <div class="l-container-tool">
       <div class="wpcc">
         <h1><%= t('wpcc.title') %></h1>

--- a/lib/wpcc/engine.rb
+++ b/lib/wpcc/engine.rb
@@ -6,9 +6,10 @@ module Wpcc
     Wpcc.parent_controller = '::ApplicationController'
 
     initializer 'wpcc precompile hooks', group: :all do |app|
-      app.config.assets.precompile += [
-
-      ]
+      app.config.assets.precompile += %w(
+        wpcc/require_config.js
+        wpcc/components/*.js
+      )
     end
 
     config.autoload_paths += %W[#{config.root}/app/presenters]


### PR DESCRIPTION
**Problem**

The frontend application on uat was not loading the necessary javascripts file to run the wpcc tool.

**Solution**

After me and @willhall88 passed *hours* investigating why the frontend app was not loading the wppc require_config: https://github.com/moneyadviceservice/wpcc/blob/master/app/assets/javascripts/wpcc/require_config.js.erb

**We found that the frontend app is using a html attribute called "data-engine" that uses to search the key located on the require js.**  So if we define wpccConfig as key definition on *frontend* we need to define on *the engine* the data-engine=wpcc.

The key definitions: https://github.com/moneyadviceservice/frontend/blob/master/app/assets/javascripts/require_config.js.erb#L81
Loading those definitions:
https://github.com/moneyadviceservice/frontend/blob/master/app/assets/javascripts/application.js#L104

So basically what was added on the PR:

1) Add to the precompile hooks the manifest and components that the engines uses.
2) Add the data-engine="wpcc" to be loaded here:
https://github.com/moneyadviceservice/frontend/blob/master/app/assets/javascripts/application.js#L104
3) Added documentations to the readme.