### PR TITLE
[DEV APPROVED] - Fixes Frequency Change issue with salary based conditional messaging

### DIFF
--- a/app/assets/javascripts/wpcc/components/SalaryConditions.js
+++ b/app/assets/javascripts/wpcc/components/SalaryConditions.js
@@ -51,6 +51,10 @@ define(['jquery', 'DoughBaseComponent'], function($, DoughBaseComponent) {
       clearTimeout(typingTimer);
     })
 
+    this.$salaryFrequency.change(function() {
+      $this._calculateAnnual();
+    })
+
   }
 
   // Function to calculate the annual salary based on different frequencies

--- a/spec/javascripts/tests/SalaryConditions_spec.js
+++ b/spec/javascripts/tests/SalaryConditions_spec.js
@@ -142,6 +142,13 @@ describe('Salary Conditions', function() {
     var clock;
 
     beforeEach(function() {
+
+      this.triggerChange = function(element, value) {
+        var e = $.Event('change');
+        $(element).val(value);
+        element.trigger(e);
+      };
+
       this.salaryField = this.component.find('[data-dough-salary-input]');
       this.salaryFrequency = this.component.find('[data-dough-frequency-select]');
       this.callout_lt5876 = this.component.find('[data-dough-callout-lt5876]');
@@ -186,6 +193,21 @@ describe('Salary Conditions', function() {
         this.callout_lt5876.hasClass('details__callout--active')
       ).to.be.true;
       done();
+    });
+
+    it('Hides the callout if frequency is changed equalling a salary over £5876', function() {
+      this.salaryField.val('5000');
+      this.salaryFrequency.val('year');
+      this.salaryField.trigger('keyup');
+      clock.tick(this.delay);
+      expect(
+        this.callout_lt5876.hasClass('details__callout--active')
+      ).to.be.true;
+
+      this.triggerChange(this.salaryFrequency, 'month');
+      expect(
+        this.callout_lt5876.hasClass('details__callout--inactive')
+      ).to.be.true;
     });
 
   });


### PR DESCRIPTION
# Fixes Frequency Change issue with salary based conditional messaging

Fixes issue where the user enters a salary which results in a callout being displayed, and then changed the frequency.  The function to calculate the annual salary now runs when the frequency is changed, to ensure that the correct callouts are displayed/hidden.