### PR TITLE
8507 Display frequency in results table headings

### DIFF
--- a/app/controllers/wpcc/your_results_controller.rb
+++ b/app/controllers/wpcc/your_results_controller.rb
@@ -14,6 +14,7 @@ module Wpcc
 
     def salary_frequency
       @salary_frequency ||= SalaryFrequency.new(
+        locale: params[:locale],
         params_salary_frequency: params[:salary_frequency],
         session_salary_frequency: session[:salary_frequency]
       )

--- a/app/models/wpcc/salary_frequency.rb
+++ b/app/models/wpcc/salary_frequency.rb
@@ -1,7 +1,7 @@
 module Wpcc
   class SalaryFrequency
     include ActiveModel::Model
-    attr_accessor :params_salary_frequency, :session_salary_frequency
+    attr_accessor :params_salary_frequency, :session_salary_frequency, :locale
 
     DEFAULT_SALARY_FREQUENCIES = Hash[
       Wpcc::YourDetailsForm::SALARY_FREQUENCIES.map { |e| [e, e] }
@@ -12,6 +12,10 @@ module Wpcc
     def initialize(attributes)
       @converter = SalaryFrequencyConverter
       super(attributes)
+    end
+
+    def to_adj
+      @converter.adjectives[locale.to_s][to_s]
     end
 
     def to_i

--- a/app/models/wpcc/salary_frequency_converter.rb
+++ b/app/models/wpcc/salary_frequency_converter.rb
@@ -8,5 +8,9 @@ module Wpcc
     def self.convert(salary_frequency)
       SALARY_FREQUENCIES[salary_frequency]
     end
+
+    def self.adjectives
+      CONVERSIONS['adjectives']
+    end
   end
 end

--- a/app/presenters/wpcc/period_contribution_presenter.rb
+++ b/app/presenters/wpcc/period_contribution_presenter.rb
@@ -32,6 +32,18 @@ module Wpcc
       formatted_contribution(object.total_contributions)
     end
 
+    def employer_frequency_heading(salary_frequency)
+      # rubocop:disable Lint/StringConversionInInterpolation
+      default_i18n_key = 'wpcc.results.period.contribution_heading.employers'
+
+      I18n.t(
+        "#{default_i18n_key}_#{salary_frequency.to_s}",
+        default: :"#{default_i18n_key}",
+        salary_frequency: salary_frequency.to_adj
+      )
+      # rubocop:enable Lint/StringConversionInInterpolation
+    end
+
     private
 
     def formatted_contribution(contribution_value)

--- a/app/views/wpcc/your_results/_contributions_table.html.erb
+++ b/app/views/wpcc/your_results/_contributions_table.html.erb
@@ -23,9 +23,9 @@
         </p>
         <%= render 'wpcc/tooltips/close' %>
       </div>
-
       <p class="results__period-heading">
-        <%= t('wpcc.results.period.contribution_heading.employers', salary_frequency: salary_frequency.to_adj) %></p>
+        <%= period.employer_frequency_heading(salary_frequency) %>
+      </p>
       <p class="results__period-details results__period-employer-contribution" data-dough-employer-contribution data-value="<%= period.employer_contribution %>">
         <%= period.formatted_employer_contribution %>
 

--- a/app/views/wpcc/your_results/_contributions_table.html.erb
+++ b/app/views/wpcc/your_results/_contributions_table.html.erb
@@ -2,8 +2,10 @@
   <% schedule.each do |period| %>
     <div class="results__period results__period-<%= period.name %>" data-dough-component="PopupTip" data-dough-results-table>
       <h3 class="results__period-title"><%= period.title %></h3>
-
-      <p class="results__period-heading"><%= t('wpcc.results.period.contribution_heading.yours') %></p>
+      
+      <p class="results__period-heading">
+        <%= t('wpcc.results.period.contribution_heading.yours', salary_frequency: salary_frequency.to_adj) %>
+      </p>
       <p class="results__period-details results__period-employee-contribution" data-dough-employee-contribution data-value="<%= period.employee_contribution %>">
         <%= period.formatted_employee_contribution %>
       </p>
@@ -12,7 +14,6 @@
         <span class="results__period-tax-relief" data-dough-tax-relief data-value="<%= period.tax_relief %>">
           <%= period.formatted_tax_relief %>
         </span>
-
         <%= render 'wpcc/tooltips/trigger' %>
       </p>
 
@@ -23,12 +24,15 @@
         <%= render 'wpcc/tooltips/close' %>
       </div>
 
-      <p class="results__period-heading"><%= t('wpcc.results.period.contribution_heading.employers') %></p>
+      <p class="results__period-heading">
+        <%= t('wpcc.results.period.contribution_heading.employers', salary_frequency: salary_frequency.to_adj) %></p>
       <p class="results__period-details results__period-employer-contribution" data-dough-employer-contribution data-value="<%= period.employer_contribution %>">
         <%= period.formatted_employer_contribution %>
-      </p>
 
-      <p class="results__period-heading"><%= t('wpcc.results.period.contribution_heading.total') %></p>
+      </p>
+      <p class="results__period-heading">
+        <%= t('wpcc.results.period.contribution_heading.total', salary_frequency: salary_frequency.to_adj) %>
+      </p>
       <p class="results__period-details results__period-total-contributions" data-dough-total>
         <%= period.formatted_total_contributions %>
       </p>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -115,9 +115,9 @@ cy:
         after_april_2019: O Ebrill 2019 ymlaen
       period:
         contribution_heading:
-          yours: Eich cyfraniad chi
-          employers: Cyfraniad cyflogwr
-          total: Cyfanswm cyfraniadau
+          yours: Eich %{salary_frequency} cyfraniad chi
+          employers: cyfraniad %{salary_frequency} cyflogwr
+          total: Cyfanswm %{salary_frequency} cyfraniadau
         tax_relief_parentheses: yn cynnwys gostyngiad treth o £
       tax_relief_warning_html: Os nad ydych chi'n talu treth incwm ar eich enillion, fyddwch chi ddim ond yn cael gostyngiad treth ar eich cyfraniadau os bydd eich cynllun pensiwn yn casglu cyfraniadau yn defnyddio'r gostyngiad treth yn y ffynhonnell. Rydym wedi tybio bod eich cynllun yn gwneud hyn. Darllenwch ragor yn ein canllaw am <a href="https://www.moneyadviceservice.org.uk/cy/articles/gostyngiad-treth-ar-gyfraniadau-pensiwn">ostyngiadau treth ar gyfraniadau pensiwn</a>.
       tax_relief_warning: Os nad ydych chi'n talu treth incwm ar eich enillion, fyddwch chi ddim ond yn cael gostyngiad treth ar eich cyfraniadau os bydd eich cynllun pensiwn yn casglu cyfraniadau yn defnyddio'r gostyngiad treth yn y ffynhonnell. Rydym wedi tybio bod eich cynllun yn gwneud hyn. Darllenwch ragor yn ein canllaw am ostyngiadau treth ar gyfraniadau pensiwn.

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -115,9 +115,9 @@ cy:
         after_april_2019: O Ebrill 2019 ymlaen
       period:
         contribution_heading:
-          yours: Eich %{salary_frequency} cyfraniad chi
-          employers: cyfraniad %{salary_frequency} cyflogwr
-          total: Cyfanswm %{salary_frequency} cyfraniadau
+          yours: Eich cyfraniad %{salary_frequency}
+          employers: Cyfraniad %{salary_frequency} y cyflogwr
+          total: Cyfanswm y cyfraniad %{salary_frequency}
         tax_relief_parentheses: yn cynnwys gostyngiad treth o £
       tax_relief_warning_html: Os nad ydych chi'n talu treth incwm ar eich enillion, fyddwch chi ddim ond yn cael gostyngiad treth ar eich cyfraniadau os bydd eich cynllun pensiwn yn casglu cyfraniadau yn defnyddio'r gostyngiad treth yn y ffynhonnell. Rydym wedi tybio bod eich cynllun yn gwneud hyn. Darllenwch ragor yn ein canllaw am <a href="https://www.moneyadviceservice.org.uk/cy/articles/gostyngiad-treth-ar-gyfraniadau-pensiwn">ostyngiadau treth ar gyfraniadau pensiwn</a>.
       tax_relief_warning: Os nad ydych chi'n talu treth incwm ar eich enillion, fyddwch chi ddim ond yn cael gostyngiad treth ar eich cyfraniadau os bydd eich cynllun pensiwn yn casglu cyfraniadau yn defnyddio'r gostyngiad treth yn y ffynhonnell. Rydym wedi tybio bod eich cynllun yn gwneud hyn. Darllenwch ragor yn ein canllaw am ostyngiadau treth ar gyfraniadau pensiwn.

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -117,6 +117,7 @@ cy:
         contribution_heading:
           yours: Eich cyfraniad %{salary_frequency}
           employers: Cyfraniad %{salary_frequency} y cyflogwr
+          employers_fourweeks: Cyfraniad y cyflogwr %{salary_frequency}
           total: Cyfanswm y cyfraniad %{salary_frequency}
         tax_relief_parentheses: yn cynnwys gostyngiad treth o £
       tax_relief_warning_html: Os nad ydych chi'n talu treth incwm ar eich enillion, fyddwch chi ddim ond yn cael gostyngiad treth ar eich cyfraniadau os bydd eich cynllun pensiwn yn casglu cyfraniadau yn defnyddio'r gostyngiad treth yn y ffynhonnell. Rydym wedi tybio bod eich cynllun yn gwneud hyn. Darllenwch ragor yn ein canllaw am <a href="https://www.moneyadviceservice.org.uk/cy/articles/gostyngiad-treth-ar-gyfraniadau-pensiwn">ostyngiadau treth ar gyfraniadau pensiwn</a>.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -115,9 +115,9 @@ en:
         after_april_2019: April 2019 onwards
       period:
         contribution_heading:
-          yours: Your contribution
-          employers: Employer's contribution
-          total: Total contributions
+          yours: Your %{salary_frequency} contribution
+          employers: Employer's %{salary_frequency} contribution
+          total: Total %{salary_frequency} contributions
         tax_relief_parentheses: includes tax relief of £
       tax_relief_warning_html: If you don’t pay income tax on your earnings, you will only receive tax relief on your pension contributions if your pension scheme collects contributions using the tax relief at source method. We have assumed your scheme does. Read more in our guide about <a href="https://www.moneyadviceservice.org.uk/en/articles/tax-relief-on-pension-contributions">tax relief on pension contributions</a>.
       tax_relief_warning: If you don’t pay income tax on your earnings, you will only receive tax relief on your pension contributions if your pension scheme collects contributions using the tax relief at source method.  We have assumed your scheme does. Read more in our guide about tax relief on pension contributions.

--- a/config/salary_frequency_conversions.yml
+++ b/config/salary_frequency_conversions.yml
@@ -8,3 +8,14 @@ tax_relief_limit_by_frequency:
   12: 666.67
   13: 615.38
   52: 153.85
+adjectives:
+  en:
+    year: annual
+    month: monthly
+    fourweeks: 4-weekly
+    week: weekly
+  cy:
+    year: blynyddol
+    month: misol
+    fourweeks: 4-wythnosol
+    week: wythnosol

--- a/config/salary_frequency_conversions.yml
+++ b/config/salary_frequency_conversions.yml
@@ -17,5 +17,5 @@ adjectives:
   cy:
     year: blynyddol
     month: misol
-    fourweeks: 4-wythnosol
+    fourweeks: bob 4 wythnos
     week: wythnosol

--- a/features/_your_results/displaying_frequency.feature
+++ b/features/_your_results/displaying_frequency.feature
@@ -22,10 +22,10 @@ Feature: Displaying frequency in the results table
 
     @welsh
     Examples:
-      | age | gender      | salary | salary_frequency | contribution | your_heading                 | employer_heading                      | total_heading                      |
-      | 45  | Benywaidd   | 200    | y Wythnos        | Minimum      | Eich cyfraniad wythnosol     | Cyfraniad wythnosol y cyflogwr        | Cyfanswm y cyfraniad wythnosol     |
-      | 53  | Benywaidd   | 1200   | fesul 4 wythnos  | Full         | Eich cyfraniad bob 4 wythnos | Cyfraniad eich cyflogwr bob 4 wythnos | Cyfanswm y cyfraniad bob 4 wythnos |
-      | 28  | Gwrywaidd   | 1500   | y Mis            | Minimum      | Eich cyfraniad misol         | Cyfraniad misol y cyflogwr            | Cyfanswm y cyfraniad misol         |
+      | age | gender      | salary | salary_frequency | contribution | your_heading                 | employer_heading                   | total_heading                      |
+      | 45  | Benywaidd   | 200    | y Wythnos        | Minimum      | Eich cyfraniad wythnosol     | Cyfraniad wythnosol y cyflogwr     | Cyfanswm y cyfraniad wythnosol     |
+      | 53  | Benywaidd   | 1200   | fesul 4 wythnos  | Full         | Eich cyfraniad bob 4 wythnos | Cyfraniad y cyflogwr bob 4 wythnos | Cyfanswm y cyfraniad bob 4 wythnos |
+      | 28  | Gwrywaidd   | 1500   | y Mis            | Minimum      | Eich cyfraniad misol         | Cyfraniad misol y cyflogwr         | Cyfanswm y cyfraniad misol         |
 
   Scenario Outline: When salary frequency is yearly
     And I am a "<age>" year old "<gender>"
@@ -33,7 +33,7 @@ Feature: Displaying frequency in the results table
     And I click the Next button
     When I move on to the results page
     And I move on to the results page
-    When I select "per Year" to change the calculations
+    When I select "<salary_frequency>" to change the calculations
     And I press recalculate
     Then my results should have "<your_heading>" "<employer_heading>" and "<total_heading>"
 

--- a/features/_your_results/displaying_frequency.feature
+++ b/features/_your_results/displaying_frequency.feature
@@ -1,46 +1,47 @@
 Feature: Displaying frequency in the results table
   In order to fully understand what I will be paying and how often
   As a user trying to work out the impact of my contributions on my take-home pay
-  I want to see the frequency being displayed clearly on my results
+  I want to see the salary frequency being displayed clearly on my results
 
   Background:
     Given I am on the Your Details step
-    And I am a "25" year old "male"
 
-  Scenario: Displaying weekly
-    Given my salary is "200" "per Week" with "Minimum" contribution
+  Scenario Outline: When salary frequency is weekly, 4-weekly and monthly
+    And I am a "<age>" year old "<gender>"
+    And my salary is "<salary>" "<salary_frequency>" with "<contribution>" contribution
     And I click the Next button
     When I move on to the results page
-    Then my results should all read:
-      | Your weekly contribution       |
-      | Employer's weekly contribution |
-      | Total weekly contributions     |
+    Then my results should have "<your_heading>" "<employer_heading>" and "<total_heading>"
 
- Scenario: Displaying 4-weekly
-    Given my salary is "1200" "per 4 weeks" with "Minimum" contribution
+    Examples:
+      | age | gender | salary | salary_frequency | contribution | your_heading               | employer_heading                 | total_heading                |
+      | 35  | male   | 200    | per Week         | Minimum      | Your weekly contribution   | Employer's weekly contribution   | Total weekly contributions   |
+      | 55  | male   | 1200   | per 4 weeks      | Full         | Your 4-weekly contribution | Employer's 4-weekly contribution | Total 4-weekly contributions |
+      | 25  | female | 1500   | per Month        | Minimum      | Your monthly contribution  | Employer's monthly contribution  | Total monthly contributions  |
+
+
+    @welsh
+    Examples:
+      | age | gender      | salary | salary_frequency | contribution | your_heading                 | employer_heading                      | total_heading                      |
+      | 45  | Benywaidd   | 200    | y Wythnos        | Minimum      | Eich cyfraniad wythnosol     | Cyfraniad wythnosol y cyflogwr        | Cyfanswm y cyfraniad wythnosol     |
+      | 53  | Benywaidd   | 1200   | fesul 4 wythnos  | Full         | Eich cyfraniad bob 4 wythnos | Cyfraniad eich cyflogwr bob 4 wythnos | Cyfanswm y cyfraniad bob 4 wythnos |
+      | 28  | Gwrywaidd   | 1500   | y Mis            | Minimum      | Eich cyfraniad misol         | Cyfraniad misol y cyflogwr            | Cyfanswm y cyfraniad misol         |
+
+  Scenario Outline: When salary frequency is yearly
+    And I am a "<age>" year old "<gender>"
+    Given my salary is "<salary>" "<salary_frequency>" with "<contribution>" contribution
     And I click the Next button
     When I move on to the results page
-    Then my results should all read:
-      | Your 4-weekly contribution       |
-      | Employer's 4-weekly contribution |
-      | Total 4-weekly contributions     |
-
- Scenario: Displaying monthly
-    Given my salary is "1500" "per Month" with "Minimum" contribution
-    And I click the Next button
-    When I move on to the results page
-    Then my results should all read:
-      | Your monthly contribution       |
-      | Employer's monthly contribution |
-      | Total monthly contributions     |
-
- Scenario: Display annual when "per Year" frequency selected on Step 3
-    Given my salary is "20000" "per Year" with "Minimum" contribution
-    And I click the Next button
     And I move on to the results page
     When I select "per Year" to change the calculations
     And I press recalculate
-    Then my results should all read:
-      | Your annual contribution       |
-      | Employer's annual contribution |
-      | Total annual contributions     |
+    Then my results should have "<your_heading>" "<employer_heading>" and "<total_heading>"
+
+    Examples:
+      | age | gender | salary | salary_frequency | contribution | your_heading             | employer_heading               | total_heading                |
+      | 37  | female | 25000  | per Year         | Full         | Your annual contribution | Employer's annual contribution | Total annual contributions   |
+
+    @welsh
+    Examples:
+      | age | gender    | salary | salary_frequency | contribution | your_heading             | employer_heading               | total_heading                  |
+      | 32  | Gwrywaidd | 25000  | y Flwyddyn       | Minimum      | Eich cyfraniad blynyddol | Cyfraniad blynyddol y cyflogwr | Cyfanswm y cyfraniad blynyddol |

--- a/features/_your_results/displaying_frequency.feature
+++ b/features/_your_results/displaying_frequency.feature
@@ -1,0 +1,46 @@
+Feature: Displaying frequency in the results table
+  In order to fully understand what I will be paying and how often
+  As a user trying to work out the impact of my contributions on my take-home pay
+  I want to see the frequency being displayed clearly on my results
+
+  Background:
+    Given I am on the Your Details step
+    And I am a "25" year old "male"
+
+  Scenario: Displaying weekly
+    Given my salary is "200" "per Week" with "Minimum" contribution
+    And I click the Next button
+    When I move on to the results page
+    Then my results should all read:
+      | Your weekly contribution       |
+      | Employer's weekly contribution |
+      | Total weekly contributions     |
+
+ Scenario: Displaying 4-weekly
+    Given my salary is "1200" "per 4 weeks" with "Minimum" contribution
+    And I click the Next button
+    When I move on to the results page
+    Then my results should all read:
+      | Your 4-weekly contribution       |
+      | Employer's 4-weekly contribution |
+      | Total 4-weekly contributions     |
+
+ Scenario: Displaying monthly
+    Given my salary is "1500" "per Month" with "Minimum" contribution
+    And I click the Next button
+    When I move on to the results page
+    Then my results should all read:
+      | Your monthly contribution       |
+      | Employer's monthly contribution |
+      | Total monthly contributions     |
+
+ Scenario: Display annual when "per Year" frequency selected on Step 3
+    Given my salary is "20000" "per Year" with "Minimum" contribution
+    And I click the Next button
+    And I move on to the results page
+    When I select "per Year" to change the calculations
+    And I press recalculate
+    Then my results should all read:
+      | Your annual contribution       |
+      | Employer's annual contribution |
+      | Total annual contributions     |

--- a/features/step_definitions/your_results_steps.rb
+++ b/features/step_definitions/your_results_steps.rb
@@ -104,11 +104,6 @@ Then(/^my results should have "([^"]*)" "([^"]*)" and "([^"]*)"$/) do |your_head
   expect(your_results_page.results_period_headings[0..2].map(&:text)).to eq(headings)
 end
 
