### PR TITLE
[DEV APPROVED] 8436 & 8437 Salary Conditional Messaging

### DIFF
--- a/app/assets/javascripts/wpcc/components/SalaryConditions.js
+++ b/app/assets/javascripts/wpcc/components/SalaryConditions.js
@@ -1,0 +1,193 @@
+define(['jquery', 'DoughBaseComponent'], function($, DoughBaseComponent) {
+  'use strict';
+
+  var SalaryConditions,
+  defaultConfig = {};
+
+  SalaryConditions = function($el, config) {
+    SalaryConditions.baseConstructor.call(this, $el, config, defaultConfig);
+
+    // Step 1 - Details
+    this.$salaryField = this.$el.find('[data-dough-salary-input]');
+    this.$salaryFrequency = this.$el.find('[data-dough-frequency-select]');
+    this.$callout_lt5876 = this.$el.find('[data-dough-callout-lt5876]');
+    this.$callout_gt5876_lt10000 = this.$el.find('[data-dough-callout-gt5876_lt10000]');
+    this.$radioDisabled = this.$el.find('[data-dough-callout-radio-disabled]');
+    this.$employerPartRadio = this.$el.find('[data-dough-employer-part-radio]');
+    this.$employerFullRadio = this.$el.find('[data-dough-employer-full-radio]');
+
+    // Step 2 - Contributions
+    this.$employeeTip = this.$el.find('[data-dough-employee-tip]');
+    this.$employeeTip_lt5876 = this.$el.find('[data-dough-employee-tip-lt5876]');
+    this.$employerTip = this.$el.find('[data-dough-employer-tip]');
+    this.$employeeContributions = this.$el.find('[data-dough-employee-contributions]');
+    this.$employerContributions = this.$el.find('[data-dough-employer-contributions]');
+
+  };
+
+  DoughBaseComponent.extend(SalaryConditions);
+
+  SalaryConditions.componentName = 'SalaryConditions';
+
+  SalaryConditions.prototype.init = function(initialised) {
+    this._initialisedSuccess(initialised);
+    this._setUpEvents();
+    this._step2Conditions();
+  };
+
+  // Set up events to detect salary input changes
+  SalaryConditions.prototype._setUpEvents = function() {
+    var $this = this,
+        typingTimer;
+
+    this.$salaryField.on('keyup change', function(){
+      clearTimeout(typingTimer);
+      typingTimer = setTimeout(function() {
+        $this._calculateAnnual()
+      }, 500);
+    })
+
+    this.$salaryField.keydown(function() {
+      clearTimeout(typingTimer);
+    })
+
+  }
+
+  // Function to calculate the annual salary based on different frequencies
+  SalaryConditions.prototype._calculateAnnual = function() {
+    var frequency    = this.$salaryFrequency.val(),
+        salary       = this.$salaryField.val(),
+        annualSalary = 0,
+        $this        = this;
+
+    // Calculate annual salary based on frequency
+    if (frequency == 'fourweeks') {
+      annualSalary = salary * 13;
+    } else if (frequency == 'week') {
+      annualSalary = salary * 52;
+    } else if (frequency == 'month') {
+      annualSalary = salary * 12;
+    } else if (frequency == 'year') {
+      annualSalary = salary;
+    };
+    
+    // Pass the value of annual salary to display message function
+    $this._displayMessage(annualSalary);
+
+  };
+
+  // Result of annual salary function passed to this function
+  // This function displays the message and saves state to local storage
+  // Local storage value used in step 2
+  SalaryConditions.prototype._displayMessage = function(annualSalary) {
+    var $this          = this,
+
+        // Annual salary is less than £5876 and not empty
+        lt5876         = annualSalary <= 5875 &&
+                         annualSalary != '',
+
+        // Annual salary is between £5876 and £10000 and not empty
+        gt5876_lt10000 = annualSalary >= 5876 &&
+                         annualSalary <= 9999 &&
+                         annualSalary != '';
+
+    if (!lt5876 && !gt5876_lt10000) {
+      $this._defaultRange($this);
+    } else if (lt5876) {
+      $this._lessThan5876($this);
+    } else if (gt5876_lt10000) {
+      $this._between5876and10000($this);
+    };
+
+  };
+
+  // Function for salary outside any conditions
+  SalaryConditions.prototype._defaultRange = function($this) {
+
+    // Hide any callouts which are displayed
+    $this.$callout_lt5876.addClass('details__callout--inactive');
+    $this.$callout_lt5876.removeClass('details__callout--active');
+    $this.$callout_gt5876_lt10000.removeClass('details__callout--active');
+    $this.$callout_gt5876_lt10000.addClass('details__callout--inactive');
+    $this.$radioDisabled.removeClass('details__callout--active');
+    $this.$radioDisabled.addClass('details__callout--inactive');
+
+    // Enable radio button if disabled & recheck inital option
+    $this.$employerPartRadio.attr('disabled', false);
+    $this.$employerPartRadio.prop('checked', true);
+
+    // Remove local storage if already saved
+    localStorage.removeItem('lt5876');
+  }
+
+  // Function for salary less than £5876
+  SalaryConditions.prototype._lessThan5876 = function($this) {
+
+    // Show relevant callouts
+    $this.$callout_lt5876.removeClass('details__callout--inactive');
+    $this.$callout_lt5876.addClass('details__callout--active');
+    $this.$radioDisabled.removeClass('details__callout--inactive');
+    $this.$radioDisabled.addClass('details__callout--active');
+
+    // Hide other callouts if visible
+    $this.$callout_gt5876_lt10000.addClass('details__callout--inactive');
+    $this.$callout_gt5876_lt10000.removeClass('details__callout--active');
+
+    // Disable Employer contributions checkbox
+    $this.$employerPartRadio.attr('disabled', true);
+    $this.$employerFullRadio.prop('checked', true);
+
+    // Save state to local storage
+    localStorage.setItem('lt5876', true);
+  };
+
+  // Function for salary between £5876 and £10000
+  SalaryConditions.prototype._between5876and10000 = function($this) {
+
+    // Display relevant callout
+    $this.$callout_gt5876_lt10000.removeClass('details__callout--inactive');
+    $this.$callout_gt5876_lt10000.addClass('details__callout--active');
+
+    // Hide previous callout if active
+    $this.$callout_lt5876.addClass('details__callout--inactive');
+    $this.$callout_lt5876.removeClass('details__callout--active');
+    $this.$radioDisabled.removeClass('details__callout--active');
+    $this.$radioDisabled.addClass('details__callout--inactive');
+
+    // Enable radio button if disabled & recheck inital option
+    $this.$employerPartRadio.attr('disabled', false);
+    $this.$employerPartRadio.prop('checked', true);
+
+    // Remove local storage if already saved
+    localStorage.removeItem('lt5876');
+  }
+
+  // Step 2 - Alters values of the contribution inputs
+  // Modifies the employee contributions tip
+  SalaryConditions.prototype._step2Conditions = function() {
+
+    var salaryCondition = localStorage.getItem('lt5876'),
+        $this           = this;
+
+    if (salaryCondition) {
+      this._updateEmployeeTip();
+      this.$employeeTip.addClass('is-hidden');
+      this.$employeeTip_lt5876.removeClass('is-hidden');
+    } else {
+      this.$employeeTip.removeClass('is-hidden');
+      this.$employeeTip_lt5876.addClass('is-hidden');
+    }
+
+  };
+
+  // Called from _step2Conditions
+  // Updates the values of the contributions inputs
+  // And removes the employer tip
+  SalaryConditions.prototype._updateEmployeeTip = function() {
+    this.$employeeContributions.val(1);
+    this.$employerContributions.val(0);
+    this.$employerTip.text('');
+  }
+
+  return SalaryConditions;
+});

