### PR TITLE
8407 limit tax relief

### DIFF
--- a/app/models/wpcc/period_contribution_calculator.rb
+++ b/app/models/wpcc/period_contribution_calculator.rb
@@ -9,6 +9,12 @@ module Wpcc
                   :tax_relief_percent,
                   :name
 
+    SALARY_FREQUENCY_CONVERSIONS = YAML.load_file(
+      Wpcc::Engine.root.join('config', 'salary_frequency_conversions.yml')
+    )
+    TAX_RELIEF_LIMIT_BY_FREQUENCY =
+      SALARY_FREQUENCY_CONVERSIONS['tax_relief_limit_by_frequency']
+
     def contribution
       log_calculation
       PeriodContribution.new(
@@ -43,7 +49,9 @@ module Wpcc
     end
 
     def tax_relief
-      (employee_contribution * (tax_relief_percent / 100.00)).round(2)
+      result = (employee_contribution * (tax_relief_percent / 100.00)).round(2)
+
+      [TAX_RELIEF_LIMIT_BY_FREQUENCY[salary_frequency], result].min
     end
 
     def total_contributions

--- a/app/models/wpcc/salary_frequency_converter.rb
+++ b/app/models/wpcc/salary_frequency_converter.rb
@@ -1,18 +1,12 @@
 module Wpcc
   class SalaryFrequencyConverter
+    CONVERSIONS = YAML.load_file(
+      Wpcc::Engine.root.join('config', 'salary_frequency_conversions.yml')
+    )
+    SALARY_FREQUENCIES = CONVERSIONS['salary_frequencies']
+
     def self.convert(salary_frequency)
-      salary_frequencies[salary_frequency]
+      SALARY_FREQUENCIES[salary_frequency]
     end
-
-    def self.salary_frequencies
-      {
-        'year' => 1,
-        'month' => 12,
-        'fourweeks' => 13,
-        'week' => 52
-      }
-    end
-
-    private_class_method :salary_frequencies
   end
 end

--- a/config/salary_frequency_conversions.yml
+++ b/config/salary_frequency_conversions.yml
@@ -1,0 +1,10 @@
+salary_frequencies:
+  year: 1
+  month: 12
+  fourweeks: 13
+  week: 52
+tax_relief_limit_by_frequency:
+  1:  8000
+  12: 666.67
+  13: 615.38
+  52: 153.85

--- a/features/_your_results/limit_tax_relief.feature
+++ b/features/_your_results/limit_tax_relief.feature
@@ -1,0 +1,39 @@
+Feature:
+  As an employee contributing greater than £40,000 per year to my pension
+  In order to get a clear picture of the impact on my take-home pay.
+  I want the results to reflect the fact that I will not get tax relief
+  for any contribution over £40,000 per year.
+
+  Background:
+    Given I am on the Your Details step of the tool
+
+  Scenario: Annual Salary
+    Given I fill my details:
+      | age | gender | salary | salary_frequency | contribution |
+      | 25  | male   | 80000  | per Year         | Full         |
+    And I click the Next button
+    And I fill my contributions:
+      | your_contribution | employer_contribution |
+      | 60                | 1                     |
+    When I move on to the results page
+    Then I should see on the results page:
+      | £48,000.00 | £48,000.00 | £48,000.00 |
+      | £8,000.00  | £8,000.00  | £8,000.00  |
+      | £800.00    | £1,600.00  | £2,400.00  |
+      | £48,800.00 | £49,600.00 | £50,400.00 |
+
+  Scenario: Weekly Salary
+    Given I fill my details:
+      | age | gender | salary | salary_frequency | contribution |
+      | 25  | female | 1200   | per Week         | Full         |
+    And I click the Next button
+    And I fill my contributions:
+      | your_contribution | employer_contribution |
+      | 65                | 1                     |
+    When I move on to the results page
+    Then I should see on the results page:
+      | £780.00 | £780.00 | £780.00 |
+      | £153.85 | £153.85 | £153.85 |
+      | £12.00  | £24.00  | £36.00  |
+      | £792.00 | £804.00 | £816.00 |
+

--- a/features/_your_results/limit_tax_relief.feature
+++ b/features/_your_results/limit_tax_relief.feature
@@ -6,15 +6,12 @@ Feature: Limit Tax Relief
 
   Background:
     Given I am on the Your Details step
+    And I am a "25" year old "male"
 
-    Scenario: Limit tax relief when above yearly figures
-      Given I fill in my details:
-        | age | gender | salary | salary_frequency | contribution |
-        | 25  | male   | 80000  | per Year         | Full         |
+    Scenario: Employee contributing more than £40,000 per year to pension
+      Given my salary is "80000" "per Year" with "Full" contribution
       And I click the Next button
-      And I fill in my contributions:
-        | your_contribution | employer_contribution |
-        | 60                | 1                     |
+      And my contribution is "60" percent
       When I move on to the results page
       Then I should see on the results page:
         | £48,000.00 | £48,000.00 | £48,000.00 |
@@ -22,14 +19,10 @@ Feature: Limit Tax Relief
         | £800.00    | £1,600.00  | £2,400.00  |
         | £48,800.00 | £49,600.00 | £50,400.00 |
 
-    Scenario: Limit tax relief when above weekly figures
-      Given I fill in my details:
-        | age | gender | salary | salary_frequency | contribution |
-        | 25  | female | 1200   | per Week         | Full         |
+    Scenario: Employee contributing more than £769.23 per week to pension
+      Given my salary is "1200" "per Week" with "Full" contribution
       And I click the Next button
-      And I fill in my contributions:
-        | your_contribution | employer_contribution |
-        | 65                | 1                     |
+      And my contribution is "65" percent
       When I move on to the results page
       Then I should see on the results page:
         | £780.00 | £780.00 | £780.00 |
@@ -37,14 +30,10 @@ Feature: Limit Tax Relief
         | £12.00  | £24.00  | £36.00  |
         | £792.00 | £804.00 | £816.00 |
 
-    Scenario: Limit tax relief when above monthly figures
-      Given I fill in my details:
-        | age | gender | salary | salary_frequency | contribution |
-        | 23  | female | 4000   | per Month        | Full         |
+    Scenario: Employee contributing more than £3,333.33 per month to pension
+      Given my salary is "4000" "per Month" with "Full" contribution
       And I click the Next button
-      And I fill in my contributions:
-        | your_contribution | employer_contribution |
-        | 90                | 1                     |
+      And my contribution is "90" percent
       When I move on to the results page
       Then I should see on the results page:
         | £3,600.00 | £3,600.00 | £3,600.00 |
@@ -52,14 +41,10 @@ Feature: Limit Tax Relief
         | £40.00    | £80.00    | £120.00   |
         | £3,640.00 | £3,680.00 | £3,720.00  |
 
-    Scenario: Limit tax relief when above per 4 weeks figures
-      Given I fill in my details:
-        | age | gender | salary | salary_frequency | contribution |
-        | 23  | female | 5000   | per 4 weeks      | Full         |
+    Scenario: Employee contributing more than £3,076.92 per 4 weeks to pension
+      Given my salary is "5000" "per 4 weeks" with "Full" contribution
       And I click the Next button
-      And I fill in my contributions:
-        | your_contribution | employer_contribution |
-        | 90                | 1                     |
+      And my contribution is "90" percent
       When I move on to the results page
       Then I should see on the results page:
         | £4,500.00 | £4,500.00 | £4,500.00 |

--- a/features/_your_results/limit_tax_relief.feature
+++ b/features/_your_results/limit_tax_relief.feature
@@ -1,39 +1,68 @@
-Feature:
-  As an employee contributing greater than £40,000 per year to my pension
+Feature: Limit Tax Relief
   In order to get a clear picture of the impact on my take-home pay.
+  As an employee contributing greater than £40,000 per year to my pension
   I want the results to reflect the fact that I will not get tax relief
   for any contribution over £40,000 per year.
 
   Background:
-    Given I am on the Your Details step of the tool
+    Given I am on the Your Details step
 
-  Scenario: Annual Salary
-    Given I fill my details:
-      | age | gender | salary | salary_frequency | contribution |
-      | 25  | male   | 80000  | per Year         | Full         |
-    And I click the Next button
-    And I fill my contributions:
-      | your_contribution | employer_contribution |
-      | 60                | 1                     |
-    When I move on to the results page
-    Then I should see on the results page:
-      | £48,000.00 | £48,000.00 | £48,000.00 |
-      | £8,000.00  | £8,000.00  | £8,000.00  |
-      | £800.00    | £1,600.00  | £2,400.00  |
-      | £48,800.00 | £49,600.00 | £50,400.00 |
+    Scenario: Limit tax relief when above yearly figures
+      Given I fill in my details:
+        | age | gender | salary | salary_frequency | contribution |
+        | 25  | male   | 80000  | per Year         | Full         |
+      And I click the Next button
+      And I fill in my contributions:
+        | your_contribution | employer_contribution |
+        | 60                | 1                     |
+      When I move on to the results page
+      Then I should see on the results page:
+        | £48,000.00 | £48,000.00 | £48,000.00 |
+        | £8,000.00  | £8,000.00  | £8,000.00  |
+        | £800.00    | £1,600.00  | £2,400.00  |
+        | £48,800.00 | £49,600.00 | £50,400.00 |
 
-  Scenario: Weekly Salary
-    Given I fill my details:
-      | age | gender | salary | salary_frequency | contribution |
-      | 25  | female | 1200   | per Week         | Full         |
-    And I click the Next button
-    And I fill my contributions:
-      | your_contribution | employer_contribution |
-      | 65                | 1                     |
-    When I move on to the results page
-    Then I should see on the results page:
-      | £780.00 | £780.00 | £780.00 |
-      | £153.85 | £153.85 | £153.85 |
-      | £12.00  | £24.00  | £36.00  |
-      | £792.00 | £804.00 | £816.00 |
+    Scenario: Limit tax relief when above weekly figures
+      Given I fill in my details:
+        | age | gender | salary | salary_frequency | contribution |
+        | 25  | female | 1200   | per Week         | Full         |
+      And I click the Next button
+      And I fill in my contributions:
+        | your_contribution | employer_contribution |
+        | 65                | 1                     |
+      When I move on to the results page
+      Then I should see on the results page:
+        | £780.00 | £780.00 | £780.00 |
+        | £153.85 | £153.85 | £153.85 |
+        | £12.00  | £24.00  | £36.00  |
+        | £792.00 | £804.00 | £816.00 |
 
+    Scenario: Limit tax relief when above monthly figures
+      Given I fill in my details:
+        | age | gender | salary | salary_frequency | contribution |
+        | 23  | female | 4000   | per Month        | Full         |
+      And I click the Next button
+      And I fill in my contributions:
+        | your_contribution | employer_contribution |
+        | 90                | 1                     |
+      When I move on to the results page
+      Then I should see on the results page:
+        | £3,600.00 | £3,600.00 | £3,600.00 |
+        | £666.67   | £666.67   | £666.67   |
+        | £40.00    | £80.00    | £120.00   |
+        | £3,640.00 | £3,680.00 | £3,720.00  |
+
+    Scenario: Limit tax relief when above per 4 weeks figures
+      Given I fill in my details:
+        | age | gender | salary | salary_frequency | contribution |
+        | 23  | female | 5000   | per 4 weeks      | Full         |
+      And I click the Next button
+      And I fill in my contributions:
+        | your_contribution | employer_contribution |
+        | 90                | 1                     |
+      When I move on to the results page
+      Then I should see on the results page:
+        | £4,500.00 | £4,500.00 | £4,500.00 |
+        | £615.38   | £615.38   | £615.38   |
+        | £50.00    | £100.00   | £150.00   |
+        | £4,550.00 | £4,600.00 | £4,650.00 |

--- a/features/step_definitions/your_contributions_steps.rb
+++ b/features/step_definitions/your_contributions_steps.rb
@@ -2,35 +2,6 @@ Given(/^I am on the WPCC homepage$/) do
   step 'I am on step 1 of the WPCC homepage'
 end
 
-Given(/^I complete the your details form and move to your contributions page$/) do
-  step 'I fill in the age, gender, salary and frequency fields'
-  step 'I click on "My employer makes contributions on part of my salary"'
-  step 'I click the Next button'
-end
-
-When(/^I fill in my employer and employee contributions$/) do
-  your_contributions_page.employee_percent.set(14)
-  your_contributions_page.employer_percent.set(15)
-end
-
-Then(/^I should see my contributions summarised$/) do
-  expect(your_results_page.your_contributions_information.text).to eq('You: 14%, Your employer: 15%')
-end
-
-Given(/^I have valid contributions$/) do
-  step 'I fill in my employer and employee contributions'
-  step 'I click the Next button'
-end
-
-Then(/^I should return to the Your Contributions step$/) do
-  expect(your_contributions_page.form).to be_visible
-end
-
-Then(/^I should see my current contributions in the form fields$/) do
-  expect(your_contributions_page.employee_percent.value).to eq('14')
-  expect(your_contributions_page.employer_percent.value).to eq('15')
-end
-
 Given(/^I complete the your contributions form$/) do
   # using default values for employee and employer percents
 end
@@ -39,20 +10,14 @@ Given(/^I move to your results page$/) do
   your_contributions_page.next_button.click
 end
 
-When(/^I click to edit my details$/) do
-  your_contributions_page.edit_link.click
+Given(/^I complete the your details form and move to your contributions page$/) do
+  step 'I fill in the age, gender, salary and frequency fields'
+  step 'I click on "My employer makes contributions on part of my salary"'
+  step 'I click the Next button'
 end
 
-Then(/^I should return to the Your Details step$/) do
-  expect(your_details_page.form).to be_visible
-end
-
-Then(/^I should see my current details in the form fields$/) do
-  expect(page).to have_css("input[value='35']")
-  expect( find(:css, 'select#your_details_form_gender').value ).to eq('female')
-  expect(page).to have_css("input[value='35000']")
-  expect( find(:css, 'select#your_details_form_salary_frequency').value ).to eq('year')
-  expect(page).to have_css("input[value='minimum']")
+Given(/^my contribution is "([^"]*)" percent$/) do |contribution|
+  step %{my employee contribution is "#{contribution}"}
 end
 
 Given(/^I fill in my contributions:$/) do |table|
