### PR TITLE
[DEV APPROVED] 8520 - Results page links and welsh text in views

### DIFF
--- a/app/views/wpcc/your_results/index.html.erb
+++ b/app/views/wpcc/your_results/index.html.erb
@@ -2,8 +2,14 @@
 
 <section class="section section--contributions">
   <h2 class="section__heading contributions__heading">2. <%= t('wpcc.contributions.title') %>
-    <span class="section__heading-summary"><%= t('wpcc.results.contribution_changes.you') %>: <%= session[:employee_percent] %>%, <%= t('wpcc.results.contribution_changes.employer') %>: <%= session[:employer_percent] %>%</span>
-    <span><%= link_to(t('wpcc.edit'), new_your_contribution_path, class: 'section__heading-edit') %></span>
+    <span class="section__heading-summary">
+      <%= t('wpcc.results.contribution_changes.you') %>: 
+      <%= session[:employee_percent] %>%, 
+      <%= t('wpcc.results.contribution_changes.employer') %>: <%= session[:employer_percent] %>%
+    </span>
+    <span>
+      <%= link_to(t('wpcc.edit'), new_your_contribution_path, class: 'section__heading-edit') %>
+    </span>
   </h2>
 </section>
 

--- a/app/views/wpcc/your_results/index.html.erb
+++ b/app/views/wpcc/your_results/index.html.erb
@@ -2,7 +2,7 @@
 
 <section class="section section--contributions">
   <h2 class="section__heading contributions__heading">2. <%= t('wpcc.contributions.title') %>
-    <span class="section__heading-summary">You: <%= session[:employee_percent] %>%, Your employer: <%= session[:employer_percent] %>%</span>
+    <span class="section__heading-summary"><%= t('wpcc.results.contribution_changes.you') %>: <%= session[:employee_percent] %>%, <%= t('wpcc.results.contribution_changes.employer') %>: <%= session[:employer_percent] %>%</span>
     <span><%= link_to(t('wpcc.edit'), new_your_contribution_path, class: 'section__heading-edit') %></span>
   </h2>
 </section>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -47,7 +47,7 @@ cy:
         details_html_2: ) neu ar eich cyflog llawn. I gael gwybod pa un, bydd angen i chi wirio gyda’ch cyflogwr.
         qualifying_earnings: Dyma’r rhan o’ch cyflog blynyddol fydd yn cael ei defnyddio i gyfrifo eich cyfraniad pensiwn dan gofrestru awtomatig. Sef eich enillion cyn treth (hyd at derfyn uchafswm o £45000 y flwyddyn) - tynnu’r trothwy enillion isaf o £5,876.
 
-      next: Next
+      next: Nesaf
       prompt: os gwelwch yn dda dewiswch
 
       callout__lt16: Rydych yn rhy ifanc i ymuno â phensiwn gweithle. Pan gyrhaeddwch 16 oed gallwch ofyn i’ch cyflogwr eich cofrestru. Os felly, bydd eich cyflogwr yn gwneud cyfraniadau.
@@ -124,12 +124,12 @@ cy:
       tax_relief_tooltip_html: Byddwch yn cael gostyngiad treth ar eich cyfraniadau pensiwn sy'n golygu y rhoddir peth o’r arian o'ch cyflog a fyddai wedi mynd i’r llywodraeth fel treth tuag at eich pensiwn yn hytrach. <a href="https://www.moneyadviceservice.org.uk/cy/articles/gostyngiad-treth-ar-gyfraniadau-pensiwn">Darllenwch fwy am sut i gael gostyngiad treth</a>.
       contribution_table_link: Darllen tabl sy’n dangos sut mae isafswm cyfraniadau cyfreithlon yn newid
       print_link: Argraffu eich canlyniadau
-      next_steps:
-        heading: Next steps
+      next_steps: 
+        heading: Y Camau Nesaf
         list:
-          pension_calculator_html: Defnyddiwch ein <a href="#">Cyfrifiannell Pensiwn</a> i weld faint o bensiwn y bydd eich cronfa yn ei chronni dros amser.
-          workplace_pensions_html: Dysgwch ragor am <a href="#">bensiynau gweithle</a>.
-          budget_planner_html: Defnyddiwch ein <a href="#">cynllunydd cyllideb</a> i weld pa effaith y bydd eich cyfraniadau yn eu cael ar eich incwm.
+          pension_calculator_html: Defnyddiwch ein <a href="https://www.moneyadviceservice.org.uk/cy/tools/cyfrifiannell-pensiwn">Cyfrifiannell Pensiwn</a> i weld faint o bensiwn y bydd eich cronfa yn ei chronni dros amser.
+          workplace_pensions_html: Dysgwch ragor am <a href="https://www.moneyadviceservice.org.uk/cy/categories/automatic-enrolment">bensiynau gweithle</a>.
+          budget_planner_html: Defnyddiwch ein <a href="https://www.moneyadviceservice.org.uk/cy/tools/cynllunydd-cyllideb/start">cynllunydd cyllideb</a> i weld pa effaith y bydd eich cyfraniadau yn eu cael ar eich incwm.
       edit_frequency:
         label: Dangos fy nghyfraniadau
         button: Al-gyfrifo

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -127,9 +127,9 @@ en:
       next_steps:
         heading: Next steps
         list:
-          pension_calculator_html: Use our <a href="#">Pension Calculator</a> to see how much pension pot you will build over time.
-          workplace_pensions_html: Find out more about <a href="#">workplace pensions</a>.
-          budget_planner_html: Use our <a href="#">budget planner</a> to see what effect your contributions will have on your income.
+          pension_calculator_html: Use our <a href="https://www.moneyadviceservice.org.uk/en/tools/pension-calculator">Pension Calculator</a> to see how much pension pot you will build over time.
+          workplace_pensions_html: Find out more about <a href="https://www.moneyadviceservice.org.uk/en/categories/automatic-enrolment">workplace pensions</a>.
+          budget_planner_html: Use our <a href="https://www.moneyadviceservice.org.uk/en/tools/budget-planner">budget planner</a> to see what effect your contributions will have on your income.
       edit_frequency:
         label: Show my contributions
         button: Recalculate


### PR DESCRIPTION
**Task 1:** 
The section 'Next steps' heading is missing Welsh. 

**Task 2:** 
Add links to the 'Next steps' section on the results page. 

**Task 3:**
Step 1 of WPCC has Next button with missing welsh translation. 

**Bonus**
In the summary of Step 2, we have Welsh translation missing for "you" and "your employer".

TP [Ticket](https://moneyadviceservice.tpondemand.com/entity/8520)

![image](https://user-images.githubusercontent.com/2187295/29572161-58002fd2-8753-11e7-9dcf-4ea36adb963b.png)

