### PR TITLE
[DEV APPROVED] 8522 - Fixes contribution conditional messaging does not trigger

### DIFF
--- a/app/assets/javascripts/wpcc/components/ContributionConditions.js
+++ b/app/assets/javascripts/wpcc/components/ContributionConditions.js
@@ -40,7 +40,8 @@ define(['jquery', 'DoughBaseComponent'], function($, DoughBaseComponent) {
   //if more than 40k call display function otherwise call the hide function
   ContributionConditions.prototype._calculateContribution = function() {
     var $this = this,
-    salaryToNumber = parseInt(this.$eligibleSalary.text()),
+    salaryNumber = this.$eligibleSalary.text().replace(/[\£,]/g, ''),
+    salaryToNumber = parseInt(salaryNumber),
     salaryContributionAmount = (salaryToNumber/100)*this.$employeeContributions.val();
     
     if (salaryContributionAmount > 40000) {

--- a/spec/javascripts/tests/ContributionConditions_spec.js
+++ b/spec/javascripts/tests/ContributionConditions_spec.js
@@ -32,7 +32,7 @@ describe('Contribution Conditions', function() {
     describe('When salary contribution is under 40000', function() {
       it('Does not display the callout message', function() {
         this.employeeContributions.val(20);
-        this.eligibleSalary.text('60000');
+        this.eligibleSalary.text('£60,000');
         this.employeeContributions.trigger('keyup');
         expect(
           this.contributionWarning.hasClass('details__callout--inactive')
@@ -43,7 +43,7 @@ describe('Contribution Conditions', function() {
     describe('When salary contribution is over 40000', function() {
       it('Displays the callout message', function() {
         this.employeeContributions.val(100);
-        this.eligibleSalary.text('60000');
+        this.eligibleSalary.text('£60,000');
         this.employeeContributions.trigger('keyup');
         expect(
           this.contributionWarning.hasClass('details__callout--active')


### PR DESCRIPTION
## Issue
The eligible salary amount has been changed to display the  currency symbol "£" within the figure rather than it being a static part of the view. This is preventing the amount which is displayed as text, to be parsed with jquery into an integer.

## Solution
Use regex to remove the "£" symbol and the comma from the eligible salary string.
Use `parseInt` to convert to integer.

<img width="863" alt="screen shot 2017-08-21 at 16 48 25" src="https://user-images.githubusercontent.com/2187295/29527378-9dcfd760-8690-11e7-906f-05ddafc07bad.png">
