### PR TITLE
Refactor 8427

### DIFF
--- a/app/controllers/wpcc/your_contributions_controller.rb
+++ b/app/controllers/wpcc/your_contributions_controller.rb
@@ -79,7 +79,7 @@ module Wpcc
 
     def salary_message
       Wpcc::SalaryMessage.new(
-        salary: session[:salary].to_f.round(2), 
+        salary: session[:salary].to_f.round(2),
         salary_frequency: session[:salary_frequency],
         message: :manually_opt_in
       )

--- a/app/controllers/wpcc/your_contributions_controller.rb
+++ b/app/controllers/wpcc/your_contributions_controller.rb
@@ -19,6 +19,8 @@ module Wpcc
       @your_contributions_form = Wpcc::YourContributionsForm.new(
         contribution_percentages
       )
+
+      @message_presenter = message_presenter
     end
 
     def create
@@ -66,6 +68,21 @@ module Wpcc
         employee_percent: employee_percent,
         employer_percent: employer_percent
       }
+    end
+
+    def message_presenter
+      Wpcc::MessagePresenter.new(
+        salary_message,
+        view_context: view_context
+      )
+    end
+
+    def salary_message
+      Wpcc::SalaryMessage.new(
+        salary: session[:salary].to_f.round(2), 
+        salary_frequency: session[:salary_frequency],
+        message: :manually_opt_in
+      )
     end
   end
 end

--- a/app/controllers/wpcc/your_details_controller.rb
+++ b/app/controllers/wpcc/your_details_controller.rb
@@ -1,7 +1,5 @@
 module Wpcc
   class YourDetailsController < EngineController
-    OPT_IN_SALARY_LOWER_LIMIT = 5_876
-    OPT_IN_SALARY_UPPER_LIMIT = 10_000
 
     protect_from_forgery
 
@@ -51,12 +49,6 @@ module Wpcc
 
     def amend_session
       your_details_form_params.each { |key, value| session[key] = value }
-      session[:manually_opt_in] = manually_opt_in?
-    end
-
-    def manually_opt_in?
-      salary = your_details_form_params[:salary].to_i
-      salary >= OPT_IN_SALARY_LOWER_LIMIT && salary <= OPT_IN_SALARY_UPPER_LIMIT
     end
   end
 end

--- a/app/controllers/wpcc/your_details_controller.rb
+++ b/app/controllers/wpcc/your_details_controller.rb
@@ -1,6 +1,5 @@
 module Wpcc
   class YourDetailsController < EngineController
-
     protect_from_forgery
 
     def new

--- a/app/controllers/wpcc/your_results_controller.rb
+++ b/app/controllers/wpcc/your_results_controller.rb
@@ -2,6 +2,7 @@ module Wpcc
   class YourResultsController < EngineController
     def index
       @schedule = Wpcc::Presenter.new(schedule, view_context: view_context)
+      @message_presenter = message_presenter
     end
 
     private
@@ -37,6 +38,20 @@ module Wpcc
           view_context: view_context
         )
       end
+    end
+
+    def message_presenter
+      Wpcc::MessagePresenter.new(
+        salary_message,
+        view_context: view_context
+      )
+    end
+
+    def salary_message
+      Wpcc::SalaryMessage.new(
+        salary: session[:salary].to_f.round(2), 
+        salary_frequency: session[:salary_frequency]
+      )
     end
   end
 end

--- a/app/controllers/wpcc/your_results_controller.rb
+++ b/app/controllers/wpcc/your_results_controller.rb
@@ -49,7 +49,7 @@ module Wpcc
 
     def salary_message
       Wpcc::SalaryMessage.new(
-        salary: session[:salary].to_f.round(2), 
+        salary: session[:salary].to_f.round(2),
         salary_frequency: session[:salary_frequency]
       )
     end

--- a/app/helpers/wpcc/home_helper.rb
+++ b/app/helpers/wpcc/home_helper.rb
@@ -1,4 +1,0 @@
-module Wpcc
-  module HomeHelper
-  end
-end

--- a/app/models/wpcc/salary_message.rb
+++ b/app/models/wpcc/salary_message.rb
@@ -11,9 +11,9 @@ module Wpcc
     end
 
     private
