### PR TITLE
[DEV APPROVED] 8477 - Display the salary below threshold callout message

### DIFF
--- a/app/presenters/wpcc/your_details_form_presenter.rb
+++ b/app/presenters/wpcc/your_details_form_presenter.rb
@@ -6,8 +6,16 @@ module Wpcc
       end
     end
 
-    def disabled_class
-      disable_minimum_contribution_option? ? 'disabled' : nil
+    def error_class(attribute)
+      object.errors[attribute].any? ? 'form__row--is-errored' : nil
+    end
+
+    def activate_disabled_callout
+      if disable_minimum_contribution_option?
+        'details__callout--active'
+      else
+        'details__callout--inactive'
+      end
     end
 
     private

--- a/app/views/wpcc/your_details/new.html.erb
+++ b/app/views/wpcc/your_details/new.html.erb
@@ -7,11 +7,7 @@
       'data-dough-validation-config': '{"showValidationSummary": false}',
       'novalidate': true
     }) do |f| %>
-    <% if @your_details_form.errors.any? %>
-      <% @your_details_form.errors.full_messages.each do |msg| %>
-        <p><%= msg %></p>
-      <% end %>
-    <% end %>
+    
     <h2 class="section__heading details__heading">1. <%= t('wpcc.details.title') %></h2>
     <div class="details__content">
       <div class="details__row" data-dough-component="PopupTip">
@@ -120,13 +116,13 @@
               <legend class="details__calculate-heading"><%= t('wpcc.details.calculate.legend') %></legend>
               <p class="details__calculate-intro"><%= t('wpcc.details.calculate.details') %></p>
               <div class="details__callouts">
-                <div class="form__row details__callout details__callout--inactive" data-dough-callout-radio-disabled>
+                <div class="form__row details__callout <%= @your_details_form.activate_disabled_callout %>" data-dough-callout-radio-disabled>
                   <div class="callout">
                     <p><%= t('wpcc.details.callout__radiodisabled') %></p>
                   </div>
                 </div>
               </div>
-              <div class="form__group-item details__calculate-item">
+              <div class="form__group-item details__calculate-item <%= @your_details_form.error_class('contribution_preference') %>">
                 <%= f.radio_button(:contribution_preference, 'minimum', class: 'details__calculate-item-select', 'data-dough-employer-part-radio': true) %>
                 <%= f.label(:contribution_preference_minimum, t('wpcc.details.options.contribution_preference.minimum'), class: 'details__calculate-item-label') %>
               </div>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -44,7 +44,6 @@ cy:
         legend: Dewiswch sut mae eich cyflogwr yn cyfrannu
         details: Mae eich cyflogwr yn penderfynu un ai i gyfrannu ar ran o’r cyflog neu’ch cyflog yn llawn. I gael gwybod pa un, bydd angen i chi wirio gyda’ch cyflogwr.
 
-
       next: Next
       prompt: os gwelwch yn dda dewiswch
 
@@ -52,7 +51,7 @@ cy:
       callout__optIn: Ni fydd eich cyflogwr yn eich cofrestru yn awtomatig am bensiwn, ond gallwch ddewis ymuno. Os felly, bydd eich cyflogwr yn gwneud cyfraniadau.
       callout__gt74: Nid ydych yn gymwys i ymuno â phensiwn gweithle gan eich bod yn hŷn na’r uchafswm oed.
       callout__lt5876: Ni fydd eich cyflogwr yn eich cofrestru yn awtomatig am gynllun pensiwn gweithle, ond gallwch ddewis ymuno. Os felly, ni fydd yn ofynnol i'ch cyflogwr wneud cyfraniadau.
-      callout__radiodisabled: Mae eich lefel enillion yn is na'r lefel isafswm cyfrannu felly bydd rhaid i chi wneud cyfraniadau yn seiliedig ar eich cyflog llawn
+      callout__radiodisabled: Ar eich lefel enillion, bydd rhaid i chi wneud cyfraniadau yn seiliedig ar eich cyflog llawn
       callout__gt5876_lt10000: Ni fydd eich cyflogwr yn eich cofrestru yn awtomatig am gynllun pensiwn gweithle, ond gallwch ddewis ymuno. Os felly, bydd eich cyflogwr yn gwneud cyfraniadau.
 
       section__heading:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -51,7 +51,7 @@ en:
       callout__optIn: Your employer will not automatically enrol you into a pension but you can choose to join. If you do so, your employer will make contributions.
       callout__gt74: You are not eligible to join a workplace pension because you are above the maximum age.
       callout__lt5876: Your employer will not automatically enrol you into a workplace pension scheme but you can choose to join. If you do so, your employer will not be obliged to make contributions.
