### PR TITLE
[DEV APROVED] TP: 8505, Comment: Fixes bug on Step 1 re salary/contributions inputs

### DIFF
--- a/app/assets/javascripts/wpcc/components/SalaryConditions.js
+++ b/app/assets/javascripts/wpcc/components/SalaryConditions.js
@@ -15,6 +15,7 @@ define(['jquery', 'DoughBaseComponent'], function($, DoughBaseComponent) {
     this.$radioDisabled = this.$el.find('[data-dough-callout-radio-disabled]');
     this.$employerPartRadio = this.$el.find('[data-dough-employer-part-radio]');
     this.$employerFullRadio = this.$el.find('[data-dough-employer-full-radio]');
+    this.contribution = 'full';
 
     // Step 2 - Contributions
     this.$employeeTip = this.$el.find('[data-dough-employee-tip]');
@@ -22,7 +23,6 @@ define(['jquery', 'DoughBaseComponent'], function($, DoughBaseComponent) {
     this.$employerTip = this.$el.find('[data-dough-employer-tip]');
     this.$employeeContributions = this.$el.find('[data-dough-employee-contributions]');
     this.$employerContributions = this.$el.find('[data-dough-employer-contributions]');
-
   };
 
   DoughBaseComponent.extend(SalaryConditions);
@@ -53,8 +53,26 @@ define(['jquery', 'DoughBaseComponent'], function($, DoughBaseComponent) {
 
     this.$salaryFrequency.change(function() {
       $this._calculateAnnual();
-    })
+    });
 
+    this._checkContributionState();
+  }
+
+  // Store value of contribution selector (full/part)
+  SalaryConditions.prototype._checkContributionState = function() {
+    // update contribution state on page load
+    if (this.$el.find('input[name="your_details_form[contribution_preference]"]:checked').val() == 'part') {
+      this.contribution = 'part';
+    }
+
+    // update contribution state when selectors changed
+    this.$el.find('input[name="your_details_form[contribution_preference]"]').on('change', function(e) {
+      if (e.target.value == 'full') {
+        this.contribution = 'full';
+      } else {
+        this.contribution = 'part';
+      }
+    });
   }
 
   // Function to calculate the annual salary based on different frequencies
@@ -74,10 +92,9 @@ define(['jquery', 'DoughBaseComponent'], function($, DoughBaseComponent) {
     } else if (frequency == 'year') {
       annualSalary = salary;
     };
-    
+
     // Pass the value of annual salary to display message function
     $this._displayMessage(annualSalary);
-
   };
 
   // Result of annual salary function passed to this function
@@ -107,7 +124,6 @@ define(['jquery', 'DoughBaseComponent'], function($, DoughBaseComponent) {
 
   // Function for salary outside any conditions
   SalaryConditions.prototype._defaultRange = function($this) {
-
     // Hide any callouts which are displayed
     $this.$callout_lt5876.addClass('details__callout--inactive');
     $this.$callout_lt5876.removeClass('details__callout--active');
@@ -116,9 +132,13 @@ define(['jquery', 'DoughBaseComponent'], function($, DoughBaseComponent) {
     $this.$radioDisabled.removeClass('details__callout--active');
     $this.$radioDisabled.addClass('details__callout--inactive');
 
-    // Enable radio button if disabled & recheck inital option
+    // Enable radio button if disabled
+    // And recheck inital option if full not already selected
     $this.$employerPartRadio.attr('disabled', false);
-    $this.$employerPartRadio.prop('checked', true);
+
+    if (this.contribution !== 'full') {
+      $this.$employerPartRadio.prop('checked', true);
+    }
 
     // Remove local storage if already saved
     localStorage.removeItem('lt5876');
@@ -126,7 +146,6 @@ define(['jquery', 'DoughBaseComponent'], function($, DoughBaseComponent) {
 
   // Function for salary less than £5876
   SalaryConditions.prototype._lessThan5876 = function($this) {
-
     // Show relevant callouts
     $this.$callout_lt5876.removeClass('details__callout--inactive');
     $this.$callout_lt5876.addClass('details__callout--active');
@@ -147,7 +166,6 @@ define(['jquery', 'DoughBaseComponent'], function($, DoughBaseComponent) {
 
   // Function for salary between £5876 and £10000
   SalaryConditions.prototype._between5876and10000 = function($this) {
-
     // Display relevant callout
     $this.$callout_gt5876_lt10000.removeClass('details__callout--inactive');
     $this.$callout_gt5876_lt10000.addClass('details__callout--active');
@@ -158,9 +176,13 @@ define(['jquery', 'DoughBaseComponent'], function($, DoughBaseComponent) {
     $this.$radioDisabled.removeClass('details__callout--active');
     $this.$radioDisabled.addClass('details__callout--inactive');
 
-    // Enable radio button if disabled & recheck inital option
+    // Enable radio button if disabled
+    // And recheck inital option if full not already selected
     $this.$employerPartRadio.attr('disabled', false);
-    $this.$employerPartRadio.prop('checked', true);
+
+    if (this.contribution !== 'full') {
+      $this.$employerPartRadio.prop('checked', true);
+    }
 
     // Remove local storage if already saved
     localStorage.removeItem('lt5876');
@@ -169,7 +191,6 @@ define(['jquery', 'DoughBaseComponent'], function($, DoughBaseComponent) {
   // Step 2 - Alters values of the contribution inputs
   // Modifies the employee contributions tip
   SalaryConditions.prototype._step2Conditions = function() {
-
     var salaryCondition = localStorage.getItem('lt5876'),
         $this           = this;
 

--- a/spec/javascripts/fixtures/SalaryConditions.html
+++ b/spec/javascripts/fixtures/SalaryConditions.html
@@ -10,15 +10,15 @@
     </select>
     <div class="details__callout--inactive" data-dough-callout-lt5876>
     </div>
-    
+
     <div class="details__callout--inactive" data-dough-callout-gt5876_lt10000>
     </div>
-    
+
     <div class="details__callout--inactive" data-dough-callout-radio-disabled>
     </div>
 
-    <input data-dough-employer-part-radio="true" type="radio" value="minimum">
-    <input data-dough-employer-full-radio="true" type="radio" value="full">
+    <input data-dough-employer-part-radio="true" name="your_details_form[contribution_preference]" type="radio" value="minimum" checked="true">
+    <input data-dough-employer-full-radio="true" name="your_details_form[contribution_preference]" type="radio" value="full">
 
     <p data-dough-employee-tip-lt5876 class="is-hidden"></p>
     <p data-dough-employee-tip></p>

--- a/spec/javascripts/tests/SalaryConditions_spec.js
+++ b/spec/javascripts/tests/SalaryConditions_spec.js
@@ -32,7 +32,13 @@ describe('Salary Conditions', function() {
       this.radioDisabled = this.component.find('[data-dough-callout-radio-disabled]');
       this.employerPartRadio = this.component.find('[data-dough-employer-part-radio]');
       this.employerFullRadio = this.component.find('[data-dough-employer-full-radio]');
+
       clock = sinon.useFakeTimers();
+
+      // set initial values for salary field and checked radio control
+      this.salaryField.val(null);
+      this.component.find('input[name="your_details_form[contribution_preference]"]')[1].checked = true;  // full salary selected
+
       this.obj.init();
     });
 
@@ -58,7 +64,7 @@ describe('Salary Conditions', function() {
     });
 
     describe('When salary is less than £5876', function() {
-      it('Shows the correct callout', function(done) {
+      it('Shows the correct callout and checks the correct radio control', function(done) {
         this.salaryFrequency.val('year');
         this.salaryField.val('3000');
         this.salaryField.trigger('keyup');
@@ -66,24 +72,35 @@ describe('Salary Conditions', function() {
         expect(
           this.callout_lt5876.hasClass('details__callout--active')
         ).to.be.true;
+        expect(
+          this.component.find('input[name="your_details_form[contribution_preference]"]:checked').val()
+        ).to.equal('full');
         done();
       });
 
-      it('Disables the employer part contribution radio', function(done) {
+      it('Disables the employer part contribution radio and checks the correct radio control', function(done) {
         this.salaryField.val('3000');
         this.salaryField.trigger('keyup');
         clock.tick(this.delay);
-        expect(this.employerPartRadio.prop('disabled')).to.be.true;
+        expect(
+          this.employerPartRadio.prop('disabled')
+        ).to.be.true;
+        expect(
+          this.component.find('input[name="your_details_form[contribution_preference]"]:checked').val()
+        ).to.equal('full');
         done();
       });
 
-      it('Displays disabled radio callout', function(done) {
+      it('Displays disabled radio callout and checks the correct radio control', function(done) {
         this.salaryField.val('3000');
         this.salaryField.trigger('keyup');
         clock.tick(this.delay);
         expect(
           this.radioDisabled.hasClass('details__callout--active')
         ).to.be.true;
+        expect(
+          this.component.find('input[name="your_details_form[contribution_preference]"]:checked').val()
+        ).to.equal('full');
         done();
       });
 
@@ -91,51 +108,64 @@ describe('Salary Conditions', function() {
         this.salaryField.val('3000');
         this.salaryField.trigger('keyup');
         clock.tick(this.delay);
-        expect(this.employerFullRadio.prop('checked')).to.be.true;
+        expect(
+          this.component.find('input[name="your_details_form[contribution_preference]"]:checked').val()
+        ).to.equal('full');
         done();
       });
 
-      it('Saves this state to local storage', function(done) {
+      it('Saves this state to local storage and checks the correct radio control', function(done) {
         this.salaryField.val('3000');
         this.salaryField.trigger('keyup');
         clock.tick(this.delay);
         expect(localStorage.getItem('lt5876')).to.equal('true');
+        expect(
+          this.component.find('input[name="your_details_form[contribution_preference]"]:checked').val()
+        ).to.equal('full');
         done();
       });
 
-      it('Clears state from localStorage if salary is changed to £5876 or above', 
+      it('Clears state from localStorage if salary is changed to £5876 or above and checks the correct radio control',
         function(done) {
         this.salaryField.val('5876');
         this.salaryField.trigger('keyup');
         clock.tick(this.delay);
         expect(localStorage.getItem('lt5876')).to.be.equal(null);
+        expect(
+          this.component.find('input[name="your_details_form[contribution_preference]"]:checked').val()
+        ).to.equal('full');
         done();
       });
     });
 
     describe('When salary is between £5876 and £10000', function() {
-      it('Shows the correct callout', function(done) {
+      it('Shows the correct callout and checks the correct radio control', function(done) {
         this.salaryField.val('7000');
         this.salaryField.trigger('keyup');
         clock.tick(this.delay);
         expect(
           this.callout_gt5876_lt10000.hasClass('details__callout--active')
         ).to.be.true;
+        expect(
+          this.component.find('input[name="your_details_form[contribution_preference]"]:checked').val()
+        ).to.equal('full');
         done();
       });
     });
 
     describe('When salary is equal to or greater than £10000', function() {
-      it('Does not display any callouts', function(done) {
+      it('Does not display any callouts and checks the correct radio control', function(done) {
         this.salaryField.val('22000');
         this.salaryField.trigger('keyup');
         clock.tick(this.delay);
         expect(this.callout_gt5876_lt10000.hasClass('details__callout--inactive')).to.be.true;
         expect(this.callout_gt5876_lt10000.hasClass('details__callout--inactive')).to.be.true;
+        expect(
+          this.component.find('input[name="your_details_form[contribution_preference]"]:checked').val()
+        ).to.equal('full');
         done();
       });
     });
-
   });
 
   describe('When frequency field is changed', function() {
@@ -256,7 +286,7 @@ describe('Salary Conditions', function() {
       this.salaryField.trigger('keyup');
       clock.tick(this.delay);
       expect(this.employeeTip_lt5876.hasClass('is-hidden')).to.be.false;
-      done(); 
+      done();
     });
 
     it('Hides the employer contribution tip', function(done) {
@@ -264,7 +294,7 @@ describe('Salary Conditions', function() {
       this.salaryField.trigger('keyup');
       clock.tick(this.delay);
       expect(this.employerTip.text()).to.equal('');
-      done(); 
+      done();
     });
   });
 


### PR DESCRIPTION
Addresses issues in [TP8505](https://moneyadviceservice.tpondemand.com/RestUI/Board.aspx?acid=6C17D8319C81AC3D36AFAD64CAE08A28#page=userstory/8439&appConfig=eyJhY2lkIjoiREI4ODcwRjkxMDNDRTM2NTlBMzhDNTRBRTVBNUU1N0UifQ==&searchPopup=Bug/8505)

Changes in the salary field were effecting the state of the contributions selector without user input. 

This PR:
- Adds a method to save the contribution state on page load and when this is changed by the user
- Uses this conditionally when changes are made to salary amount