-# Then(/^my results should all read:$/) do |table|
-#   headings = table.raw.flatten
-#   expect(your_results_page.results_period_headings[0..2].map(&:text)).to eq(headings)
-# end
-
 Then(/^I should see a link to the legal minimum contributions table$/) do
   expect(your_results_page).to have_legal_contributions_table_link
 end

--- a/features/step_definitions/your_results_steps.rb
+++ b/features/step_definitions/your_results_steps.rb
@@ -99,10 +99,15 @@ Then(/^I should( not)? see the manually_opt_in "([^"]*)"$/) do |should_not, mess
   end
 end
 
-Then(/^my results should all read:$/) do |table|
-  headings = table.raw.flatten
+Then(/^my results should have "([^"]*)" "([^"]*)" and "([^"]*)"$/) do |your_heading, employer_heading, total_heading|
+  headings = [your_heading, employer_heading, total_heading]
   expect(your_results_page.results_period_headings[0..2].map(&:text)).to eq(headings)
 end
+
+# Then(/^my results should all read:$/) do |table|
+#   headings = table.raw.flatten
+#   expect(your_results_page.results_period_headings[0..2].map(&:text)).to eq(headings)
+# end
 
 Then(/^I should see a link to the legal minimum contributions table$/) do
   expect(your_results_page).to have_legal_contributions_table_link