--- a/app/assets/javascripts/wpcc/require_config.js.erb
+++ b/app/assets/javascripts/wpcc/require_config.js.erb
@@ -7,6 +7,7 @@
 //= depend_on_asset dough/assets/js/components/DoughBaseComponent
 //= depend_on_asset dough/assets/js/components/PopupTip
 //= depend_on_asset wpcc/components/ConditionalMessaging
+//= depend_on_asset wpcc/components/SalaryConditions
 
 <%
   def requirejs_path(asset)
@@ -24,7 +25,8 @@
       Validation: requirejs_path('dough/assets/js/components/Validation'),
 
       # Non Dough Component
-      ConditionalMessaging: requirejs_path('wpcc/components/ConditionalMessaging')
+      ConditionalMessaging: requirejs_path('wpcc/components/ConditionalMessaging'),
+      SalaryConditions: requirejs_path('wpcc/components/SalaryConditions')
     }
   }
 %>

--- a/app/assets/stylesheets/wpcc/base/_wpcc.scss
+++ b/app/assets/stylesheets/wpcc/base/_wpcc.scss
@@ -1,3 +1,7 @@
+.is-hidden {
+  display: none;
+}
+
 .wpcc__intro {
   @extend %paragraph-intro;
 }

--- a/app/assets/stylesheets/wpcc/section/_details.scss
+++ b/app/assets/stylesheets/wpcc/section/_details.scss
@@ -90,6 +90,11 @@
     background-color: $color-green-pale;
     border: 1px solid $color-green-medium;
   }
+
+  input[type="radio"]:disabled + label {
+    color: $color-grey-light;
+    border-color: $color-grey-pale;
+  }
 }
 
 .details__calculate-item-select {

--- a/app/views/wpcc/your_contributions/new.html.erb
+++ b/app/views/wpcc/your_contributions/new.html.erb
@@ -10,7 +10,6 @@
       <p><%= t('wpcc.contributions.description_tooltip') %></p>
     </p>
   </div>
-
   <%= form_for(
     @your_contributions_form,
     url: your_contributions_path,
@@ -19,9 +18,7 @@
       'data-dough-validation-config': '{"showValidationSummary": false}',
       'novalidate': true
     }) do |f| %>
-
     <div data-dough-component="SalaryConditions">
-
       <div class="contributions__row">
         <div class="contributions__source contributions__source--employee form__row">
           <h3 class="contributions__source-title"><%= t('wpcc.contributions.your_contribution_title') %></h3>
@@ -39,8 +36,6 @@
           <%= t('wpcc.contributions.input_of_label') %>
           <span>£<%= @your_contribution.eligible_salary %></span>
         </div>
-
-
         <div class="contributions__source contributions__source--employer form__row">
           <h3 class="contributions__source-title"><%= t('wpcc.contributions.employer_contribution_title') %></h3>
           <p data-dough-employer-tip><%= t('wpcc.contributions.employer_contribution_tip') %></p>

--- a/app/views/wpcc/your_contributions/new.html.erb
+++ b/app/views/wpcc/your_contributions/new.html.erb
@@ -19,43 +19,50 @@
       'data-dough-validation-config': '{"showValidationSummary": false}',
       'novalidate': true
     }) do |f| %>
-    <div class="contributions__row">
-      <div class="contributions__source contributions__source--employee form__row">
-        <h3 class="contributions__source-title"><%= t('wpcc.contributions.your_contribution_title') %></h3>
-        <p><%= t('wpcc.contributions.your_contribution_tip') %></p>
-        <%= f.number_field :employee_percent,
-          class: "contributions__source-input",
-          required: true,
-          min: 0,
-          max: 100,
-          'data-dough-validation-empty': t('wpcc.contributions.employee_validation.blank'),
-          'data-dough-validation-invalid': t('wpcc.contributions.employee_validation.out_of_range')
-        %>
-        <%= t('wpcc.contributions.input_of_label') %>
-        <span>£<%= @your_contribution.eligible_salary %></span>
-      </div>
 