+
     def manually_opt_in?
       salary >= OPT_IN_SALARY_LOWER_LIMIT && salary <= OPT_IN_SALARY_UPPER_LIMIT
     end
-
   end
 end

--- a/app/models/wpcc/salary_message.rb
+++ b/app/models/wpcc/salary_message.rb
@@ -1,0 +1,19 @@
+module Wpcc
+  class SalaryMessage
+    include ActiveModel::Model
+    attr_accessor :salary, :salary_frequency, :message
+
+    OPT_IN_SALARY_LOWER_LIMIT = 5_876
+    OPT_IN_SALARY_UPPER_LIMIT = 10_000
+
+    def manually_opt_in_message?
+      message == :manually_opt_in && manually_opt_in?
+    end
+
+    private
+    def manually_opt_in?
+      salary >= OPT_IN_SALARY_LOWER_LIMIT && salary <= OPT_IN_SALARY_UPPER_LIMIT
+    end
+
+  end
+end

--- a/app/presenters/wpcc/message_presenter.rb
+++ b/app/presenters/wpcc/message_presenter.rb
@@ -1,6 +1,4 @@
 module Wpcc
   class MessagePresenter < Presenter
-    
-    
   end
 end

--- a/app/presenters/wpcc/message_presenter.rb
+++ b/app/presenters/wpcc/message_presenter.rb
@@ -1,0 +1,6 @@
+module Wpcc
+  class MessagePresenter < Presenter
+    
+    
+  end
+end

--- a/app/views/wpcc/shared/_your_details.html.erb
+++ b/app/views/wpcc/shared/_your_details.html.erb
@@ -11,10 +11,10 @@
       <%= link_to(t('wpcc.edit'), new_your_detail_path, class: 'section__heading-edit') %>
     </span>
   </h2>
-  <% if session[:manually_opt_in] %>
+  <% if message_presenter.manually_opt_in_message? %>
     <div class="contributions__row">
       <div class="callout">
-        <%= t('wpcc.contributions.manually_optIn') %>
+        <p><%= t('wpcc.contributions.manually_optIn') %></p>
       </div>
     </div>
   <% end %>

--- a/app/views/wpcc/your_contributions/new.html.erb
+++ b/app/views/wpcc/your_contributions/new.html.erb
@@ -1,4 +1,4 @@
-<%= render 'wpcc/shared/your_details' %>
+<%= render 'wpcc/shared/your_details', message_presenter: @message_presenter %>
 
 <section class="contributions">
   <h2 class="wpcc__heading">2. <%= t('wpcc.contributions.title') %></h2>

--- a/app/views/wpcc/your_results/index.html.erb
+++ b/app/views/wpcc/your_results/index.html.erb
@@ -1,4 +1,4 @@
-<%= render 'wpcc/shared/your_details' %>
+<%= render 'wpcc/shared/your_details', message_presenter: @message_presenter %>
 
 <section class="section section--contributions">
   <h2 class="section__heading contributions__heading">2. <%= t('wpcc.contributions.title') %>

--- a/features/manually_opt_in_message.feature
+++ b/features/manually_opt_in_message.feature
@@ -4,48 +4,57 @@ Feature: Conditional messaging for users earning £5876 - £10,000 (inclusive)
   pension scheme, and will not be automatically enrolled like my higher earning
   colleagues so that I can take the appropriate action with my employer.
 
-
   @no-javascript
-  Scenario Outline: salary earning is between £5,876 and £10,000
+  Scenario Outline: Viewing my details on step 2 and my salary is between £5,876 and £10,000
     Given that I am on the WPCC homepage in my own "<language>"
     When  I enter my age "<gender>" and "<salary_frequency>" 
     And   I choose to make the minimum contribution
     And   I enter a "<salary>" between the salary band
     And   I submit my details
 	  Then  I should be able to proceed to the next page
-    And   I should see the auto-enrolment "<conditional_message>" in my own language
+    And   I should see the manually_opt_in "<message>" in my own language
 
     Examples:
-      | language | gender    | salary_frequency | salary | conditional_message                                                                                                                                             |
+      | language | gender    | salary_frequency | salary | message                                                                                                                                                         |
       | English  | Female    | per Year         | 6000   | Your employer will not automatically enrol you into a workplace pension scheme but you can choose to join. If you do so, your employer will make contributions. |
       | Welsh    | Benywaidd | y Flwyddyn       | 6000   | Ni fydd eich cyflogwr yn eich cofrestru yn awtomatig am gynllun pensiwn gweithle, ond gallwch ddewis ymuno. Os felly, bydd eich cyflogwr yn gwneud cyfraniadau. |
 
-  Scenario Outline: salary earning is above the upper threshold of £10,000
+  Scenario Outline: Viewing my details on step 2 and my salary is above £10,000
     Given that I am on the WPCC homepage in my own "<language>"
     When  I enter my age "<gender>" and "<salary_frequency>" 
     And   I enter a "<salary>" above the upper salary threshold
     And   I choose to make the minimum contribution
     And   I submit my details
 	  Then  I should be able to proceed to the next page
-    And   I should not see the auto-enrolment "<conditional_message>"
+    And   I should not see the manually_opt_in "<message>"
 
     Examples:
-      | language | gender    | salary_frequency | salary  | conditional_message                                                                                                                                             |
+      | language | gender    | salary_frequency | salary  | message                                                                                                                                                         |
       | English  | Female    | per Year         | 10001   | Your employer will not automatically enrol you into a workplace pension scheme but you can choose to join. If you do so, your employer will make contributions. |
       | Welsh    | Benywaidd | y Flwyddyn       | 10001   | Ni fydd eich cyflogwr yn eich cofrestru yn awtomatig am gynllun pensiwn gweithle, ond gallwch ddewis ymuno. Os felly, bydd eich cyflogwr yn gwneud cyfraniadau. |
 
 
-  Scenario Outline: salary earning is below the lower threshold of £5,876
+  Scenario Outline: Viewing my details on step 2 and my salary is below £5,876
     Given that I am on the WPCC homepage in my own "<language>"
     When  I enter my age "<gender>" and "<salary_frequency>"
     And   I enter a "<salary>" below the low salary threshold
     And   I choose to make the full contribution
     And   I submit my details
     Then  I should be able to proceed to the next page
-    And   I should not see the auto-enrolment "<conditional_message>"
+    And   I should not see the manually_opt_in "<message>"
 
     Examples:
-      | language | gender    | salary_frequency | salary | conditional_message                                                                                                                                             |
+      | language | gender    | salary_frequency | salary | message                                                                                                                                                         |
       | English  | Female    | per Year         | 5875   | Your employer will not automatically enrol you into a workplace pension scheme but you can choose to join. If you do so, your employer will make contributions. |
       | Welsh    | Benywaidd | y Flwyddyn       | 5875   | Ni fydd eich cyflogwr yn eich cofrestru yn awtomatig am gynllun pensiwn gweithle, ond gallwch ddewis ymuno. Os felly, bydd eich cyflogwr yn gwneud cyfraniadau. |
 
+  Scenario Outline: Viewing my details on step 3
+    Given I am on step 1 of the WPCC homepage
+    When  I enter my details with a salary within manually_opt_in range and submit the form
+    And   I submit the Your Contributiions form and proceed to Your Results
+    Then  I should not see the manually_opt_in "<message>"
+
+    Examples:
+      | language | message                                                                                                                                                         |
+      | English  | Your employer will not automatically enrol you into a workplace pension scheme but you can choose to  join. If you do so, your employer will make contributions.|
+      | Welsh    | Ni fydd eich cyflogwr yn eich cofrestru yn awtomatig am gynllun pensiwn gweithle, ond gallwch ddewis ymuno. Os felly, bydd eich cyflogwr yn gwneud cyfraniadau. |

--- a/features/step_definitions/manually_opt_in_message_steps.rb
+++ b/features/step_definitions/manually_opt_in_message_steps.rb
@@ -30,10 +30,23 @@ When(/^I enter a "([^"]*)" below the low salary threshold$/) do |salary|
   your_details_page.salary.set(salary)
 end
 