--- a/features/step_definitions/your_results_steps.rb
+++ b/features/step_definitions/your_results_steps.rb
@@ -99,6 +99,11 @@ Then(/^I should( not)? see the manually_opt_in "([^"]*)"$/) do |should_not, mess
   end
 end
 
+Then(/^my results should all read:$/) do |table|
+  headings = table.raw.flatten
+  expect(your_results_page.results_period_headings[0..2].map(&:text)).to eq(headings)
+end
+
 Then(/^I should see a link to the legal minimum contributions table$/) do
   expect(your_results_page).to have_legal_contributions_table_link
 end

--- a/features/support/ui/your_results.rb
+++ b/features/support/ui/your_results.rb
@@ -25,6 +25,7 @@ module UI
     elements :percent_table_headings, 'table.contribution-changes__table th'
     elements :table_cells, 'table.contribution-changes__table tbody tr td'
 
+    elements :results_period_headings, '.results__period-heading'
     section :current_period, PeriodSection, '.results__period-april_2017_march_2018'
     section :second_period, PeriodSection, '.results__period-april_2018_march_2019'
     section :third_period, PeriodSection, '.results__period-after_april_2019'

--- a/spec/controllers/your_results_controller_spec.rb
+++ b/spec/controllers/your_results_controller_spec.rb
@@ -51,7 +51,11 @@ RSpec.describe Wpcc::YourResultsController do
       request.session[:salary_frequency] = 'week'
       expect(Wpcc::SalaryFrequency)
         .to receive(:new)