-      <div class="contributions__source contributions__source--employer form__row">
-        <h3 class="contributions__source-title"><%= t('wpcc.contributions.employer_contribution_title') %></h3>
-        <p><%= t('wpcc.contributions.employer_contribution_tip') %></p>
-        <%= f.number_field :employer_percent,
-          class: "contributions__source-input",
-          required: true,
-          min: 0,
-          max: 100,
-          'data-dough-validation-empty': t('wpcc.contributions.employer_validation.blank'),
-          'data-dough-validation-invalid': t('wpcc.contributions.employee_validation.out_of_range')
-        %>
-        <%= t('wpcc.contributions.input_of_label') %>
-        <span>£<%= @your_contribution.eligible_salary %></span>
-      </div>
-    </div>
+    <div data-dough-component="SalaryConditions">
 
-    <div class="contributions__row">
-      <div class="callout">
-        <p><%= t('wpcc.contributions.employee_contribution_warning') %></p>
+      <div class="contributions__row">
+        <div class="contributions__source contributions__source--employee form__row">
+          <h3 class="contributions__source-title"><%= t('wpcc.contributions.your_contribution_title') %></h3>
+          <p data-dough-employee-tip><%= t('wpcc.contributions.your_contribution_tip') %></p>
+          <p data-dough-employee-tip-lt5876 class="is-hidden"><%= t('wpcc.contributions.your_contribution_tip_lt5876') %></p>
+          <%= f.number_field :employee_percent,
+            class: "contributions__source-input",
+            required: true,
+            min: 0,
+            max: 100,
+            'data-dough-employee-contributions': true,
+            'data-dough-validation-empty': t('wpcc.contributions.employee_validation.blank'),
+            'data-dough-validation-invalid': t('wpcc.contributions.employee_validation.out_of_range')
+          %>
+          <%= t('wpcc.contributions.input_of_label') %>
+          <span>£<%= @your_contribution.eligible_salary %></span>
+        </div>
+
+
+        <div class="contributions__source contributions__source--employer form__row">
+          <h3 class="contributions__source-title"><%= t('wpcc.contributions.employer_contribution_title') %></h3>
+          <p data-dough-employer-tip><%= t('wpcc.contributions.employer_contribution_tip') %></p>
+          <%= f.number_field :employer_percent,
+            class: "contributions__source-input",
+            required: true,
+            min: 0,
+            max: 100,
+            'data-dough-employer-contributions': true,
+            'data-dough-validation-empty': t('wpcc.contributions.employer_validation.blank'),
+            'data-dough-validation-invalid': t('wpcc.contributions.employee_validation.out_of_range')
+          %>
+          <%= t('wpcc.contributions.input_of_label') %>
+          <span>£<%= @your_contribution.eligible_salary %></span>
+        </div>
       </div>
-      <%= f.submit t('wpcc.contributions.calculate_button'), class: 'button button--primary' %>
+      <div class="contributions__row">
+        <div class="callout">
+          <p><%= t('wpcc.contributions.employee_contribution_warning') %></p>
+        </div>
+        <%= f.submit t('wpcc.contributions.calculate_button'), class: 'button button--primary' %>
+      </div>
     </div>
   <% end %>
 </section>

--- a/app/views/wpcc/your_details/new.html.erb
+++ b/app/views/wpcc/your_details/new.html.erb
@@ -79,49 +79,78 @@
           </div>
         </div>
       </div>
-      <div class="details__row" data-dough-component="PopupTip">
-        <div class="details__field">
-          <div class="form__row details__salary">
-            <div class="details__field-label">
-              <%= f.label :salary, t('wpcc.details.salary.label'), class: 'form__label-heading' %>
-              <button type="button" class="popup-tip__button" data-dough-popup-trigger>
-                <span aria-hidden="true">i</span>
-                <span class="visually-hidden"><%= t('wpcc.details.tooltip_show') %></span>
-              </button>
-            </div>
-            <div class="details__salary-amount">
+
+      <div data-dough-component="SalaryConditions">
+
+        <div class="details__row" data-dough-component="PopupTip">
+          <div class="details__field">
+            <div class="form__row details__salary">
+              <div class="details__field-label">
+                <%= f.label :salary, t('wpcc.details.salary.label'), class: 'form__label-heading' %>
+                <button type="button" class="popup-tip__button" data-dough-popup-trigger>
+                  <span aria-hidden="true">i</span>
+                  <span class="visually-hidden"><%= t('wpcc.details.tooltip_show') %></span>
+                </button>
+              </div>
+              <div class="details__salary-amount">
               <%= f.text_field :salary,
                 required: true,
-                'data-dough-validation-empty': t('wpcc.details.salary.validation')
+                'data-dough-validation-empty': t('wpcc.details.salary.validation'),
+                'data-dough-salary-input': true
               %>
-            </div>
-            <div class="details__salary-frequency">
-              <%= f.label :salary_frequency, t('wpcc.details.salary.frequency.label'), class: 'form__label-heading details__field-label visually-hidden' %>
-              <%= f.select(:salary_frequency, options_for_select(@your_details_form.salary_frequency_options, @salary_frequency)) %>
+              </div>
+              <div class="details__salary-frequency">
+                <%= f.label :salary_frequency, t('wpcc.details.salary.frequency.label'), class: 'form__label-heading details__field-label visually-hidden' %>
+                
+                <%= f.select(:salary_frequency, options_for_select(@your_details_form.salary_frequency_options, @salary_frequency), {}, {'data-dough-frequency-select': true}) %>
+              </div>
+              <div data-dough-popup-content class="popup-tip__content details__helper">
+                <p><%= t('wpcc.details.salary.tooltip') %></p>
+                <%= render 'wpcc/shared/popup_tip_close' %>
+              </div>
             </div>
           </div>
