### PR TITLE
Updates markup for updated tooltip dough component

### DIFF
--- a/app/views/wpcc/your_details/new.html.erb
+++ b/app/views/wpcc/your_details/new.html.erb
@@ -31,8 +31,10 @@
             %>
           </div>
         </div>
-        <div data-dough-popup-content class="popup-tip__content details__helper">
-          <p><%= t('wpcc.details.age.tooltip') %></p>
+        <div data-dough-popup-container class="popup-tip__container details__helper">
+          <p data-dough-popup-content class="popup-tip__content">
+            <%= t('wpcc.details.age.tooltip') %>
+          </p>
           <%= render 'wpcc/shared/popup_tip_close' %>
         </div>
       </div>
@@ -55,8 +57,8 @@
             %>
           </div>
         </div>
-        <div data-dough-popup-content class="popup-tip__content details__helper">
-          <p><%= t('wpcc.details.gender.tooltip') %></p>
+        <div data-dough-popup-container class="popup-tip__container details__helper">
+          <p data-dough-popup-content class="popup-tip__content"><%= t('wpcc.details.gender.tooltip') %></p>
           <%= render 'wpcc/shared/popup_tip_close' %>
         </div>
       </div>
@@ -102,11 +104,11 @@
                 
                 <%= f.select(:salary_frequency, options_for_select(@your_details_form.salary_frequency_options, @salary_frequency), {}, {'data-dough-frequency-select': true}) %>
               </div>
-              <div data-dough-popup-content class="popup-tip__content details__helper">
-                <p><%= t('wpcc.details.salary.tooltip') %></p>
-                <%= render 'wpcc/shared/popup_tip_close' %>
-              </div>
             </div>
+          </div>
+          <div data-dough-popup-container class="popup-tip__container details__helper">
+            <p data-dough-popup-content class="popup-tip__content"><%= t('wpcc.details.salary.tooltip') %></p>
+            <%= render 'wpcc/shared/popup_tip_close' %>
           </div>
           <div class="details__callouts">
             <div class="form__row details__callout details__callout--inactive" data-dough-callout-lt5876>


### PR DESCRIPTION
## Updates Markup for the updated tooltip dough component

A recent update has been made to the tooltip component in dough, as a result the markup to use the component has been changed.

This PR updates the markup for the tooltips in the your details section.

The original dough PR is [here](https://github.com/moneyadviceservice/dough/pull/288)

Please note that the version of dough in frontend will need to be bumped, this will be done as soon as this PR is merged.