-        .with(params_salary_frequency: nil, session_salary_frequency: 'week')
+        .with(
+          locale: nil,
+          params_salary_frequency: nil,
+          session_salary_frequency: 'week'
+        )
         .and_return(salary_frequency)
 
       @controller.send(:salary_frequency)

--- a/spec/models/salary_frequency_spec.rb
+++ b/spec/models/salary_frequency_spec.rb
@@ -11,20 +11,71 @@ RSpec.describe Wpcc::SalaryFrequency do
   let(:locale) { :en }
 
   describe '#to_adj' do
-    let(:params_salary_frequency) { 'week' }
-    let(:session_salary_frequency) { 'week' }
-
     context 'when english' do
-      it 'returns the frequency adjective' do
-        expect(subject.to_adj).to eq('weekly')
+      context 'for weekly salary_frequency' do
+        let(:params_salary_frequency) { 'week' }
+        let(:session_salary_frequency) { 'week' }
+        it 'returns the frequency adjective' do
+          expect(subject.to_adj).to eq('weekly')
+        end
+      end
+
+      context 'for 4-weekly salary_frequency' do
+        let(:params_salary_frequency) { 'fourweeks' }
+        let(:session_salary_frequency) { 'fourweeks' }
+        it 'returns the frequency adjective' do
+          expect(subject.to_adj).to eq('4-weekly')
+        end
+      end
+
+      context 'for montly salary_frequency' do
+        let(:params_salary_frequency) { 'month' }
+        let(:session_salary_frequency) { 'month' }
+        it 'returns the frequency adjective' do
+          expect(subject.to_adj).to eq('monthly')
+        end
+      end
+      context 'for 4-weekly salary_frequency' do
+        let(:params_salary_frequency) { 'year' }
+        let(:session_salary_frequency) { 'year' }
+        it 'returns the frequency adjective' do
+          expect(subject.to_adj).to eq('annual')
+        end
       end
     end
 
     context 'when welsh' do
       let(:locale) { :cy }
 