@@ -67,6 +32,45 @@ end
 
 Given(/^my employer contribution is "([^"]*)"$/) do |employer_percent|
   your_contributions_page.employer_percent.set(employer_percent)
+end
+
+Given(/^I have valid contributions$/) do
+  step 'I fill in my employer and employee contributions'
+  step 'I click the Next button'
+end
+
+When(/^I fill in my employer and employee contributions$/) do
+  your_contributions_page.employee_percent.set(14)
+  your_contributions_page.employer_percent.set(15)
+end
+
+When(/^I click to edit my details$/) do
+  your_contributions_page.edit_link.click
+end
+
+Then(/^I should see my contributions summarised$/) do
+  expect(your_results_page.your_contributions_information.text).to eq('You: 14%, Your employer: 15%')
+end
+
+Then(/^I should return to the Your Contributions step$/) do
+  expect(your_contributions_page.form).to be_visible
+end
+
+Then(/^I should see my current contributions in the form fields$/) do
+  expect(your_contributions_page.employee_percent.value).to eq('14')
+  expect(your_contributions_page.employer_percent.value).to eq('15')
+end
+
+Then(/^I should return to the Your Details step$/) do
+  expect(your_details_page.form).to be_visible
+end
+
+Then(/^I should see my current details in the form fields$/) do
+  expect(page).to have_css("input[value='35']")
+  expect( find(:css, 'select#your_details_form_gender').value ).to eq('female')
+  expect(page).to have_css("input[value='35000']")
+  expect( find(:css, 'select#your_details_form_salary_frequency').value ).to eq('year')
+  expect(page).to have_css("input[value='minimum']")
 end
 
 When(/^I click to edit my contributions$/) do

