### PR TITLE
8506 Display messages based on contribution percents

### DIFF
--- a/app/controllers/wpcc/your_results_controller.rb
+++ b/app/controllers/wpcc/your_results_controller.rb
@@ -21,7 +21,7 @@ module Wpcc
     helper_method :salary_frequency
 
     def period_legal_percents
-      calendar.periods.map do |period|
+      period_filter.periods.map do |period|
         Wpcc::PeriodPresenter.new(
           period,
           view_context: view_context
@@ -38,18 +38,29 @@ module Wpcc
     end
     helper_method :message_presenter
 
+    def period_filter_presenter
+      Wpcc::PeriodFilterPresenter.new(period_filter, view_context: view_context)
+    end
+    helper_method :period_filter_presenter
+
     private
 
     def calendar
       @calendar ||= Wpcc::ContributionsCalendar.new(contributions_params)
     end
 
+    def period_filter
+      @period_filter ||= PeriodFilter.new(
+        user_input_employee_percent: session[:employee_percent].to_i,
+        user_input_employer_percent: session[:employer_percent].to_i
+      )
+    end
+
     def contributions_params
       {
         eligible_salary: session[:eligible_salary].to_i,
-        employee_percent: session[:employee_percent].to_i,
-        employer_percent: session[:employer_percent].to_i,
-        salary_frequency: salary_frequency.to_i
+        salary_frequency: salary_frequency.to_i,
+        periods: period_filter.filtered_periods
       }
     end
 

--- a/app/controllers/wpcc/your_results_controller.rb
+++ b/app/controllers/wpcc/your_results_controller.rb
@@ -51,8 +51,8 @@ module Wpcc
 
     def period_filter
       @period_filter ||= PeriodFilter.new(
-        user_input_employee_percent: session[:employee_percent].to_i,
-        user_input_employer_percent: session[:employer_percent].to_i
+        user_input_employee_percent: session[:employee_percent].to_f,
+        user_input_employer_percent: session[:employer_percent].to_f
       )
     end
 

--- a/app/models/wpcc/contributions_calendar.rb
+++ b/app/models/wpcc/contributions_calendar.rb
@@ -1,13 +1,10 @@
 module Wpcc
   class ContributionsCalendar
     include ActiveModel::Model
-    attr_accessor :eligible_salary,
-                  :salary_frequency,
-                  :employee_percent,
-                  :employer_percent
+    attr_accessor :eligible_salary, :salary_frequency, :periods
 
     def schedule
-      filtered_periods.map do |period|
+      periods.map do |period|
         Wpcc::PeriodContributionCalculator.new(
           name: period.name,
           employee_percent: period.highest_employee_percent,
@@ -17,17 +14,6 @@ module Wpcc
           tax_relief_percent: period.tax_relief_percent
         ).contribution
       end
-    end
-
-    delegate :periods, :filtered_periods, to: :period_filter
-
-    private
-
-    def period_filter
-      @period_filter ||= PeriodFilter.new(
-        user_input_employee_percent: employee_percent,
-        user_input_employer_percent: employer_percent
-      )
     end
   end
 end

--- a/app/models/wpcc/your_contributions_form.rb
+++ b/app/models/wpcc/your_contributions_form.rb
@@ -8,11 +8,11 @@ module Wpcc
     validates :employer_percent, inclusion: { in: 0..100 }
 
     def employee_percent
-      @employee_percent.to_i
+      @employee_percent.to_f
     end
 
     def employer_percent
-      @employer_percent.to_i
+      @employer_percent.to_f
     end
   end
 end

--- a/app/presenters/wpcc/period_filter_presenter.rb
+++ b/app/presenters/wpcc/period_filter_presenter.rb
@@ -1,23 +1,40 @@
 module Wpcc
   class PeriodFilterPresenter < Presenter
     def contribution_percents_explanation
-      second_period = periods[1]
-      last_period = periods.last
+      @second_period = periods[1]
+      @last_period = periods.last
 
-      case
-      when user_input_employee_percent > last_period.employee_percent &&
-          user_input_employer_percent > last_period.employer_percent
+      if user_inputs_greater_than_legal_minimums?
         t('wpcc.results.large_contribution_percent_for_two_periods')
-      when user_input_employee_percent > second_period.employee_percent &&
-            user_input_employee_percent < last_period.employee_percent &&
-              user_input_employer_percent > second_period.employer_percent &&
-                user_input_employer_percent < last_period.employer_percent
+      elsif user_inputs_between_2nd_and_3rd_period_legal_minimums?
         t('wpcc.results.large_contribution_percent_for_middle_period')
-      when user_input_employee_percent > last_period.employee_percent
+      elsif user_input_for_employee_percent_greater_than_legal_minimums?
         t('wpcc.results.employee_large_contribution_percent_for_two_periods')
-      when user_input_employer_percent > last_period.employer_percent
+      elsif user_input_for_employer_percent_greater_than_legal_minimums?
         t('wpcc.results.employer_large_contribution_percent_for_two_periods')
       end
+    end
+
+    private
+
+    def user_inputs_greater_than_legal_minimums?
+      user_input_for_employee_percent_greater_than_legal_minimums? &&
+        user_input_for_employer_percent_greater_than_legal_minimums?
+    end
+
+    def user_inputs_between_2nd_and_3rd_period_legal_minimums?
+      user_input_employee_percent > @second_period.employee_percent &&
+        user_input_employee_percent < @last_period.employee_percent &&
+        user_input_employer_percent > @second_period.employer_percent &&
+        user_input_employer_percent < @last_period.employer_percent
+    end
+
+    def user_input_for_employee_percent_greater_than_legal_minimums?
+      user_input_employee_percent > @last_period.employee_percent
+    end
+
+    def user_input_for_employer_percent_greater_than_legal_minimums?
+      user_input_employer_percent > @last_period.employer_percent
     end
   end
 end

--- a/app/presenters/wpcc/period_filter_presenter.rb
+++ b/app/presenters/wpcc/period_filter_presenter.rb
@@ -1,0 +1,23 @@
+module Wpcc
+  class PeriodFilterPresenter < Presenter
+    def contribution_percents_explanation
+      second_period = periods[1]
+      last_period = periods.last
+
+      case
+      when user_input_employee_percent > last_period.employee_percent &&
+          user_input_employer_percent > last_period.employer_percent
+        t('wpcc.results.large_contribution_percent_for_two_periods')
+      when user_input_employee_percent > second_period.employee_percent &&
+            user_input_employee_percent < last_period.employee_percent &&
+              user_input_employer_percent > second_period.employer_percent &&
+                user_input_employer_percent < last_period.employer_percent
+        t('wpcc.results.large_contribution_percent_for_middle_period')
+      when user_input_employee_percent > last_period.employee_percent
+        t('wpcc.results.employee_large_contribution_percent_for_two_periods')
+      when user_input_employer_percent > last_period.employer_percent
+        t('wpcc.results.employer_large_contribution_percent_for_two_periods')
+      end
+    end
+  end
+end

--- a/app/views/wpcc/your_results/index.html.erb
+++ b/app/views/wpcc/your_results/index.html.erb
@@ -15,7 +15,10 @@
     data-dough-component="UpdateResults"
     data-dough-update-results-config='{"i18nStrings": {"parentheses": "<%= t('wpcc.results.period.tax_relief_parentheses') %>"}}'
   >
-    <p><%= t('wpcc.results.description', eligible_salary: session[:eligible_salary]) %></p>
+    <p>
+      <%= t('wpcc.results.description', eligible_salary: session[:eligible_salary]) %>
+      <%= period_filter_presenter.contribution_percents_explanation %>
+    </p>
 
     <% if message_presenter.tax_relief_warning? %>
       <div class="callout">

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -97,6 +97,14 @@ cy:
         Bydd cyfraddau cyfraniadau pensiwn isaf yn cynyddu yn Ebrill 2018 ac eto yn Ebrill 2019.
         Bydd y ffigyrau hyn yn dangos sut y bydd hyn yn effeithio ar eich cyfraniadau.
         Bydd cyfraniadau yn seiliedig ar eich enillion o £%{eligible_salary} y flwyddyn.
+      large_contribution_percent_for_two_periods:
+        Rydych chi a'ch cyflogwr eisoes yn talu mwy na'r isafswm newydd, felly rydym wedi dangos y cyfraniadau cyfredol yn unig. Ni fydd y rhain yn newid oni bai bod eich cyflog yn cynyddu neu rydych chi ac/neu eich cyflogwr yn dewis talu mwy.
+      large_contribution_percent_for_middle_period:
+        Rydych chi a'ch cyflogwr eisoes yn talu mwy na'r isafswm newydd ar gyfer Ebrill 2018 felly rydym wedi dangos y cynnydd ar gyfer Ebrill 2019 yn unig.
+      employee_large_contribution_percent_for_two_periods:
+        Rydych chi eisoes yn talu mwy na'r isafswm newydd, felly rydym wedi dangos sut fydd cyfraniadau eich cyflogwr yn cynyddu yn unig. Ni fydd eich cyfraniadau yn newid oni bai bod eich cyflog yn cynyddu neu os ydych yn dewis talu mwy.
+      employer_large_contribution_percent_for_two_periods:
+        Mae eich cyflogwr eisoes yn talu mwy na'r isafswm newydd, felly rydym wedi dangos sut fydd eich cyfraniadau chi yn cynyddu yn unig. Ni fydd cyfraniad eich cyflogwr yn newid oni bai bod eich cyflog yn cynyddu neu rydych chi neu eich cyflogwr yn dewis talu mwy.
       period_title:
         april_2017_march_2018: Nawr
         april_2018_march_2019: Ebrill 2018 – Mawrth 2019

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -96,7 +96,15 @@ en:
       description: |
         Minimum pension contribution rates will increase in April 2018 and again in April 2019.
         These figures show how this will affect your contributions.
-        Contributions will be based on your earnings of £%{eligible_salary} a year
+        Contributions will be based on your earnings of £%{eligible_salary} a year.
+      large_contribution_percent_for_two_periods:
+        "Both you and your employer are already paying above the new minimums so we have just shown the current contributions. These won't change unless your salary increases or you and/or your employer choose to pay more."
+      large_contribution_percent_for_middle_period:
+        "Both you and your employer are already paying above the new minimum for April 2018 so we have only shown the increase for April 2019."
+      employee_large_contribution_percent_for_two_periods:
+        "You are already paying above the new minimums so we have just shown how your employer's contributions will increase. Your contributions won't change unless your salary increases or you choose to pay more."
+      employer_large_contribution_percent_for_two_periods:
+        "Your employer is already paying above the new minimums so we have just shown how your contributions will increase. Your employer's contribution won't change unless your salary increases or your employer chooses to pay more."
       period_title:
         april_2017_march_2018: Now
         april_2018_march_2019: April 2018 - March 2019

--- a/features/_your_results/message_based_on_contribution_percents.feature
+++ b/features/_your_results/message_based_on_contribution_percents.feature
@@ -1,0 +1,71 @@
+Feature: Display messaging based on results table shown in results
+  In order to better understand my results,
+  As a user of the WPCC tool,
+  I want to see explanation of my pension contribution
+
+  Background:
+    Given I have valid details
+
+  Scenario Outline: Employee and Employer contributions are greater than the minimum for 2018 AND 2019
+    Given I fill in my contributions:
+      | your_contribution | employer_contribution |
+      | 6                 | 4                     |
+    When I move on to the results page
+    Then I should see a contribution explanation "<message>"
+
+    Examples:
+      | message |
+      | Both you and your employer are already paying above the new minimums so we have just shown the current contributions. These won't change unless your salary increases or you and/or your employer choose to pay more. |
+
+    @welsh
+    Examples:
+      | message |
+      | Rydych chi a'ch cyflogwr eisoes yn talu mwy na'r isafswm newydd, felly rydym wedi dangos y cyfraniadau cyfredol yn unig. Ni fydd y rhain yn newid oni bai bod eich cyflog yn cynyddu neu rydych chi ac/neu eich cyflogwr yn dewis talu mwy. |
+
+  Scenario Outline: Employee and Employer contributions are greater than the minimum for 2018 but NOT for 2019
+    Given I fill in my contributions:
+      | your_contribution | employer_contribution |
+      | 4                 | 2.5                   |
+    When I move on to the results page
+    Then I should see a contribution explanation "<message>"
+
+    Examples:
+      | message |
+      | Both you and your employer are already paying above the new minimum for April 2018 so we have only shown the increase for April 2019. |
+
+    @welsh
+    Examples:
+      | message |
+      | Rydych chi a'ch cyflogwr eisoes yn talu mwy na'r isafswm newydd ar gyfer Ebrill 2018 felly rydym wedi dangos y cynnydd ar gyfer Ebrill 2019 yn unig. |
+
+  Scenario Outline: Only Employee contribution is greater than the minimum for 2018 AND 2019
+    Given I fill in my contributions:
+      | your_contribution | employer_contribution |
+      | 6                 | 1                     |
+    When I move on to the results page
+    Then I should see a contribution explanation "<message>"
+
+    Examples:
+      | message |
+      | You are already paying above the new minimums so we have just shown how your employer's contributions will increase. Your contributions won't change unless your salary increases or you choose to pay more. |
+
+    @welsh
+    Examples:
+      | message |
+      | Rydych chi eisoes yn talu mwy na'r isafswm newydd, felly rydym wedi dangos sut fydd cyfraniadau eich cyflogwr yn cynyddu yn unig. Ni fydd eich cyfraniadau yn newid oni bai bod eich cyflog yn cynyddu neu os ydych yn dewis talu mwy. |
+
+  Scenario Outline: Only Employer contribution is greater than the minimum for 2018 AND 2019
+    Given I fill in my contributions:
+      | your_contribution | employer_contribution |
+      | 1                 | 3.1                   |
+    When I move on to the results page
+    Then I should see a contribution explanation "<message>"
+
+    Examples:
+      | message |
+      | Your employer is already paying above the new minimums so we have just shown how your contributions will increase. Your employer's contribution won't change unless your salary increases or your employer chooses to pay more. |
+
+    @welsh
+    Examples:
+      | message |
+      | Mae eich cyflogwr eisoes yn talu mwy na'r isafswm newydd, felly rydym wedi dangos sut fydd eich cyfraniadau chi yn cynyddu yn unig. Ni fydd cyfraniad eich cyflogwr yn newid oni bai bod eich cyflog yn cynyddu neu rydych chi neu eich cyflogwr yn dewis talu mwy. |

--- a/features/step_definitions/your_contributions_steps.rb
+++ b/features/step_definitions/your_contributions_steps.rb
@@ -59,6 +59,6 @@ Then(/^I should return to the Your Contributions step$/) do
 end
 
 Then(/^I should see my current contributions in the form fields$/) do
-  expect(your_contributions_page.employee_percent.value).to eq('14')
-  expect(your_contributions_page.employer_percent.value).to eq('15')
+  expect(your_contributions_page.employee_percent.value).to eq('14.0')
+  expect(your_contributions_page.employer_percent.value).to eq('15.0')
 end

--- a/features/step_definitions/your_results_steps.rb
+++ b/features/step_definitions/your_results_steps.rb
@@ -146,3 +146,7 @@ Then(/^I should see the values on the results page as:$/) do |table|
   step %{I should see my employer contributions for third period as "#{third_period[3]}"}
   step %{I should see my total contributions for third period as "#{third_period[4]}"}
 end
+
+Then(/^I should see a contribution explanation "([^"]*)"$/) do |message|
+  expect(your_results_page.description.first).to have_content(message)
+end

