### PR TITLE
8459 Select 'full salary' contribution preference

### DIFF
--- a/app/models/wpcc/your_details_form.rb
+++ b/app/models/wpcc/your_details_form.rb
@@ -16,5 +16,21 @@ module Wpcc
     validates :salary_frequency, inclusion: { in: SALARY_FREQUENCIES }
     validates :contribution_preference, inclusion: { in: CONTRIBUTIONS }
     validates_with Wpcc::SalaryThresholdValidator
+
+    def contribution_preference
+      return 'full' if minimum_contribution? && contribution_errors?
+
+      @contribution_preference.blank? ? 'minimum' : @contribution_preference
+    end
+
+    private
+
+    def minimum_contribution?
+      @contribution_preference == 'minimum'
+    end
+
+    def contribution_errors?
+      errors.key?(:contribution_preference)
+    end
   end
 end

--- a/app/views/wpcc/your_details/new.html.erb
+++ b/app/views/wpcc/your_details/new.html.erb
@@ -127,7 +127,7 @@
                 </div>
               </div>
               <div class="form__group-item details__calculate-item">
-                <%= f.radio_button(:contribution_preference, 'minimum', disabled: @your_details_form.disabled_class, class: 'details__calculate-item-select', 'data-dough-employer-part-radio': true, checked: true) %>
+                <%= f.radio_button(:contribution_preference, 'minimum', class: 'details__calculate-item-select', 'data-dough-employer-part-radio': true) %>
                 <%= f.label(:contribution_preference_minimum, t('wpcc.details.options.contribution_preference.minimum'), class: 'details__calculate-item-label') %>
               </div>
               <div class="form__group-item details__calculate-item">

--- a/features/_your_details/your_details_disabling_minimum_contributions.feature
+++ b/features/_your_details/your_details_disabling_minimum_contributions.feature
@@ -6,12 +6,12 @@ Feature: Your Details disabling minimum contribution
   @no-javascript
   Scenario Outline: Annual salary rate below £5,876 with minimum employer contributions
     Given I am on the Your Details step
-    When I enter my details
+    And I enter my details
     And I enter a "<salary>" below the minimum threshold
     And I select a valid "<salary_frequency>"
     And I choose to make minimum contributions
-    And I submit my details
-    Then I should not be able to choose to make minimum employer contributions
+    When I submit my details
+    And I should see that the full contribution option should be selected
 
     Examples:
       | salary | salary_frequency |

--- a/features/step_definitions/your_details_steps.rb
+++ b/features/step_definitions/your_details_steps.rb
@@ -126,10 +126,6 @@ Then(/^I should see "([^"]*)" summarised$/) do |my_details|
   expect(page).to have_content(my_details)
 end
 
-Then(/^I should not be able to choose to make minimum employer contributions$/) do
-  expect(your_details_page.minimum_contribution_button).to be_disabled
-end
-
 Then(/^the Your Contributions step should tell me my qualifying earnings$/) do
   expect(your_contributions_page.contributions_description).to have_content('£29,124')
 end
@@ -170,6 +166,10 @@ Then(/^I should see that the minimum contribution option should be selected by d
   expect(your_details_page.minimum_contribution_button).to be_checked
 end
 
-Then(/^I should see that the full contribution option should not be selected$/) do
-  expect(your_details_page.full_contribution_button).not_to be_checked
+Then(/^I should see that the full contribution option should( not| NOT)? be selected$/) do |should_not|
+  if should_not
+    expect(your_details_page.full_contribution_button).not_to be_checked
+  else
+    expect(your_details_page.full_contribution_button).to be_checked
+  end
 end

--- a/spec/models/your_details_form_spec.rb
+++ b/spec/models/your_details_form_spec.rb
@@ -95,4 +95,44 @@ describe Wpcc::YourDetailsForm, type: :model do
       end
     end
   end
+
+  describe 'contribution_preference' do
+    context 'no contribution' do
+      let(:contribution_preference) { nil }
+
+      it 'returns minimum' do
+        expect(subject.contribution_preference).to eq('minimum')
+      end
+    end
+
+    context 'when the form is valid' do
+      context 'full contribution' do
+        let(:contribution_preference) { 'full' }
+
+        it 'returns full' do
+          expect(subject.contribution_preference).to eq('full')
+        end
+      end
+
+      context 'full contribution' do
+        let(:contribution_preference) { 'minimum' }
+
+        it 'returns minimum' do
+          expect(subject.contribution_preference).to eq('minimum')
+        end
+      end
+    end
+
+    context 'for salary below the minimum threshold' do
+      context 'minimum contribution' do
+        let(:salary) { 5_000 }
+        let(:contribution_preference) { 'minimum' }
+
+        it 'returns full' do
+          subject.valid?
+          expect(subject.contribution_preference).to eq('full')
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
This pr addresses [Tp User Store 8459](https://moneyadviceservice.tpondemand.com/restui/board.aspx?acid=ddd7f3a626844ab8d1bee3f06ec28efa#page=board/5624876525867731357&appConfig=eyJhY2lkIjoiREI4ODcwRjkxMDNDRTM2NTlBMzhDNTRBRTVBNUU1N0UifQ==&boardPopup=userstory/8459/silent).
### Objective
**This is for users without access to javascript**
* On first visiting the form, the minimum contribution_preference radio button is pre-checked.
* If the user has entered a salary below the minimum threshold and has selected the minimum contribution_preference radio button, on submission of the form, he will be returned to the form and the full contribution preference radio button will be checked.
* The minimum contribution_preference radio button will NOT be disabled as doing so would result in a poor experience for the user e.g. if he were to amend the salary to above the minimum threshold, he would not be able to check the minimum contribution_preference radio button even though it should now be a viable option.