### PR TITLE
Lock dough-ruby gem to a version that works

### DIFF
--- a/wpcc.gemspec
+++ b/wpcc.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   s.test_files = Dir['spec/**/*']
 
-  s.add_dependency 'dough-ruby'
+  s.add_dependency 'dough-ruby', '~> 5.25'
 
   s.add_runtime_dependency 'rails', '>= 4', '< 5'
 end


### PR DESCRIPTION
A couple of times when deploying the gem on frontend, there have been some issues with the dough-ruby version there, not working with WPCC. This will lock the gem to use a version of dough-ruby that it is compatible with.

Frontend - you will have to update this if you need to propagate, changes from dough-ruby into wpcc gem. 