-Then(/^I should see the auto\-enrolment "([^"]*)" in my own language$/) do |conditional_message|
-  expect(page).to have_content(conditional_message)
+When(/^I enter my details with a salary within manually_opt_in range and submit the form$/) do
+  your_details_page.age.set(35)
+  your_details_page.genders.select('Male')
+  your_details_page.salary.set(8_500)
+  your_details_page.salary_frequencies.select('per Year')
+  your_details_page.minimum_contribution_button.set(true)
+  your_details_page.next_button.click
 end
 
-Then(/^I should not see the auto\-enrolment "([^"]*)"$/) do |conditional_message|
-  expect(page).to_not have_content(conditional_message)
+When(/^I submit the Your Contributiions form and proceed to Your Results$/) do
+  your_contributions_page.next_button.click
+end
+
+Then(/^I should see the manually_opt_in "([^"]*)" in my own language$/) do |message|
+  expect(page).to have_content(message)
+end
+
+Then(/^I should not see the manually_opt_in "([^"]*)"$/) do |message|
+  expect(page).to_not have_content(message)
 end

--- a/spec/controllers/your_contributions_controller_spec.rb
+++ b/spec/controllers/your_contributions_controller_spec.rb
@@ -7,6 +7,8 @@ module Wpcc
       let(:contribution_preference) { 'minimum' }
       let(:eligible_salary) { 24_124 }
       let(:salary_frequency) { 'year' }