--- a/features/support/ui/your_results.rb
+++ b/features/support/ui/your_results.rb
@@ -16,6 +16,7 @@ module UI
     element :percent_input, '.contributions__source-input'
     element :your_contributions_edit, '.contributions__heading a'
     element :your_contributions_information, '.section--contributions .section__heading-summary'
+    elements :description, '.results__content p'
 
     element :salary_frequencies, "select[name='salary_frequency']"
     element :recalculate_button, "input[type='submit']"

--- a/spec/models/contributions_calendar_spec.rb
+++ b/spec/models/contributions_calendar_spec.rb
@@ -4,18 +4,21 @@ describe Wpcc::ContributionsCalendar, type: :model do
   let(:contributions_calendar) do
     described_class.new(
       eligible_salary: eligible_salary,
-      employee_percent: employee_percent,
-      employer_percent: employer_percent,
-      salary_frequency: salary_frequency
+      salary_frequency: salary_frequency,
+      periods: periods
     )
   end
 
   let(:eligible_salary) { 0 }
-  let(:employee_percent) { 0 }
-  let(:employer_percent) { 0 }
   let(:salary_frequency) { 1 }
 
   describe '#schedule' do
+    let(:periods) do
+      Wpcc::PeriodFilter.new(
+        user_input_employee_percent: 1,
+        user_input_employer_percent: 2
+      ).periods
+    end
     let(:period_contribution_calculator) do
       double('PeriodContributionCalculator')
     end