-      callout__radiodisabled: Your earnings level is below the minimum contribution level so you will have to make contributions based on your full salary
+      callout__radiodisabled: At your earnings level, you will have to make contributions based on your full salary
       callout__gt5876_lt10000: Your employer will not automatically enroll you into a workplace pension scheme but you can choose to join. If you do so, your employer will make contributions.
 
       section__heading:

--- a/features/_your_details/your_details_disabling_minimum_contributions.feature
+++ b/features/_your_details/your_details_disabling_minimum_contributions.feature
@@ -11,14 +11,15 @@ Feature: Your Details disabling minimum contribution
     And I select a valid "<salary_frequency>"
     And I choose to make minimum contributions
     When I submit my details
-    And I should see that the full contribution option should be selected
+    Then I should see that the full contribution option should be selected
+    And I should see the salary below threshold "<callout_message>" 
 
     Examples:
-      | salary | salary_frequency |
-      | 5000   | per Year         |
-      | 450    | per 4 weeks      |
-      | 480    | per Month        |
-      | 70     | per Week         |
+      | salary | salary_frequency | callout_message                                                                       |
+      | 5000   | per Year         | At your earnings level, you will have to make contributions based on your full salary |
+      | 450    | per 4 weeks      | At your earnings level, you will have to make contributions based on your full salary |
+      | 480    | per Month        | At your earnings level, you will have to make contributions based on your full salary |
+      | 70     | per Week         | At your earnings level, you will have to make contributions based on your full salary |
 
   @no-javascript
   Scenario: Annual salary rate below £5,876 with full employer contributions

--- a/features/step_definitions/your_details_steps.rb
+++ b/features/step_definitions/your_details_steps.rb
@@ -173,3 +173,7 @@ Then(/^I should see that the full contribution option should( not| NOT)? be sele
     expect(your_details_page.full_contribution_button).to be_checked
   end
 end
+
+Then(/^I should see the salary below threshold "([^"]*)"$/) do |callout_message|
+  expect(your_details_page.salary_below_threshold_callout).to have_content(callout_message)
+end

--- a/features/support/ui/your_details.rb
+++ b/features/support/ui/your_details.rb
@@ -12,6 +12,8 @@ module UI
     element :minimum_contribution_button, '#your_details_form_contribution_preference_minimum'
     element :full_contribution_button, '#your_details_form_contribution_preference_full'
 
+    element :salary_below_threshold_callout, '[data-dough-callout-radio-disabled]'
+
     element :next_button, "input[type='submit']"
   end
 end

--- a/spec/presenters/your_details_form_presenter_spec.rb
+++ b/spec/presenters/your_details_form_presenter_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Wpcc::YourDetailsFormPresenter do
     end
   end
 
-  describe '#disabled_class' do
+  describe '#activate_disabled_callout' do
     context 'salary lower than threshold' do
       let(:age) { 35 }
       let(:gender) { 'female' }
@@ -34,19 +34,21 @@ RSpec.describe Wpcc::YourDetailsFormPresenter do
         your_details_form.valid?
       end
 
-      context 'make minimum contribution' do
+      context 'when minimum contribution is selected' do
         let(:pref) { 'minimum' }
 
-        it 'disabled minimum contribution option' do
-          expect(subject.disabled_class).to eq('disabled')
+        it 'returns an active class name' do
+          class_name = 'details__callout--active'
+          expect(subject.activate_disabled_callout).to eq(class_name)
         end
       end
 
-      context 'make minimum contribution' do
+      context 'when full contribution is selected' do
         let(:pref) { 'full' }
 
-        it 'disabled minimum contribution option' do
-          expect(subject.disabled_class).to be_nil
+        it 'returns an inactive class name' do
+          class_name = 'details__callout--inactive'
+          expect(subject.activate_disabled_callout).to eq(class_name)
         end
       end
     end


### PR DESCRIPTION
This pr addresses [TP User story 8477](https://moneyadviceservice.tpondemand.com/restui/board.aspx?acid=ddd7f3a626844ab8d1bee3f06ec28efa#page=board/5624876525867731357&appConfig=eyJhY2lkIjoiREI4ODcwRjkxMDNDRTM2NTlBMzhDNTRBRTVBNUU1N0UifQ==&boardPopup=userstory/8477/silent). The requirements of this story changed during the course of completing it, please be sure to read the comments on the card.

### Objective
A user should not be allowed to enter a  a salary below the minimum threshold AND select the minimum contribution option. The UI needs to communicate why he will be not allowed to proceed to Step 2 if he enters that combination.

### Technical
Since all the callout messages are already present in the markup though hidden from view:
* a presenter method is used to change the class of the callout message to active
* use existing dough class to style the minimum contribution radio option in red