### PR TITLE
[DEV APPROVED] 8472 - Conditional messaging step 2

### DIFF
--- a/app/presenters/wpcc/presenter.rb
+++ b/app/presenters/wpcc/presenter.rb
@@ -1,6 +1,6 @@
 module Wpcc
   class Presenter < SimpleDelegator
-    delegate :t, :number_to_currency, to: :view_context
+    delegate :t, :number_to_currency, :session, to: :view_context
 
     attr_reader :object, :view_context
 

--- a/app/presenters/wpcc/your_contribution_presenter.rb
+++ b/app/presenters/wpcc/your_contribution_presenter.rb
@@ -1,7 +1,12 @@
 module Wpcc
   class YourContributionPresenter < Presenter
     def formatted_eligible_salary
-      formatted_currency(object.eligible_salary)
+      formatted_currency(object.eligible_salary, precision: 0)
+    end
+
+    def earnings_description
+      t("wpcc.contributions.description_#{session[:contribution_preference]}",
+        eligible_salary: formatted_eligible_salary)
     end
 
     def upper_earnings_threshold

--- a/app/views/wpcc/your_contributions/new.html.erb
+++ b/app/views/wpcc/your_contributions/new.html.erb
@@ -4,16 +4,7 @@
   <h2 class="wpcc__heading">2. <%= t('wpcc.contributions.title') %></h2>
   <div class="contributions__row">
     <p class="t-contributions_description">