+          <div class="details__callouts">
+            <div class="form__row details__callout details__callout--inactive" data-dough-callout-lt5876>
+              <div class="callout">
+                <p><%= t('wpcc.details.callout__lt5876') %></p>
+              </div>
+            </div>
+
+            <div class="form__row details__callout details__callout--inactive" data-dough-callout-gt5876_lt10000>
+              <div class="callout">
+                <p><%= t('wpcc.details.callout__gt5876_lt10000') %></p>
+              </div>
+            </div>
+
+          </div>
         </div>
-        <div data-dough-popup-content class="popup-tip__content details__helper">
-          <p><%= t('wpcc.details.salary.tooltip') %></p>
-          <%= render 'wpcc/shared/popup_tip_close' %>
+        
+        <div class="details__row">
+          <div class="form__row">
+            <fieldset>
+              <legend class="details__calculate-heading"><%= t('wpcc.details.calculate.legend') %></legend>
+              <p class="details__calculate-intro"><%= t('wpcc.details.calculate.details') %></p>
+              <div class="details__callouts">
+                <div class="form__row details__callout details__callout--inactive" data-dough-callout-radio-disabled>
+                  <div class="callout">
+                    <p><%= t('wpcc.details.callout__radiodisabled') %></p>
+                  </div>
+                </div>
+              </div>
+              <div class="form__group-item details__calculate-item">
+                <%= f.radio_button(:contribution_preference, 'minimum', disabled: @your_details_form.disabled_class, class: 'details__calculate-item-select', 'data-dough-employer-part-radio': true) %>
+                <%= f.label(:contribution_preference_minimum, t('wpcc.details.options.contribution_preference.minimum'), class: 'details__calculate-item-label') %>
+              </div>
+              <div class="form__group-item details__calculate-item">
+                <%= f.radio_button(:contribution_preference, 'full', class: 'details__calculate-item-select', 'data-dough-employer-full-radio': true) %>
+                <%= f.label(:contribution_preference_full, t('wpcc.details.options.contribution_preference.full'), class: 'details__calculate-item-label') %>
+              </div>
+            </fieldset>
+          </div>
         </div>
       </div>
-      <div class="details__row">
-        <div class="form__row">
-          <fieldset>
-            <legend class="details__calculate-heading"><%= t('wpcc.details.calculate.legend') %></legend>
-            <p class="details__calculate-intro"><%= t('wpcc.details.calculate.details') %></p>
-            <div class="form__group-item details__calculate-item">
-              <%= f.radio_button(:contribution_preference, 'minimum', disabled: @your_details_form.disabled_class, class: 'details__calculate-item-select') %>
-              <%= f.label(:contribution_preference_minimum, t('wpcc.details.options.contribution_preference.minimum'), class: 'details__calculate-item-label') %>
-            </div>
-            <div class="form__group-item details__calculate-item">
-              <%= f.radio_button(:contribution_preference, 'full', class: 'details__calculate-item-select') %>
-              <%= f.label(:contribution_preference_full, t('wpcc.details.options.contribution_preference.full'), class: 'details__calculate-item-label') %>
-            </div>
-          </fieldset>
-        </div>
-      </div>
+
       <div class="details__row">
         <div class="details__field">
           <div class="form__row">
@@ -129,6 +158,7 @@
           </div>
         </div>
       </div>
+
     </div>
   <% end %>
 </section>

--- a/app/views/wpcc/your_details/new.html.erb
+++ b/app/views/wpcc/your_details/new.html.erb
@@ -79,9 +79,7 @@
           </div>
         </div>
       </div>
-
       <div data-dough-component="SalaryConditions">
-
         <div class="details__row" data-dough-component="PopupTip">
           <div class="details__field">
             <div class="form__row details__salary">
@@ -116,16 +114,13 @@
                 <p><%= t('wpcc.details.callout__lt5876') %></p>
               </div>
             </div>
-
             <div class="form__row details__callout details__callout--inactive" data-dough-callout-gt5876_lt10000>
               <div class="callout">
                 <p><%= t('wpcc.details.callout__gt5876_lt10000') %></p>
               </div>
             </div>
-
           </div>
         </div>
-        
         <div class="details__row">
           <div class="form__row">
             <fieldset>
@@ -150,7 +145,6 @@
           </div>
         </div>
       </div>
-
       <div class="details__row">
         <div class="details__field">
           <div class="form__row">
@@ -158,7 +152,6 @@
           </div>
         </div>
       </div>
-
     </div>
   <% end %>
 </section>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -51,10 +51,8 @@ cy:
       callout__lt16: Rydych yn rhy ifanc i ymuno â phensiwn gweithle. Pan gyrhaeddwch 16 oed gallwch ofyn i’ch cyflogwr eich cofrestru. Os felly, bydd eich cyflogwr yn gwneud cyfraniadau.
       callout__optIn: Ni fydd eich cyflogwr yn eich cofrestru yn awtomatig am bensiwn, ond gallwch ddewis ymuno. Os felly, bydd eich cyflogwr yn gwneud cyfraniadau.
       callout__gt74: Nid ydych yn gymwys i ymuno â phensiwn gweithle gan eich bod yn hŷn na’r uchafswm oed.
