### PR TITLE
[DEV APPROVED] Fix "translation missing" errors

### DIFF
--- a/app/views/wpcc/tooltips/_close.html.erb
+++ b/app/views/wpcc/tooltips/_close.html.erb
@@ -5,6 +5,6 @@
     </svg>
   </span>
   <span class="visually-hidden">
-    <%= t('wpcc.details.tooltip_hide') %>
+    <%= t('wpcc.tooltip_hide') %>
   </span>
 </button>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -96,7 +96,7 @@ cy:
         WELSH: Minimum pension contribution rates will increase in stages until April 2019.
         These figures show how this will affect your contributions. Contributions will be
         based on your eligible salary of £%{eligible_salary} per year.
-      period_titles:
+      period_title:
         april_2017_march_2018: 'Welsh for Today - March 2018'
         april_2018_march_2019: 'Welsh for April 2018 - March 2019'
         after_april_2019: 'Welsh for April 2019 onwards'

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -62,6 +62,9 @@ module Dummy
     config.assets.paths << Rails.root.join('..', '..', 'vendor', 'assets', 'bower_components')
 
     config.time_zone = 'London'
+
+    # Missing translations should raise exceptions
+    config.action_view.raise_on_missing_translations = true
   end
 end
 


### PR DESCRIPTION
## Context

I was developing the user story of deploying the secret url to production ([here](https://moneyadviceservice.tpondemand.com/entity/8460)) and my tests were not passing due to missing translations keys.

## Solution

1) make the tests catch those translation errors, from now on.

## Fixes

1) Fix the error ` translation missing for: cy.wpcc.results.period_title.april_2017_march_2018`
2) Fix the error `translation missing: cy.wpcc.details.tooltip_hide`