-      <% if session[:contribution_preference] == 'minimum' %>
-          <%= t('wpcc.contributions.description_minimum', 
-            eligible_salary: @your_contribution.formatted_eligible_salary,
-          ) %>
-      <% end %>
-      <% if session[:contribution_preference] == 'full' %>
-          <%= t('wpcc.contributions.description_full', 
-            eligible_salary: @your_contribution.formatted_eligible_salary,
-          ) %>
-      <% end %>
+      <%= @your_contribution.earnings_description %>
     </p>
   </div>
   <%= form_for(
@@ -41,7 +32,7 @@
           %>
           <%= t('wpcc.contributions.input_of_label') %>
           <span>
-            £<span data-dough-contribution-salary><%= @your_contribution.eligible_salary %></span>
+            <span data-dough-contribution-salary><%= @your_contribution.formatted_eligible_salary %></span>
           </span>
         </div>
         <div class="contributions__source contributions__source--employer form__row">
@@ -57,7 +48,7 @@
             'data-dough-validation-invalid': t('wpcc.contributions.employee_validation.out_of_range')
           %>
           <%= t('wpcc.contributions.input_of_label') %>
-          <span>£<%= @your_contribution.eligible_salary %></span>
+          <span><%= @your_contribution.formatted_eligible_salary %></span>
         </div>
       </div>
       <div class="contributions__row">

--- a/app/views/wpcc/your_contributions/new.html.erb
+++ b/app/views/wpcc/your_contributions/new.html.erb
@@ -4,18 +4,20 @@
   <h2 class="wpcc__heading">2. <%= t('wpcc.contributions.title') %></h2>
   <div class="contributions__row">
     <p class="t-contributions_description">
-      <%= t('wpcc.contributions.description', 
-        eligible_salary: @your_contribution.formatted_eligible_salary,
-        lower_earnings_threshold: @your_contribution.lower_earnings_threshold
-      ) %>
-    </p>
-    <p>
-      <p>
-        <%= t('wpcc.contributions.description_tooltip',
-          upper_earnings_threshold: @your_contribution.upper_earnings_threshold,
-          lower_earnings_threshold: @your_contribution.lower_earnings_threshold
-        ) %>
-      </p>
+      <% if session[:contribution_preference] == 'minimum' %>
+        <p>
+          <%= t('wpcc.contributions.description_minimum', 
+            eligible_salary: @your_contribution.formatted_eligible_salary,
+          ) %>
+        </p>
+      <% end %>
+      <% if session[:contribution_preference] == 'full' %>
+        <p>
+          <%= t('wpcc.contributions.description_full', 
+            eligible_salary: @your_contribution.formatted_eligible_salary,
+          ) %>
+        </p>
+      <% end %>
     </p>
   </div>
   <%= form_for(

--- a/app/views/wpcc/your_contributions/new.html.erb
+++ b/app/views/wpcc/your_contributions/new.html.erb
@@ -5,18 +5,14 @@
   <div class="contributions__row">
     <p class="t-contributions_description">
       <% if session[:contribution_preference] == 'minimum' %>
-        <p>
           <%= t('wpcc.contributions.description_minimum', 
             eligible_salary: @your_contribution.formatted_eligible_salary,
           ) %>
-        </p>
       <% end %>
       <% if session[:contribution_preference] == 'full' %>
-        <p>
           <%= t('wpcc.contributions.description_full', 
             eligible_salary: @your_contribution.formatted_eligible_salary,
           ) %>
-        </p>
       <% end %>
     </p>
   </div>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -70,8 +70,8 @@ cy:
 
     contributions:
       title: Eich cyfraniadaulower
-      description: Gwneir cyfraniadau ar eich cyflog cymwys o %{eligible_salary} y flwyddyn. Dyma eich cyflog meinws y trothwy Yswiriant Gwladol o %{lower_earnings_threshold}.
-      description_tooltip: Dyma’r rhan o’ch cyflog blynyddol a ddefnyddir i gyfrifo’ch cyfraniad pensiwn dan gofrestru awtomatig. Sef eich enillion cyn treth (hyd at derfyn uchafswm o %{upper_earnings_threshold} y flwyddyn) – meinws trothwy enillion isaf o %{lower_earnings_threshold}.
+      description_minimum: Gwneir cyfraniadau ar eich enillion cymwys o %{eligible_salary} y flwyddyn.
+      description_full: Gwneir cyfraniadau ar eich cyflog o %{eligible_salary} y flwyddyn.
       your_contribution_title: Nodwch eich cyfraniad
       your_contribution_tip: Yr isafswm cyfreithiol yw 1%
       your_contribution_tip_lt5876: Ar eich lefel cyflog, nid oes isafswm cyfreithiol o gyfraniad ond efallai y bydd eich cynllun pensiwn gweithlu wedi gosod isafswm. Holwch eich cyflogwr.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -70,8 +70,8 @@ en:
 
     contributions:
       title: Your contributions
-      description: Contributions will be made on your eligible salary of %{eligible_salary} per year. This is your salary minus the National Insurance threshold of %{lower_earnings_threshold}.
-      description_tooltip: This is the part of your annual pay that will be used to calculate your pension contribution under automatic enrolment. It is your earnings before tax (up to a maximum limit of %{upper_earnings_threshold} per year) – less the lower earnings threshold of %{lower_earnings_threshold}.
+      description_minimum:  Contributions will be made on your qualifying earnings of %{eligible_salary} per year.
+      description_full:  Contributions will be made on your salary of %{eligible_salary} per year.
       your_contribution_title: Enter your contribution
       your_contribution_tip: The legal minimum is 1%
       your_contribution_tip_lt5876: At your salary level there is no legal minimum contribution but your workplace pension scheme may have a set minimum. Check with your employer.

--- a/spec/presenters/your_contribution_presenter_spec.rb
+++ b/spec/presenters/your_contribution_presenter_spec.rb
@@ -29,58 +29,24 @@ RSpec.describe Wpcc::YourContributionPresenter do
     end
   end
 
-  describe '#description_minimum' do
-    it 'returns the qualifying earnings message' do
-      # rubocop:disable LineLength
-      qualifying_earnings = 'Contributions will be made on your qualifying earnings of £19,124 per year.'
-      # rubocop:enable LineLength
-      expect(subject.description_minimum).to eq qualifying_earnings
-    end
-  end
-
-  describe '#description_full' do
-    it 'returns the qualifying earnings message' do
-      qualifying_earnings =
-        'Contributions will be made on your salary of £19,124 per year.'
-      expect(subject.description_full).to eq qualifying_earnings
-    end
-  end
-
-  describe '#contribution_preference?' do
-    it 'returns true if contribution_preference value is set in session' do
-      expect(subject.contribution_preference?).to be_truthy
-    end
-  end
-
-  describe '#contribution_minimum?' do
-    it 'returns true if contribution_minimum value is set in session' do
-      expect(subject.contribution_minimum?).to be_truthy
-    end
-  end
-
-  describe '#contribution_full?' do
-    let(:session) { { contribution_preference: 'full' } }
-    it 'returns true if contribution_full value is set in session' do
-      expect(subject.contribution_full?).to be_truthy
-    end
-  end
-
   describe '#earnings_description' do
     context 'full salary' do
       let(:session) { { contribution_preference: 'full' } }
       it 'should return full salary description' do
-        expect(subject).to receive(:description_full)
-
-        subject.earnings_description
+        qualifying_earnings =
+          'Contributions will be made on your salary of £19,124 per year.'
+        expect(subject.earnings_description).to eq qualifying_earnings
       end
     end
 
     context 'qualifying earnings' do
       let(:session) { { contribution_preference: 'minimum' } }
       it 'should return qualifying earnings description' do
-        expect(subject).to receive(:description_minimum)
-
-        subject.earnings_description
+        # rubocop:disable LineLength
+        qualifying_earnings =
+          'Contributions will be made on your qualifying earnings of £19,124 per year.'
+        # rubocop:enable LineLength
+        expect(subject.earnings_description).to eq qualifying_earnings
       end
     end
   end

--- a/spec/presenters/your_contribution_presenter_spec.rb
+++ b/spec/presenters/your_contribution_presenter_spec.rb
@@ -5,10 +5,15 @@ RSpec.describe Wpcc::YourContributionPresenter do
 
   let(:object) { double(Wpcc::ContributionCalculator, eligible_salary: 19_124) }
   let(:context) { ActionController::Base.new.view_context }
+  let(:session) { { contribution_preference: 'minimum' } }
+
+  before do
+    allow(context).to receive(:session).and_return(session)
+  end
 
   describe '#formatted_eligible_salary' do
     it 'formats a number to a currency with 2 decimal places' do
-      expect(subject.formatted_eligible_salary).to eq('£19,124.00')
+      expect(subject.formatted_eligible_salary).to eq('£19,124')
     end
   end
 
@@ -21,6 +26,62 @@ RSpec.describe Wpcc::YourContributionPresenter do
   describe '#lower_earnings_threshold' do
     it 'gets the lower earnings threshold and formats it' do
       expect(subject.lower_earnings_threshold).to eq('£5,876')
+    end
+  end
+
+  describe '#description_minimum' do
+    it 'returns the qualifying earnings message' do
+      # rubocop:disable LineLength
+      qualifying_earnings = 'Contributions will be made on your qualifying earnings of £19,124 per year.'
+      # rubocop:enable LineLength
+      expect(subject.description_minimum).to eq qualifying_earnings
+    end
+  end
+
+  describe '#description_full' do
+    it 'returns the qualifying earnings message' do
+      qualifying_earnings =
+        'Contributions will be made on your salary of £19,124 per year.'
+      expect(subject.description_full).to eq qualifying_earnings
+    end
+  end
+
+  describe '#contribution_preference?' do
+    it 'returns true if contribution_preference value is set in session' do
+      expect(subject.contribution_preference?).to be_truthy
+    end
+  end
+
+  describe '#contribution_minimum?' do
+    it 'returns true if contribution_minimum value is set in session' do
+      expect(subject.contribution_minimum?).to be_truthy
+    end
+  end
+
+  describe '#contribution_full?' do
+    let(:session) { { contribution_preference: 'full' } }
+    it 'returns true if contribution_full value is set in session' do
+      expect(subject.contribution_full?).to be_truthy
+    end
+  end
+
+  describe '#earnings_description' do
+    context 'full salary' do
+      let(:session) { { contribution_preference: 'full' } }
+      it 'should return full salary description' do
+        expect(subject).to receive(:description_full)
+
+        subject.earnings_description
+      end
+    end
+
+    context 'qualifying earnings' do
+      let(:session) { { contribution_preference: 'minimum' } }
+      it 'should return qualifying earnings description' do
+        expect(subject).to receive(:description_minimum)
+
+        subject.earnings_description
+      end
     end
   end
 end


### PR DESCRIPTION
Because part salary uses the concept of 'qualifying earnings', the text that displays for users who selected 'full salary' is somewhat misleading because contributions are then based on salary - not qualifying earnings.
 
As such we need this intro text to be conditional.

TP [Ticket](https://moneyadviceservice.tpondemand.com/entity/8472)

## Solution:

Use session data to determine the selected `contribution_preference` from step 1.
Display a message depending on the selection.
Hide logic from view using presenters.
Write cucumber tests. <--- @thecountgs _tests were written in RSpec in the end rather than in Cuke_

![screen shot 2017-08-16 at 17 38 42](https://user-images.githubusercontent.com/2187295/29374601-ebdd01ac-82a9-11e7-8fdb-c12f34f40497.png)
![screen shot 2017-08-16 at 17 38 59](https://user-images.githubusercontent.com/2187295/29374602-ebe2a8b4-82a9-11e7-8eb7-6818ca2d68ae.png)