-      it 'returns the frequency adjective' do
-        expect(subject.to_adj).to eq('wythnosol')
+      context 'for weekly salary_frequency' do
+        let(:params_salary_frequency) { 'week' }
+        let(:session_salary_frequency) { 'week' }
+        it 'returns the frequency adjective' do
+          expect(subject.to_adj).to eq('wythnosol')
+        end
+      end
+
+      context 'for 4-weekly salary_frequency' do
+        let(:params_salary_frequency) { 'fourweeks' }
+        let(:session_salary_frequency) { 'fourweeks' }
+        it 'returns the frequency adjective' do
+          expect(subject.to_adj).to eq('bob 4 wythnos')
+        end
+      end
+
+      context 'for montly salary_frequency' do
+        let(:params_salary_frequency) { 'month' }
+        let(:session_salary_frequency) { 'month' }
+        it 'returns the frequency adjective' do
+          expect(subject.to_adj).to eq('misol')
+        end
+      end
+      context 'for 4-weekly salary_frequency' do
+        let(:params_salary_frequency) { 'year' }
+        let(:session_salary_frequency) { 'year' }
+        it 'returns the frequency adjective' do
+          expect(subject.to_adj).to eq('blynyddol')
+        end
       end
     end
   end

--- a/spec/models/salary_frequency_spec.rb
+++ b/spec/models/salary_frequency_spec.rb
@@ -1,12 +1,33 @@
 RSpec.describe Wpcc::SalaryFrequency do
   subject do
     described_class.new(
+      locale: locale,
       params_salary_frequency: params_salary_frequency,
       session_salary_frequency: session_salary_frequency
     )
   end
 
   let(:params_salary_frequency) { nil }
