### PR TITLE
[DEV APPROVED] - 8426 Amendments to tax relief warning

### DIFF
--- a/app/models/wpcc/your_details_form.rb
+++ b/app/models/wpcc/your_details_form.rb
@@ -12,7 +12,7 @@ module Wpcc
 
     validates :age, presence: true
     validates :gender, inclusion: { in: GENDERS }
-    validates :salary, numericality: { only_integer: true, greater_than: 0 }
+    validates :salary, numericality: { greater_than: 0 }
     validates :salary_frequency, inclusion: { in: SALARY_FREQUENCIES }
     validates :contribution_preference, inclusion: { in: CONTRIBUTIONS }
     validates_with Wpcc::SalaryThresholdValidator

--- a/app/views/wpcc/your_results/index.html.erb
+++ b/app/views/wpcc/your_results/index.html.erb
@@ -12,6 +12,12 @@
 
   <div class="results__content">
     <p><%= t('wpcc.results.description', eligible_salary: session[:eligible_salary]) %></p>
+    
+    <% if @message_presenter.tax_relief_warning? %>
+      <div class="callout">
+        <p><%= @message_presenter.tax_relief_warning %></p>
+      </div>
+    <% end %>
 
     <%= render 'frequency_selector_form', salary_frequency: @salary_frequency %>
 
@@ -43,12 +49,6 @@
         </div>
       <% end %>
     </div>
-
-    <% if @message_presenter.tax_relief_warning? %>
-      <div class="callout">
-        <p><%= @message_presenter.tax_relief_warning %></p>
-      </div>
-    <% end %>
 
     <p><a href="#" data-dough-component="Print"><%= t('wpcc.results.print_link') %></a></p>
     <p><a href="#"><%= t('wpcc.results.contribution_table_link') %></a></p>

--- a/features/_your_results/tax_relief_warning.feature
+++ b/features/_your_results/tax_relief_warning.feature
@@ -17,6 +17,9 @@ Feature: Display Tax Relief Warning
       | language | salary | salary_frequency | warning_message |
       | Welsh    | 11000  | y Flwyddyn       | Os nad ydych chi'n talu treth incwm ar eich enillion, fyddwch chi ddim ond yn cael gostyngiad treth ar eich cyfraniadau |
       | English  | 11000  | per Year         | If you don’t pay income tax on your earnings, you will only receive tax relief on your pension contributions            |
+      | English  | 858.33 | per Month        | If you don’t pay income tax on your earnings, you will only receive tax relief on your pension contributions            |
+      | English  | 784.61 | per 4 weeks      | If you don’t pay income tax on your earnings, you will only receive tax relief on your pension contributions            |
+      | English  | 121.14 | per Week         | If you don’t pay income tax on your earnings, you will only receive tax relief on your pension contributions            |
 
   @no-javascript
   Scenario Outline: Earning £11,500 per year
@@ -32,6 +35,9 @@ Feature: Display Tax Relief Warning
       | language | salary | salary_frequency | warning_message |
       | Welsh    | 11500  | y Flwyddyn       | Os nad ydych chi'n talu treth incwm ar eich enillion, fyddwch chi ddim ond yn cael gostyngiad treth ar eich cyfraniadau |
       | English  | 11500  | per Year         | If you don’t pay income tax on your earnings, you will only receive tax relief on your pension contributions            |
+      | English  | 958.33 | per Month        | If you don’t pay income tax on your earnings, you will only receive tax relief on your pension contributions            |
+      | English  | 884.61 | per 4 weeks      | If you don’t pay income tax on your earnings, you will only receive tax relief on your pension contributions            |
+      | English  | 221.15 | per Week         | If you don’t pay income tax on your earnings, you will only receive tax relief on your pension contributions            |
   
   @no-javascript
   Scenario Outline: Earning above £11,500 per year
@@ -47,4 +53,7 @@ Feature: Display Tax Relief Warning
       | language | salary | salary_frequency | warning_message |
       | Welsh    | 11501  | y Flwyddyn       | Os nad ydych chi'n talu treth incwm ar eich enillion, fyddwch chi ddim ond yn cael gostyngiad treth ar eich cyfraniadau |
       | English  | 11501  | per Year         | If you don’t pay income tax on your earnings, you will only receive tax relief on your pension contributions            |
+      | English  | 959.33 | per Month        | If you don’t pay income tax on your earnings, you will only receive tax relief on your pension contributions            |
+      | English  | 885.61 | per 4 weeks      | If you don’t pay income tax on your earnings, you will only receive tax relief on your pension contributions            |
+      | English  | 222.14 | per Week         | If you don’t pay income tax on your earnings, you will only receive tax relief on your pension contributions            |
 

--- a/spec/models/your_details_form_spec.rb
+++ b/spec/models/your_details_form_spec.rb
@@ -44,7 +44,7 @@ describe Wpcc::YourDetailsForm, type: :model do
       it { should_not allow_value('foo').for(:salary) }
       it { should_not allow_value(0).for(:salary) }
       it { should_not allow_value(-1).for(:salary) }
-      it { should_not allow_value(12.4).for(:salary) }
+      it { should allow_value(12.4).for(:salary) }
     end
 
     context 'salary_frequency' do


### PR DESCRIPTION
This pr addresses a bug on [TP user story 8426](https://moneyadviceservice.tpondemand.com/restui/board.aspx?acid=ddd7f3a626844ab8d1bee3f06ec28efa#page=board/5624876525867731357&appConfig=eyJhY2lkIjoiREI4ODcwRjkxMDNDRTM2NTlBMzhDNTRBRTVBNUU1N0UifQ==&boardPopup=userstory/8426/silent).

### Objective
* Move the tax relief warning message to be positioned above the results table.
* Fix calculations for weekly salaries.

### Technical
The YourDetails form was validating the salary to be an integer, which was preventing the form being submitted if a float was entered. The validation was changed to check for positive numbers only.