+      let(:salary_message) { double(Wpcc::SalaryMessage) }
+
       let(:your_contribution) do
         double(
           eligible_salary: eligible_salary,
@@ -74,6 +76,25 @@ module Wpcc
 
           expect(your_contributions_form.employee_percent).to eq(10)
           expect(your_contributions_form.employer_percent).to eq(40)
+        end
+
+        it 'arranges for the conditional message to display' do
+          expect(Wpcc::SalaryMessage)
+            .to receive(:new)
+            .with(
+              salary: salary,
+              salary_frequency: salary_frequency,
+              message: :manually_opt_in
+            )
+            .and_return(salary_message)
+
+          get :new,
+              nil,
+              employee_percent: 10,
+              employer_percent: 40,
+              salary: salary,
+              contribution_preference: contribution_preference,
+              salary_frequency: 'year'
         end
       end
     end

--- a/spec/controllers/your_details_controller_spec.rb
+++ b/spec/controllers/your_details_controller_spec.rb
@@ -53,39 +53,6 @@ module Wpcc
 
           expect(response).to redirect_to new_your_contribution_path
         end
-
-        context 'salary requires manually opting in to enrolment' do
-          let(:data_for_form) do
-            {
-              'age' => 34,
-              'salary' => @salary,
-              'gender' => 'female',
-              'salary_frequency' => 'month',
-              'contribution_preference' => 'full'
-            }
-          end
-
-          it 'stores true if salary outside auto enrolment range' do
-            @salary = 5_876
-            post_create
-
-            expect(session[:manually_opt_in]).to eq(true)
-          end
-
-          it 'stores true if salary is above auto enrolment range' do
-            @salary = 10_001
-            post_create
-
-            expect(session[:manually_opt_in]).to eq(false)
-          end
-
-          it 'stores true if salary is below auto enrolment range' do
-            @salary = 5_875
-            post_create
-
-            expect(session[:manually_opt_in]).to eq(false)
-          end
-        end
       end
 
       context 'failure' do

--- a/spec/models/salary_message_spec.rb
+++ b/spec/models/salary_message_spec.rb
@@ -1,60 +1,40 @@
 RSpec.describe Wpcc::SalaryMessage do
+  subject do
+    described_class.new(
+      salary: @salary,
+      salary_frequency: 'per whatever',
+      message: message
+    )
+  end
+
   describe '#manually_opt_in_message?' do
-    subject do
-      described_class.new(
-        salary: salary,
-        salary_frequency: salary_frequency,
-        message: message
-      )
-    end
+    context 'message is set to manually_opt_in' do
+      let(:message) { :manually_opt_in }
 
-    context 'when yearly frequency' do
-      let(:salary) { 380 }
-      let(:salary_frequency) { 'year' }
+      it 'returns true if salary outside auto enrolment range' do
+        @salary = 5_876
 
-      it 'returns salary' do
-        expect(convert).to eq(380)
+        expect(subject.manually_opt_in_message?).to eq(true)
+      end
+
+      it 'returns false if salary is above auto enrolment range' do
+        @salary = 10_001
+
+        expect(subject.manually_opt_in_message?).to eq(false)
+      end
+
+      it 'returns false if salary is below auto enrolment range' do
+        @salary = 5_875
+
+        expect(subject.manually_opt_in_message?).to eq(false)
       end
     end
 
-    context 'when weekly frequency' do
-      let(:salary) { 500 }
-      let(:salary_frequency) { 'week' }
+    context 'message is NOT set to manually_opt_in' do
+      let(:message) { :not_manually_opt_in }
 
-      it 'returns salary multiplied by 52' do
-        expect(convert).to eq(26_000)
-      end
-    end
-
-    context 'when monthly frequency' do
-      let(:salary) { 1000 }
-      let(:salary_frequency) { 'month' }
-
-      it 'returns salary multiplied by 12' do
-        expect(convert).to eq(12_000)
-      end
-    end
-
-    context 'when per four weeks frequency' do
-      let(:salary) { 1000 }
-      let(:salary_frequency) { 'fourweeks' }
-
-      it 'returns salary multiplied by 13' do
-        expect(convert).to eq(13_000)
-      end
-    end
-
-    context 'when non-existent frequency' do
-      let(:salary) { 1000 }
-      let(:salary_frequency) { 'non-existent' }
-
-      it 'raises an exception' do
-        expect do
-          convert
-        end.to raise_exception(
-          RuntimeError,
-          "Salary frequency 'non-existent' is not supported."
-        )
+      it 'returns false' do
+        expect(subject.manually_opt_in_message?).to eq(false)
       end
     end
   end

--- a/spec/models/salary_message_spec.rb
+++ b/spec/models/salary_message_spec.rb
@@ -1,0 +1,61 @@
+RSpec.describe Wpcc::SalaryMessage do
+  describe '#manually_opt_in_message?' do
+    subject do
+      described_class.new(
+        salary: salary,
+        salary_frequency: salary_frequency,
+        message: message
+      )
+    end
+
+    context 'when yearly frequency' do
+      let(:salary) { 380 }
+      let(:salary_frequency) { 'year' }
+
+      it 'returns salary' do
+        expect(convert).to eq(380)
+      end
+    end
+
+    context 'when weekly frequency' do
+      let(:salary) { 500 }
+      let(:salary_frequency) { 'week' }
+
+      it 'returns salary multiplied by 52' do
+        expect(convert).to eq(26_000)
+      end
+    end
+
+    context 'when monthly frequency' do
+      let(:salary) { 1000 }
+      let(:salary_frequency) { 'month' }
+
+      it 'returns salary multiplied by 12' do
+        expect(convert).to eq(12_000)
+      end
+    end
+
+    context 'when per four weeks frequency' do
+      let(:salary) { 1000 }
+      let(:salary_frequency) { 'fourweeks' }
+
+      it 'returns salary multiplied by 13' do
+        expect(convert).to eq(13_000)
+      end
+    end
+
+    context 'when non-existent frequency' do
+      let(:salary) { 1000 }
+      let(:salary_frequency) { 'non-existent' }
+
+      it 'raises an exception' do
+        expect do
+          convert
+        end.to raise_exception(
+          RuntimeError,
+          "Salary frequency 'non-existent' is not supported."
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
This pr refactors the original approach I took to address [TP User Story 8427](https://moneyadviceservice.tpondemand.com/restui/board.aspx?acid=ddd7f3a626844ab8d1bee3f06ec28efa#page=board/5624876525867731357&appConfig=eyJhY2lkIjoiREI4ODcwRjkxMDNDRTM2NTlBMzhDNTRBRTVBNUU1N0UifQ==&boardPopup=userstory/8427/silent).

This approach creates:
* a SalaryMessage class to be responsible for the conditional messages.
* a MessagePresenter to wrap the SalaryMessage instance.

Controllers needing to display conditional messages, should:
* instantiate a SalaryMessage with the appropriate message
* wrap it in a MessagePresenter instance
* assign to a variable for use by the view 