-
       callout__lt5876: Ni fydd eich cyflogwr yn eich cofrestru yn awtomatig am gynllun pensiwn gweithle, ond gallwch ddewis ymuno. Os felly, ni fydd yn ofynnol i'ch cyflogwr wneud cyfraniadau.
       callout__radiodisabled: Your earnings level is below the minimum contribution level so you will have to make contributions based on your full salary
-
       callout__gt5876_lt10000: Your employer will not automatically enroll you into a workplace pension scheme but you can choose to join. If you do so, your employer will make contributions.
 
     contributions:

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -52,13 +52,19 @@ cy:
       callout__optIn: Ni fydd eich cyflogwr yn eich cofrestru yn awtomatig am bensiwn, ond gallwch ddewis ymuno. Os felly, bydd eich cyflogwr yn gwneud cyfraniadau.
       callout__gt74: Nid ydych yn gymwys i ymuno â phensiwn gweithle gan eich bod yn hŷn na’r uchafswm oed.
 
+      callout__lt5876: Ni fydd eich cyflogwr yn eich cofrestru yn awtomatig am gynllun pensiwn gweithle, ond gallwch ddewis ymuno. Os felly, ni fydd yn ofynnol i'ch cyflogwr wneud cyfraniadau.
+      callout__radiodisabled: Your earnings level is below the minimum contribution level so you will have to make contributions based on your full salary
+
+      callout__gt5876_lt10000: Your employer will not automatically enroll you into a workplace pension scheme but you can choose to join. If you do so, your employer will make contributions.
+
     contributions:
       title: Eich cyfraniadau
       description: Gwneir cyfraniadau ar eich cyflog cymwys o £%{eligible_salary} y flwyddyn. Dyma eich cyflog meinws y trothwy Yswiriant Gwladol o £££.
       description_tooltip: Dyma’r rhan o’ch cyflog blynyddol a ddefnyddir i gyfrifo’ch cyfraniad pensiwn dan gofrestru awtomatig. Sef eich enillion cyn treth (hyd at derfyn uchafswm o £45000 y flwyddyn) – meinws trothwy enillion isaf o £5,876.
       your_contribution_title: Nodwch eich cyfraniad
       your_contribution_tip: Yr isafswm cyfreithiol yw 1%
-      contribution_preference_title: Nodwch gyfraniad eich cyflogwr
+      your_contribution_tip_lt5876: Ar eich lefel cyflog, nid oes isafswm cyfreithiol o gyfraniad ond efallai y bydd eich cynllun pensiwn gweithlu wedi gosod isafswm. Holwch eich cyflogwr.
+      employer_contribution_title: Nodwch gyfraniad eich cyflogwr
       employer_contribution_tip: Yr isafswm cyfreithiol yw 1%
       input_of_label: o
       calculate_button: Cyfrifwch eich cyfraniadau

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -50,10 +50,8 @@ en:
       callout__lt16: You are too young to join a workplace pension. When you reach the age of 16 you may ask your employer to enrol you. If you do so, your employer will make contributions.
       callout__optIn: Your employer will not automatically enrol you into a pension but you can choose to join. If you do so, your employer will make contributions.
       callout__gt74: You are not eligible to join a workplace pension because you are above the maximum age.
-
       callout__lt5876: Your employer will not automatically enrol you into a workplace pension scheme but you can choose to join. If you do so, your employer will not be obliged to make contributions.
       callout__radiodisabled: Your earnings level is below the minimum contribution level so you will have to make contributions based on your full salary
-
       callout__gt5876_lt10000: Your employer will not automatically enroll you into a workplace pension scheme but you can choose to join. If you do so, your employer will make contributions.
 
     contributions:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -51,13 +51,19 @@ en:
       callout__optIn: Your employer will not automatically enrol you into a pension but you can choose to join. If you do so, your employer will make contributions.
       callout__gt74: You are not eligible to join a workplace pension because you are above the maximum age.
 
+      callout__lt5876: Your employer will not automatically enrol you into a workplace pension scheme but you can choose to join. If you do so, your employer will not be obliged to make contributions.
+      callout__radiodisabled: Your earnings level is below the minimum contribution level so you will have to make contributions based on your full salary
+
+      callout__gt5876_lt10000: Your employer will not automatically enroll you into a workplace pension scheme but you can choose to join. If you do so, your employer will make contributions.
+
     contributions:
       title: Your contributions
       description: Contributions will be made on your eligible salary of £%{eligible_salary} per year. This is your salary minus the National Insurance threshold of £££.
       description_tooltip: This is the part of your annual pay that will be used to calculate your pension contribution under automatic enrolment. It is your earnings before tax (up to a maximum limit of £45000 per year) – less the lower earnings threshold of £5,876.
       your_contribution_title: Enter your contribution
       your_contribution_tip: The legal minimum is 1%
-      contribution_preference_title: Enter your employer’s contribution
+      your_contribution_tip_lt5876: At your salary level there is no legal minimum contribution but your workplace pension scheme may have a set minimum. Check with your employer.
+      employer_contribution_title: Enter your employer’s contribution
       employer_contribution_tip: The legal minimum is 1%
       input_of_label: of
       calculate_button: Calculate your contributions

--- a/spec/javascripts/fixtures/SalaryConditions.html
+++ b/spec/javascripts/fixtures/SalaryConditions.html
@@ -1,0 +1,36 @@
+<div>
+  <div data-dough-component="SalaryConditions">
+
+    <input data-dough-salary-input type="text" />
+
+    <select data-dough-frequency-select>
+      <option value="year">per Year</option>
+      <option value="month">per Month</option>
+      <option value="fourweeks">per 4 weeks</option>
+      <option value="week">per Week</option>
+    </select>
+
+    <div class="details__callout--inactive" data-dough-callout-lt5876>
+      
+    </div>
+    
+    <div class="details__callout--inactive" data-dough-callout-gt5876_lt10000>
+      
+    </div>
+    
+    <div class="details__callout--inactive" data-dough-callout-radio-disabled>
+      
+    </div>
+
+    <input data-dough-employer-part-radio="true" type="radio" value="minimum">
+    <input data-dough-employer-full-radio="true" type="radio" value="full">
+
+    <p data-dough-employee-tip-lt5876 class="is-hidden"></p>
+    <p data-dough-employee-tip></p>
+    <p data-dough-employer-tip></p>
+
+    <input data-dough-employee-contributions type="number" value="1" />
+    <input data-dough-employer-contributions type="number" value="1" />
+
+  </div>
+</div>

