### PR TITLE
[DEV APPROVED] 8449 - Contributions Conditions Component

### DIFF
--- a/app/assets/javascripts/wpcc/components/ContributionConditions.js
+++ b/app/assets/javascripts/wpcc/components/ContributionConditions.js
@@ -1,0 +1,72 @@
+define(['jquery', 'DoughBaseComponent'], function($, DoughBaseComponent) {
+  'use strict';
+
+  var ContributionConditions,
+  defaultConfig = {};
+
+  ContributionConditions = function($el, config) {
+    ContributionConditions.baseConstructor.call(this, $el, config, defaultConfig);
+
+    this.$employeeContributions = this.$el.find('[data-dough-employee-contributions]');
+    this.$eligibleSalary = this.$el.find('[data-dough-contribution-salary]');
+    this.$contributionWarning = this.$el.find('[data-dough-callout-contribution-gt40000]');
+
+  };
+
+  DoughBaseComponent.extend(ContributionConditions);
+
+  ContributionConditions.componentName = 'ContributionConditions';
+
+  ContributionConditions.prototype.init = function(initialised) {
+    this._initialisedSuccess(initialised);
+    this._calculateContribution();
+    this._setUpEvents();
+  };
+
+  // Set up events to detect contribution input changes
+  ContributionConditions.prototype._setUpEvents = function() {
+    var $this = this;
+
+    var contributionsCallback = function() {
+      $this._calculateContribution();
+    };
+
+    this.$employeeContributions.keyup(contributionsCallback);
+    this.$employeeContributions.change(contributionsCallback);
+
+  }
+
+  //add up employee contributions based on salary
+  //if more than 40k call display function otherwise call the hide function
+  ContributionConditions.prototype._calculateContribution = function() {
+    var $this = this,
+    salaryToNumber = parseInt(this.$eligibleSalary.text()),
+    salaryContributionAmount = (salaryToNumber/100)*this.$employeeContributions.val();
+    
+    if (salaryContributionAmount > 40000) {
+      $this._displayMessage();
+    }
+    else {
+      $this._hideMessage();
+    }
+
+  }
+
+  //display warning message
+  ContributionConditions.prototype._displayMessage = function() {
+
+    this.$contributionWarning.removeClass('details__callout--inactive');
+    this.$contributionWarning.addClass('details__callout--active');
+
+  };
+
+  //hide warning message
+  ContributionConditions.prototype._hideMessage = function() {
+
+    this.$contributionWarning.removeClass('details__callout--active');
+    this.$contributionWarning.addClass('details__callout--inactive');
+
+  };
+
+  return ContributionConditions;
+});

--- a/app/assets/javascripts/wpcc/require_config.js.erb
+++ b/app/assets/javascripts/wpcc/require_config.js.erb
@@ -8,6 +8,7 @@
 //= depend_on_asset dough/assets/js/components/PopupTip
 //= depend_on_asset wpcc/components/ConditionalMessaging
 //= depend_on_asset wpcc/components/SalaryConditions
+//= depend_on_asset wpcc/components/ContributionConditions
 
 <%
   def requirejs_path(asset)
@@ -26,7 +27,8 @@
 
       # Non Dough Component
       ConditionalMessaging: requirejs_path('wpcc/components/ConditionalMessaging'),
-      SalaryConditions: requirejs_path('wpcc/components/SalaryConditions')
+      SalaryConditions: requirejs_path('wpcc/components/SalaryConditions'),
+      ContributionConditions: requirejs_path('wpcc/components/ContributionConditions')
     }
   }
 %>

--- a/app/views/wpcc/your_contributions/new.html.erb
+++ b/app/views/wpcc/your_contributions/new.html.erb
@@ -18,7 +18,7 @@
       'data-dough-validation-config': '{"showValidationSummary": false}',
       'novalidate': true
     }) do |f| %>
-    <div data-dough-component="SalaryConditions">
+    <div data-dough-component="SalaryConditions ContributionConditions">
       <div class="contributions__row">
         <div class="contributions__source contributions__source--employee form__row">
           <h3 class="contributions__source-title"><%= t('wpcc.contributions.your_contribution_title') %></h3>
@@ -34,7 +34,9 @@
             'data-dough-validation-invalid': t('wpcc.contributions.employee_validation.out_of_range')
           %>
           <%= t('wpcc.contributions.input_of_label') %>
-          <span>£<%= @your_contribution.eligible_salary %></span>
+          <span>
+            £<span data-dough-contribution-salary><%= @your_contribution.eligible_salary %></span>
+          </span>
         </div>
         <div class="contributions__source contributions__source--employer form__row">
           <h3 class="contributions__source-title"><%= t('wpcc.contributions.employer_contribution_title') %></h3>
@@ -53,10 +55,12 @@
         </div>
       </div>
       <div class="contributions__row">
-        <div class="callout">
-          <p><%= t('wpcc.contributions.employee_contribution_warning') %></p>
+        <div class="form__row details__callout details__callout--inactive" data-dough-callout-contribution-gt40000>
+          <div class="callout">
+            <p><%= t('wpcc.contributions.contribution_gt40000_warning') %></p>
+          </div>
         </div>
