### PR TITLE
Bump version from 1.4.0 to 1.5.0

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,22 @@
+## 1.5.0
+
+* TP-8447: Calculate yearly contributions results by monthly salary equivalent
+* TP-8473: Set minimum contribution as default
+* TP-8407: Limit tax relief when yearly contributions above £40,000.
+* TP-8469: Step 1 enhancements
+* TP-8214: Print results feature
+* TP-8426: Amendments to tax relief warning
+* TP-8449: Add eligible salary contribution conditional message
+* TP-8445: Refactor cucumber steps
+* TP-8427: Opt in message for users earning between 5876 and 10,000 inclusive
+* TP-8426: Display warning message when salary is below £11,500
+* TP-8302: Display same results for contributions above the legal minimum
+* TP-8406: Add a frequency selector on last step
+* TP-8438: Client side validation for step 2
+* Updating Dough
+* Add git pre-push hook
+* Add logger message to period contribution calculator
+
 ## 1.4.0
 
 * TP-8284: Add Test for full pay contribution scenario

--- a/lib/wpcc/version.rb
+++ b/lib/wpcc/version.rb
@@ -1,7 +1,7 @@
 module Wpcc
   module Version
     MAJOR = 1
-    MINOR = 4
+    MINOR = 5
     PATCH = 0
 
     STRING = [MAJOR, MINOR, PATCH].join('.')


### PR DESCRIPTION
In order to deploy the wpcc to a secret url in production I think now we need to return to do the bump versions, since the tool is going to production.

This PR addresses the latest master version.

But please do not merge this PR until #94 is merged to master (but it is free to review)