### PR TITLE
Fixes the issue with the global nav not being full width at full screen

### DIFF
--- a/app/assets/stylesheets/wpcc/application.scss
+++ b/app/assets/stylesheets/wpcc/application.scss
@@ -20,10 +20,6 @@ $responsive: true;
 @import 'yeast/assets/base/reset';
 @import 'yeast/assets/base/type';
 
-// Layout
-@import 'yeast/assets/layout/common/constrained';
-@import 'yeast/assets/layout/common/tool';
-
 // Dough Theme Components
 @import 'yeast/assets/components/dough_theme/form/form';
 @import 'yeast/assets/components/dough_theme/field_help_text/field_help_text';


### PR DESCRIPTION
This is being caused because we are using the layout and tool CSS from yeast within the project, this is so we could preview the spacing and layout in the dummy app.  Sounds great but means that one of our required class attributes were being overwritten by some css being delivered *after* those in frontend.

| Before |
|--------|
|<img width="1405" alt="before" src="https://user-images.githubusercontent.com/13165846/29670812-c47d006c-88df-11e7-8cb6-09a845882ef8.png">|

|After |
|-----|
|<img width="1440" alt="after" src="https://user-images.githubusercontent.com/13165846/29670834-d52f2c8c-88df-11e7-8a59-38a70b967965.png">|