+  let(:locale) { :en }
+
+  describe '#to_adj' do
+    let(:params_salary_frequency) { 'week' }
+    let(:session_salary_frequency) { 'week' }
+
+    context 'when english' do
+      it 'returns the frequency adjective' do
+        expect(subject.to_adj).to eq('weekly')
+      end
+    end
+
+    context 'when welsh' do
+      let(:locale) { :cy }
+
+      it 'returns the frequency adjective' do
+        expect(subject.to_adj).to eq('wythnosol')
+      end
+    end
+  end
 
   describe '#to_i' do
     let(:session_salary_frequency) { 'month' }

--- a/spec/presenters/period_contribution_presenter_spec.rb
+++ b/spec/presenters/period_contribution_presenter_spec.rb
@@ -43,4 +43,35 @@ RSpec.describe Wpcc::PeriodContributionPresenter do
       )
     end
   end
+
+  describe '#employer_frequency_heading' do
+    let(:salary_frequency) { Wpcc::SalaryFrequency.new(attributes) }
+    let(:attributes) do
+      {
+        locale: locale,
+        params_salary_frequency: nil,
+        session_salary_frequency: 'fourweeks'
+      }
+    end
+
+    context 'for english fourweekly salary frequency' do
+      let(:locale) { 'en' }
+      it 'returns the english translation for 4-weekly' do
+        expect(subject.employer_frequency_heading(salary_frequency))
+          .to eq('Employer\'s 4-weekly contribution')
+      end
+    end
+
+    context 'for welsh fourweekly salary frequency' do
+      let(:locale) { 'cy' }
+
+      before { I18n.locale = :cy }
+      after { I18n.locale = :en }
+
+      it 'returns the welsh translation for 4-weekly' do
+        expect(subject.employer_frequency_heading(salary_frequency))
+          .to eq('Cyfraniad y cyflogwr bob 4 wythnos')
+      end
+    end
+  end
 end


### PR DESCRIPTION
This pr addresses [TP User Story 8507](https://moneyadviceservice.tpondemand.com/restui/board.aspx?acid=ddd7f3a626844ab8d1bee3f06ec28efa#page=board/5624876525867731357&appConfig=eyJhY2lkIjoiREI4ODcwRjkxMDNDRTM2NTlBMzhDNTRBRTVBNUU1N0UifQ==&boardPopup=userstory/8507/silent). Specifically, the headings for Your, Employer and Total contributions on the results views should include the salary_frequency for example:
* Your annual contributions
* Employer's annual contributions
* Total annual contributions

### Technical
We decided to add additional values to the salary_frequency config file to facilitate the english and welsh terminology that is required to display on the view. Please see the commit message for more technical detail.