--- a/features/step_definitions/your_details_steps.rb
+++ b/features/step_definitions/your_details_steps.rb
@@ -2,18 +2,6 @@ Given(/^I am on the Your Details step$/) do
   your_details_page.load(locale: :en)
 end
 
-When(/^I fill in my details$/) do
-  your_details_page.age.set(35)
-  your_details_page.genders.select('Female')
-  your_details_page.salary.set(35000)
-  your_details_page.salary_frequencies.select('per Year')
-  your_details_page.minimum_contribution_button.set(true)
-end
-
-When(/^I proceed to the next step$/) do
-  your_details_page.next_button.click
-end
-
 Given(/^I have valid details$/) do
   steps %{
     Given I am on the Your Details step
@@ -28,6 +16,17 @@ end
 
 Given(/^I am on the Your Results step$/) do
   your_results_page.load(locale: :en)
+end
+
+Given(/^I am a "([^"]*)" year old "([^"]*)"$/) do |age, gender|
+  step %{I enter my age as "#{age}"}
+  step %{I select my gender as "#{gender}"}
+end
+
+Given(/^my salary is "([^"]*)" "([^"]*)" with "([^"]*)" contribution$/) do |salary, salary_frequency, contribution|
+  step %{I enter my salary as "#{salary}"}
+  step %{I select my salary frequency as "#{salary_frequency}"}
+  step %{I choose my contribution preference as "#{contribution}"}
 end
 
 Given(/^I fill in my details:$/) do |table|