@@ -31,6 +34,7 @@ describe Wpcc::ContributionsCalendar, type: :model do
     end
 
     describe 'creates PeriodContribution objects for each period' do
+      let(:periods) { [next_period] }
       let(:next_period) do
         double(
           name: 'some_period',
@@ -38,12 +42,6 @@ describe Wpcc::ContributionsCalendar, type: :model do
           employee_percent: 3,
           employer_percent: 4
         )
-      end
-
-      before do
-        allow(contributions_calendar)
-          .to receive(:filtered_periods)
-          .and_return([next_period])
       end
 
       it 'calls the PeriodContributionCalculator passing the percentages' do
@@ -64,42 +62,6 @@ describe Wpcc::ContributionsCalendar, type: :model do
 
         schedule
       end
-    end
-  end
-
-  describe '#periods' do
-    let(:period_filter) { double(Wpcc::PeriodFilter) }
-
-    it 'converts the data in the config file to PeriodContribution objects' do
-      expect(Wpcc::PeriodFilter)
-        .to receive(:new)
-        .with(
-          user_input_employee_percent: 0,
-          user_input_employer_percent: 0
-        )
-        .and_return(period_filter)
-
-      expect(period_filter).to receive(:periods)
-
-      contributions_calendar.periods
-    end
-  end
-
-  describe '#filtered_periods' do
-    let(:period_filter) { double(Wpcc::PeriodFilter) }
-
-    it 'calls the PeriodFilter to get the periods required for scheduling' do
-      expect(Wpcc::PeriodFilter)
-        .to receive(:new)
-        .with(
-          user_input_employee_percent: 0,
-          user_input_employer_percent: 0
-        )
-        .and_return(period_filter)
-
-      expect(period_filter).to receive(:filtered_periods)
-
-      contributions_calendar.filtered_periods
     end
   end
 end