--- a/spec/javascripts/fixtures/SalaryConditions.html
+++ b/spec/javascripts/fixtures/SalaryConditions.html
@@ -2,24 +2,19 @@
   <div data-dough-component="SalaryConditions">
 
     <input data-dough-salary-input type="text" />
-
     <select data-dough-frequency-select>
       <option value="year">per Year</option>
       <option value="month">per Month</option>
       <option value="fourweeks">per 4 weeks</option>
       <option value="week">per Week</option>
     </select>
-
     <div class="details__callout--inactive" data-dough-callout-lt5876>
-      
     </div>
     
     <div class="details__callout--inactive" data-dough-callout-gt5876_lt10000>
-      
     </div>
     
     <div class="details__callout--inactive" data-dough-callout-radio-disabled>
-      
     </div>
 
     <input data-dough-employer-part-radio="true" type="radio" value="minimum">

--- a/spec/javascripts/test-main.js
+++ b/spec/javascripts/test-main.js
@@ -33,6 +33,7 @@ require.config({
     utilities: 'vendor/assets/bower_components/dough/assets/js/lib/utilities',
 
     // WPCC components
-    ConditionalMessaging: 'app/assets/javascripts/wpcc/components/ConditionalMessaging'
+    ConditionalMessaging: 'app/assets/javascripts/wpcc/components/ConditionalMessaging',
+    SalaryConditions: 'app/assets/javascripts/wpcc/components/SalaryConditions'
   }
 })

--- a/spec/javascripts/tests/SalaryConditions_spec.js
+++ b/spec/javascripts/tests/SalaryConditions_spec.js
@@ -75,7 +75,7 @@ describe('Salary Conditions', function() {
         clock.tick(this.delay);
         expect(this.employerPartRadio.prop('disabled')).to.be.true;
         done();
-      })
+      });
 
       it('Displays disabled radio callout', function(done) {
         this.salaryField.val('3000');
@@ -93,7 +93,7 @@ describe('Salary Conditions', function() {
         clock.tick(this.delay);
         expect(this.employerFullRadio.prop('checked')).to.be.true;
         done();
-      })
+      });
 
       it('Saves this state to local storage', function(done) {
         this.salaryField.val('3000');
@@ -101,16 +101,16 @@ describe('Salary Conditions', function() {
         clock.tick(this.delay);
         expect(localStorage.getItem('lt5876')).to.equal('true');
         done();
-      })
+      });
 
-      it('Clears state from localStorage if salary is changed to above £5867', 
+      it('Clears state from localStorage if salary is changed to £5876 or above', 
         function(done) {
-        this.salaryField.val('5879');
+        this.salaryField.val('5876');
         this.salaryField.trigger('keyup');
         clock.tick(this.delay);
         expect(localStorage.getItem('lt5876')).to.be.equal(null);
         done();
-      })
+      });
     });
 
     describe('When salary is between £5876 and £10000', function() {
@@ -133,7 +133,59 @@ describe('Salary Conditions', function() {
         expect(this.callout_gt5876_lt10000.hasClass('details__callout--inactive')).to.be.true;
         expect(this.callout_gt5876_lt10000.hasClass('details__callout--inactive')).to.be.true;
         done();
-      })
+      });
+    });
+
+  });
+
+  describe('When frequency field is changed', function() {
+    var clock;
+
+    beforeEach(function() {
+      this.salaryField = this.component.find('[data-dough-salary-input]');
+      this.salaryFrequency = this.component.find('[data-dough-frequency-select]');
+      this.callout_lt5876 = this.component.find('[data-dough-callout-lt5876]');
+      this.callout_gt5876_lt10000 = this.component.find('[data-dough-callout-gt5876_lt10000]');
+      this.radioDisabled = this.component.find('[data-dough-callout-radio-disabled]');
+      clock = sinon.useFakeTimers();
+      this.obj.init();
+    });
+
+    afterEach(function() {
+      clock.restore();
+    });
+
+    it('Displays correct callout based on monthly frequency', function(done) {
+      this.salaryField.val('300');
+      this.salaryFrequency.val('month');
+      this.salaryField.trigger('keyup');
+      clock.tick(this.delay);
+      expect(
+        this.callout_lt5876.hasClass('details__callout--active')
+      ).to.be.true;
+      done();
+    });
+
+    it('Displays correct callout based on fourweeks frequency', function(done) {
+      this.salaryField.val('300');
+      this.salaryFrequency.val('fourweeks');
+      this.salaryField.trigger('keyup');
+      clock.tick(this.delay);
+      expect(
+        this.callout_lt5876.hasClass('details__callout--active')
+      ).to.be.true;
+      done();
+    });
+
+    it('Displays correct callout based on weekly frequency', function(done) {
+      this.salaryField.val('30');
+      this.salaryFrequency.val('week');
+      this.salaryField.trigger('keyup');
+      clock.tick(this.delay);
+      expect(
+        this.callout_lt5876.hasClass('details__callout--active')
+      ).to.be.true;
+      done();
     });
 
   });