-        <%= f.submit t('wpcc.contributions.calculate_button'), class: 'button button--primary' %>
+        <%= f.submit(t('wpcc.contributions.calculate_button'), class: 'button button--primary', 'data-dough-submit': true) %>
       </div>
     </div>
   <% end %>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -67,6 +67,7 @@ cy:
       input_of_label: o
       calculate_button: Cyfrifwch eich cyfraniadau
       employee_contribution_warning: Y cyfraniad uchaf gewch chi ei roi mewn pensiwn fesul blwyddyn yw 100% o’ch cyflog neu £40,000, pa bynnag un sydd leiaf.
+      contribution_gt40000_warning: Rhoddir gostyngiad treth ar gyfraniadau hyd at £40,000 y flwyddyn yn unig, neu 100% o’ch enillion, pa bynnag un sydd leiaf.
       employee_validation:
         blank: Rhowch eich cyfraniad
         out_of_range: Rhaid i'ch cyfraniad fod yn yr ystod 0 - 100%

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -66,6 +66,7 @@ en:
       input_of_label: of
       calculate_button: Calculate your contributions
       employee_contribution_warning: The maximum you can contribute to a pension per year is 100% of your salary or £40,000, whichever is lower.
+      contribution_gt40000_warning: Tax relief is only applied to contributions of up to £40,000 per year or 100% of your earnings, whichever is lower.
       employee_validation:
         blank: Please enter your contribution
         out_of_range: Your contribution must be in the range 0% - 100%

--- a/spec/javascripts/fixtures/ContributionConditions.html
+++ b/spec/javascripts/fixtures/ContributionConditions.html
@@ -1,0 +1,11 @@
+<div>
+  <section data-dough-component="ContributionConditions">
+
+    <input data-dough-employee-contributions type="number">
+
+    <span data-dough-contribution-salary></span>
+
+    <div class="details__callout--inactive" data-dough-callout-contribution-gt40000></div>
+
+  </section>
+</div>

--- a/spec/javascripts/test-main.js
+++ b/spec/javascripts/test-main.js
@@ -34,6 +34,7 @@ require.config({
 
     // WPCC components
     ConditionalMessaging: 'app/assets/javascripts/wpcc/components/ConditionalMessaging',
-    SalaryConditions: 'app/assets/javascripts/wpcc/components/SalaryConditions'
+    SalaryConditions: 'app/assets/javascripts/wpcc/components/SalaryConditions',
+    ContributionConditions: 'app/assets/javascripts/wpcc/components/ContributionConditions'
   }
 })

--- a/spec/javascripts/tests/ContributionConditions_spec.js
+++ b/spec/javascripts/tests/ContributionConditions_spec.js
@@ -1,0 +1,54 @@
+describe('Contribution Conditions', function() {
+  'use strict';
+
+  beforeEach(function(done) {
+    var _this = this;
+
+    requirejs(
+      ['jquery', 'ContributionConditions'],
+      function($, ContributionConditions) {
+        _this.$html = $(window.__html__['spec/javascripts/fixtures/ContributionConditions.html']).appendTo('body');
+        _this.component = _this.$html.find('[data-dough-component="ContributionConditions"]');
+        _this.contributionConditions = ContributionConditions;
+        _this.obj = new _this.contributionConditions(_this.component);
+        done();
+      }, done);
+  });
+
+  afterEach(function() {
+    this.$html.remove();
+  });
+
+  describe('When an employee contribution percentage is entered', function() {
+    
+    beforeEach(function() {
+      this.employeeContributions = this.component.find('[data-dough-employee-contributions]');
+      this.eligibleSalary = this.component.find('[data-dough-contribution-salary]');
+      this.contributionWarning = this.component.find('[data-dough-callout-contribution-gt40000]');
+
+      this.obj.init();
+    });
+
+    describe('When salary contribution is under 40000', function() {
+      it('Does not display the callout message', function() {
+        this.employeeContributions.val(20);
+        this.eligibleSalary.text('60000');
+        this.employeeContributions.trigger('keyup');
+        expect(
+          this.contributionWarning.hasClass('details__callout--inactive')
+        ).to.be.true;
+      });
+    });
+
+    describe('When salary contribution is over 40000', function() {
+      it('Displays the callout message', function() {
+        this.employeeContributions.val(100);
+        this.eligibleSalary.text('60000');
+        this.employeeContributions.trigger('keyup');
+        expect(
+          this.contributionWarning.hasClass('details__callout--active')
+        ).to.be.true;
+      });
+    });
+  });
+});


### PR DESCRIPTION
# Client side contribution percentage conditional messaging

Tax relief is only applied to contributions of up to £40,000 per year or 100% of your earnings, whichever is lower.
When I select any % that would result in an annual pension contribution of more than £40,000
Then I should be told that my proposed contribution is greater than the maximum allowed for tax relief and submit button should be disabled.

TP [ticket](https://moneyadviceservice.tpondemand.com/entity/8449)

<img width="645" alt="screen shot 2017-08-04 at 10 19 55" src="https://user-images.githubusercontent.com/2187295/28962721-854bf754-78fe-11e7-8e02-cde6bc56e5c3.png">