--- a/spec/presenters/period_filter_presenter_spec.rb
+++ b/spec/presenters/period_filter_presenter_spec.rb
@@ -1,0 +1,77 @@
+RSpec.describe Wpcc::PeriodFilterPresenter do
+  subject(:presenter) do
+    described_class.new(object, view_context: context)
+  end
+
+  let(:object) do
+    Wpcc::PeriodFilter.new(
+      user_input_employee_percent: user_input_employee_percent,
+      user_input_employer_percent: user_input_employer_percent
+    )
+  end
+
+  let(:context) { ActionController::Base.new.view_context }
+
+  describe '#contribution_percents_explanation' do
+    subject(:contribution_percents_explanation) do
+      presenter.contribution_percents_explanation
+    end
+
+    context 'when user inputs are less than legal minimums' do
+      let(:user_input_employee_percent) { 1 }
+      let(:user_input_employer_percent) { 1 }
+
+      it 'returns nil' do
+        expect(contribution_percents_explanation).to be_nil
+      end
+    end
+
+    context 'when user inputs are greater than ALL legal minimums' do
+      let(:user_input_employee_percent) { 6 }
+      let(:user_input_employer_percent) { 4 }
+
+      it 'returns message' do
+        expect(contribution_percents_explanation).to eq(
+          I18n.t('wpcc.results.large_contribution_percent_for_two_periods')
+        )
+      end
+    end
+
+    context 'when user inputs are between 2nd and 3rd period legal minimums' do
+      let(:user_input_employee_percent) { 4 }
+      let(:user_input_employer_percent) { 2.5 }
+
+      it 'returns message' do
+        expect(contribution_percents_explanation).to eq(
+          I18n.t('wpcc.results.large_contribution_percent_for_middle_period')
+        )
+      end
+    end
+
+    context 'when user employee percent is greater than legal minimums' do
+      let(:user_input_employee_percent) { 6 }
+      let(:user_input_employer_percent) { 1 }
+
+      it 'returns message' do
+        expect(contribution_percents_explanation).to eq(
+          I18n.t(
+            'wpcc.results.employee_large_contribution_percent_for_two_periods'
+          )
+        )
+      end
+    end
+
+    context 'when user employer percent is greater than legal minimums' do
+      let(:user_input_employee_percent) { 1 }
+      let(:user_input_employer_percent) { 4 }
+
+      it 'returns message' do
+        expect(contribution_percents_explanation).to eq(
+          I18n.t(
+            'wpcc.results.employer_large_contribution_percent_for_two_periods'
+          )
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
This pr addresses [TP User Story 8506](https://moneyadviceservice.tpondemand.com/restui/board.aspx?acid=ddd7f3a626844ab8d1bee3f06ec28efa#page=board/5624876525867731357&appConfig=eyJhY2lkIjoiREI4ODcwRjkxMDNDRTM2NTlBMzhDNTRBRTVBNUU1N0UifQ==&searchPopup=UserStory/8506).
### Objective
Additional messages need to be displayed on the results page to explain to the user how his results are calculated. These messages will vary depending on what he inputs for contribution percents.

### Technical
* Expose the PeriodFilter to the view
* Create an additional presenter which gives us access to the user input contribution percents.
* Convert the percents to floats instead of integers
* There is one complex method which is used to display the correct message which we tried to refactor and abstract from the view.