@@ -175,7 +227,7 @@ describe('Salary Conditions', function() {
       }
 
       done();
-    })
+    });
 
     it('Updates the employee contribution tip', function(done) {
       this.salaryField.val('3000');
@@ -183,7 +235,7 @@ describe('Salary Conditions', function() {
       clock.tick(this.delay);
       expect(this.employeeTip_lt5876.hasClass('is-hidden')).to.be.false;
       done(); 
-    })
+    });
 
     it('Hides the employer contribution tip', function(done) {
       this.salaryField.val('3000');
@@ -191,10 +243,10 @@ describe('Salary Conditions', function() {
       clock.tick(this.delay);
       expect(this.employerTip.text()).to.equal('');
       done(); 
-    })
+    });
   });
 
-  describe('When user proceeds to step 2 with salary above £5876', function() {
+  describe('When user proceeds to step 2 with salary of £5876 or above', function() {
     var clock;
 
     beforeEach(function() {

--- a/spec/javascripts/tests/SalaryConditions_spec.js
+++ b/spec/javascripts/tests/SalaryConditions_spec.js
@@ -1,0 +1,238 @@
+describe('Salary Conditions', function() {
+  'use strict';
+
+  beforeEach(function(done) {
+    var _this = this;
+
+    requirejs(
+      ['jquery', 'SalaryConditions'],
+      function($, SalaryConditions) {
+        _this.$html = $(window.__html__['spec/javascripts/fixtures/SalaryConditions.html']).appendTo('body');
+        _this.component = _this.$html.find('[data-dough-component="SalaryConditions"]');
+        _this.salaryConditions = SalaryConditions;
+        _this.obj = new _this.salaryConditions(_this.component);
+        _this.delay = 550;
+        done();
+      }, done);
+  });
+
+  afterEach(function() {
+    this.$html.remove();
+  });
+
+  describe('When salary field is changed', function() {
+
+    var clock;
+
+    beforeEach(function() {
+      this.salaryField = this.component.find('[data-dough-salary-input]');
+      this.salaryFrequency = this.component.find('[data-dough-frequency-select]');
+      this.callout_lt5876 = this.component.find('[data-dough-callout-lt5876]');
+      this.callout_gt5876_lt10000 = this.component.find('[data-dough-callout-gt5876_lt10000]');
+      this.radioDisabled = this.component.find('[data-dough-callout-radio-disabled]');
+      this.employerPartRadio = this.component.find('[data-dough-employer-part-radio]');
+      this.employerFullRadio = this.component.find('[data-dough-employer-full-radio]');
+      clock = sinon.useFakeTimers();
+      this.obj.init();
+    });
+
+    afterEach(function() {
+      clock.restore();
+    });
+
+    it('Does not display callouts when salary field is empty', function() {
+      this.salaryField.val(null);
+      this.salaryFrequency.val('year');
+
+      expect(
+        this.callout_lt5876.hasClass('details__callout--inactive')
+      ).to.be.true;
+
+      expect(
+        this.callout_gt5876_lt10000.hasClass('details__callout--inactive')
+      ).to.be.true;
+
+      expect(
+        this.radioDisabled.hasClass('details__callout--inactive')
+      ).to.be.true;
+    });
+
+    describe('When salary is less than £5876', function() {
+      it('Shows the correct callout', function(done) {
+        this.salaryFrequency.val('year');
+        this.salaryField.val('3000');
+        this.salaryField.trigger('keyup');
+        clock.tick(this.delay);
+        expect(
+          this.callout_lt5876.hasClass('details__callout--active')
+        ).to.be.true;
+        done();
+      });
+
+      it('Disables the employer part contribution radio', function(done) {
+        this.salaryField.val('3000');
+        this.salaryField.trigger('keyup');
+        clock.tick(this.delay);
+        expect(this.employerPartRadio.prop('disabled')).to.be.true;
+        done();
+      })
+
+      it('Displays disabled radio callout', function(done) {
+        this.salaryField.val('3000');
+        this.salaryField.trigger('keyup');
+        clock.tick(this.delay);
+        expect(
+          this.radioDisabled.hasClass('details__callout--active')
+        ).to.be.true;
+        done();
+      });
+
+      it('Selects the employer full contribution radio option', function(done) {
+        this.salaryField.val('3000');
+        this.salaryField.trigger('keyup');
+        clock.tick(this.delay);
+        expect(this.employerFullRadio.prop('checked')).to.be.true;
+        done();
+      })
+
+      it('Saves this state to local storage', function(done) {
+        this.salaryField.val('3000');
+        this.salaryField.trigger('keyup');
+        clock.tick(this.delay);
+        expect(localStorage.getItem('lt5876')).to.equal('true');
+        done();
+      })
+
+      it('Clears state from localStorage if salary is changed to above £5867', 
+        function(done) {
+        this.salaryField.val('5879');
+        this.salaryField.trigger('keyup');
+        clock.tick(this.delay);
+        expect(localStorage.getItem('lt5876')).to.be.equal(null);
+        done();
+      })
+    });
+
+    describe('When salary is between £5876 and £10000', function() {
+      it('Shows the correct callout', function(done) {
+        this.salaryField.val('7000');
+        this.salaryField.trigger('keyup');
+        clock.tick(this.delay);
+        expect(
+          this.callout_gt5876_lt10000.hasClass('details__callout--active')
+        ).to.be.true;
+        done();
+      });
+    });
+
+    describe('When salary is equal to or greater than £10000', function() {
+      it('Does not display any callouts', function(done) {
+        this.salaryField.val('22000');
+        this.salaryField.trigger('keyup');
+        clock.tick(this.delay);
+        expect(this.callout_gt5876_lt10000.hasClass('details__callout--inactive')).to.be.true;
+        expect(this.callout_gt5876_lt10000.hasClass('details__callout--inactive')).to.be.true;
+        done();
+      })
+    });
+
+  });
+
+  describe('When user proceeds to step 2 with salary below £5876', function() {
+    var clock;
+
+    beforeEach(function() {
+      this.salaryField = this.component.find('[data-dough-salary-input]');
+      this.employeeTip = this.component.find('[data-dough-employee-tip]');
+      this.employeeTip_lt5876 = this.component.find('[data-dough-employee-tip-lt5876]');
+      this.employerTip = this.component.find('[data-dough-employer-tip]');
+      this.employeeContributions = this.component.find('[data-dough-employee-contributions]');
+      this.employerContributions = this.component.find('[data-dough-employer-contributions]');
+      clock = sinon.useFakeTimers();
+      this.obj.init();
+    });
+
+    afterEach(function() {
+      clock.restore();
+    });
+
+    it('Has saved state to local storage', function(done) {
+      this.salaryField.val('3000');
+      this.salaryField.trigger('keyup');
+      clock.tick(this.delay);
+      expect(localStorage.getItem('lt5876')).to.equal('true');
+      done();
+    });
+
+    it('Adjusts the default contribution values', function(done) {
+      this.salaryField.val('3000');
+      this.salaryField.trigger('keyup');
+      clock.tick(this.delay);
+
+      if (localStorage.getItem('lt5876') == 'true') {
+        expect(this.employeeContributions.val()).to.equal('1');
+        expect(this.employerContributions.val()).to.equal('0');
+      }
+
+      done();
+    })
+
+    it('Updates the employee contribution tip', function(done) {
+      this.salaryField.val('3000');
+      this.salaryField.trigger('keyup');
+      clock.tick(this.delay);
+      expect(this.employeeTip_lt5876.hasClass('is-hidden')).to.be.false;
+      done(); 
+    })
+
+    it('Hides the employer contribution tip', function(done) {
+      this.salaryField.val('3000');
+      this.salaryField.trigger('keyup');
+      clock.tick(this.delay);
+      expect(this.employerTip.text()).to.equal('');
+      done(); 
+    })
+  });
+
+  describe('When user proceeds to step 2 with salary above £5876', function() {
+    var clock;
+
+    beforeEach(function() {
+      this.salaryField = this.component.find('[data-dough-salary-input]');
+      this.employeeContributions = this.component.find('[data-dough-employee-contributions]');
+      this.employerContributions = this.component.find('[data-dough-employer-contributions]');
+      this.employeeTip = this.component.find('[data-dough-employee-tip]');
+      this.employeeTip_lt5876 = this.component.find('[data-dough-employee-tip-lt5876]');
+      this.employerTip = this.component.find('[data-dough-employer-tip]');
+      clock = sinon.useFakeTimers();
+      this.obj.init();
+    });
+
+    it('Has not saved state to local storage', function(done) {
+      this.salaryField.val('6000');
+      this.salaryField.trigger('keyup');
+      clock.tick(this.delay);
+      expect(localStorage.getItem('lt5876')).to.equal(null);
+      done();
+    });
+
+    it('Shows the original contribution values', function(done) {
+      this.salaryField.val('6000');
+      this.salaryField.trigger('keyup');
+      clock.tick(this.delay);
+      expect(this.employeeContributions.val()).to.equal('1');
+      expect(this.employerContributions.val()).to.equal('1');
+      done();
+    });
+
+    it('Displays the correct contribution tips', function(done) {
+      this.salaryField.val('6000');
+      this.salaryField.trigger('keyup');
+      clock.tick(this.delay);
+      expect(this.employeeTip.hasClass('is-hidden')).to.be.false;
+      expect(this.employeeTip_lt5876.hasClass('is-hidden')).to.be.true;
+      expect(this.employerTip.text()).to.not.equal(null);
+      done();
+    });
+  });
+});


### PR DESCRIPTION
# Conditional Messaging based on salary

[**8436**](https://moneyadviceservice.tpondemand.com/entity/8436)
Workers who earn under £5876 are not automatically opted into a workplace pension scheme. Although their employer is obliged to let them join the scheme if they choose, they are not obliged to make contributions.

[**8437**](https://moneyadviceservice.tpondemand.com/entity/8437)
Automatic enrolment into a pension scheme only applies to workers earning over £10,000, aged 22-State Pension age.
Users earning less can opt-in but will not be auto enrolled.

## Step 1 - Your Details

| Salary Below £5876 |
|------|
| First radio disabled, employer radio selected, callout displayed + State saved to local storage for use in step 2, callout also displayed above radio options |
|![image](https://user-images.githubusercontent.com/13165846/28567376-016128aa-712a-11e7-884b-7a74f0c26a83.png)|

| Salary Between £5876 and £10000 |
|--------|
| Callout displayed, user still able to select either radio option |
|![image](https://user-images.githubusercontent.com/13165846/28566325-b2944b1a-7126-11e7-83d5-abb8e7238d71.png)|

| Salary of £10000 and above |
|-------|
| Nothing unusual |
|![image](https://user-images.githubusercontent.com/13165846/28566353-d04c1ba6-7126-11e7-9577-f48dd77dc8c4.png)|

## Step 2 - Your Contributions

| Salary Less than £5876 |
|-----|
| Employee contribution defaults to 1%, employer contribution defaults to 0%, Replacement tip text for employee's form, tip text hidden on employers form |
|![image](https://user-images.githubusercontent.com/13165846/28566849-4bba4726-7128-11e7-8e6c-c29bb41edafa.png)|

## Overview of tests

<img width="580" alt="screen shot 2017-07-27 at 08 24 37" src="https://user-images.githubusercontent.com/13165846/28658853-16268dbc-72a5-11e7-824f-8c0a91178397.png">