@@ -103,16 +102,20 @@ When(/^I submit my details$/) do
   your_details_page.next_button.click
 end
 
-Then(/^I should not be able to choose to make minimum employer contributions$/) do
-  expect(your_details_page.minimum_contribution_button).to be_disabled
-end
-
 When(/^I choose to make full contributions$/) do
   your_details_page.full_contribution_button.set(true)
 end
 
-Then(/^I should be able to proceed to the next page$/) do
-  expect(page.current_url).to have_content('/your_contributions/new')
+When(/^I fill in my details$/) do
+  your_details_page.age.set(35)
+  your_details_page.genders.select('Female')
+  your_details_page.salary.set(35000)
+  your_details_page.salary_frequencies.select('per Year')
+  your_details_page.minimum_contribution_button.set(true)
+end
+
+When(/^I proceed to the next step$/) do
+  your_details_page.next_button.click
 end
 
 When(/^I enter my age as 35$/) do
@@ -141,6 +144,14 @@ end
 
 When(/^I press next$/) do
   your_details_page.next_button.click
+end
+
+Then(/^I should be able to proceed to the next page$/) do
+  expect(page.current_url).to have_content('/your_contributions/new')
+end
+
+Then(/^I should not be able to choose to make minimum employer contributions$/) do
+  expect(your_details_page.minimum_contribution_button).to be_disabled
 end
 
 Then(/^the Step 2 intro paragraph should display my eligible salary$/) do

