### PR TITLE
[WIP] 8473 - Radio button for part salary is checked by default

### DIFF
--- a/app/views/wpcc/your_details/new.html.erb
+++ b/app/views/wpcc/your_details/new.html.erb
@@ -134,7 +134,7 @@
                 </div>
               </div>
               <div class="form__group-item details__calculate-item">
-                <%= f.radio_button(:contribution_preference, 'minimum', disabled: @your_details_form.disabled_class, class: 'details__calculate-item-select', 'data-dough-employer-part-radio': true) %>
+                <%= f.radio_button(:contribution_preference, 'minimum', disabled: @your_details_form.disabled_class, class: 'details__calculate-item-select', 'data-dough-employer-part-radio': true, checked: true) %>
                 <%= f.label(:contribution_preference_minimum, t('wpcc.details.options.contribution_preference.minimum'), class: 'details__calculate-item-label') %>
               </div>
               <div class="form__group-item details__calculate-item">

--- a/features/_your_details/your_details_check_min_contribution_by_default.feature
+++ b/features/_your_details/your_details_check_min_contribution_by_default.feature
@@ -1,0 +1,14 @@
+Feature: Radio button for part salary is checked by default
+  As a Workplace Pension Contribution Calculator user
+  I need the selections to default to the scenario most likely to apply to me
+  So that I can get my information without having to look things up
+
+  Scenario Outline: Default contribution preference
+    Given I am on the Your Details step in my "<language>"
+    Then I should see that the minimum contribution option should be selected by default
+    And I should see that the full contribution option should not be selected
+
+    Examples:
+      | language |
+      | English  |
+      | Welsh    |

--- a/features/step_definitions/your_details_steps.rb
+++ b/features/step_definitions/your_details_steps.rb
@@ -2,6 +2,12 @@ Given(/^I am on the Your Details step$/) do
   your_details_page.load(locale: :en)
 end
 
+Given(/^I am on the Your Details step in my "([^"]*)"$/) do |language|
+  locale = language_to_locale(language)
+
+  your_details_page.load(locale: locale)
+end
+
 When(/^I fill in my details$/) do
   your_details_page.age.set(35)
   your_details_page.genders.select('Female')
@@ -168,4 +174,12 @@ Then(/^the employer_percent input intro paragraph should display the correct per
   within('.contributions__source--employer') do
     expect(your_contributions_page).to have_content('The legal minimum is 1%')
   end
+end
+
+Then(/^I should see that the minimum contribution option should be selected by default$/) do
+  expect(your_details_page.minimum_contribution_button).to be_checked
+end
+
+Then(/^I should see that the full contribution option should not be selected$/) do
+  expect(your_details_page.full_contribution_button).not_to be_checked
 end


### PR DESCRIPTION
#User Story:
As a lazy and ignorant user I need the selections to default to the scenario most likely to apply to me so that I can get my information without having to look things up.
 
Acceptance criteria:
Given I am on Step 1
Then the 'part salary' radio-box should be selected by default.

TP [Ticket](https://moneyadviceservice.tpondemand.com/entity/8473)

## Solution
`checked: true`

<img width="761" alt="screen shot 2017-08-07 at 11 35 20" src="https://user-images.githubusercontent.com/2187295/29023202-9a3dcd28-7b64-11e7-88f4-965f9e53bafc.png">