--- a/spec/models/contributions_calendar_spec.rb
+++ b/spec/models/contributions_calendar_spec.rb
@@ -14,7 +14,7 @@ describe Wpcc::ContributionsCalendar, type: :model do
     let(:eligible_salary) { 0 }
     let(:employee_percent) { 0 }
     let(:employer_percent) { 0 }
-    let(:salary_frequency) { 0 }
+    let(:salary_frequency) { 1 }
     let(:period_contribution_calculator) do
       double('PeriodContributionCalculator')
     end

--- a/spec/models/period_contribution_calculator_spec.rb
+++ b/spec/models/period_contribution_calculator_spec.rb
@@ -108,5 +108,43 @@ describe Wpcc::PeriodContributionCalculator, type: :model do
         expect(period_contribution.tax_relief).to eq(1.72)
       end
     end
+
+    context 'when employee is contributing more than 40,000 per year' do
+      let(:eligible_salary) { 80_000 }
+      let(:employee_percent) { 60 }
+      let(:employer_percent) { 1 }
+
+      context 'when yearly frequency' do
+        let(:salary_frequency) { 1 }
+
+        it 'returns employee tax relief' do
+          expect(period_contribution.tax_relief).to eq(8000)
+        end
+      end
+
+      context 'when monthly frequency' do
+        let(:salary_frequency) { 12 }
+
+        it 'returns employee tax relief limit' do
+          expect(period_contribution.tax_relief).to eq(666.67)
+        end
+      end
+
+      context 'when per 4 weeks frequency' do
+        let(:salary_frequency) { 13 }
+
+        it 'returns employee tax relief limit' do
+          expect(period_contribution.tax_relief).to eq(615.38)
+        end
+      end
+
+      context 'when weekly frequency' do
+        let(:salary_frequency) { 52 }
+
+        it 'returns employee tax relief limit' do
+          expect(period_contribution.tax_relief).to eq(153.85)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
TP: https://moneyadviceservice.tpondemand.com/entity/8407

This PR adds the feature of where an employee contribution percentage amounts to an annual contribution greater than £40,000 the results page should limit annual tax relief to £8000 (20% of £40,000).

This PR also addresses other frequencies as well.