### PR TITLE
[DEV APPROVED] TP: 8213, Comment: Adds email component

### DIFF
--- a/app/assets/javascripts/wpcc/components/Email.js
+++ b/app/assets/javascripts/wpcc/components/Email.js
@@ -1,0 +1,88 @@
+define(['jquery', 'DoughBaseComponent'], function($, DoughBaseComponent) {
+  'use strict';
+
+  var Email,
+    defaultConfig = {
+      i18nStrings: {
+        detailsHeading: 'Your details',
+        contributionsHeading: 'Your contributions',
+        resultsHeading: 'Your Results',
+        qualifyingEarningsHeading: 'Qualifying earnings'
+      }
+    };
+
+  Email = function($el, config) {
+    Email.baseConstructor.call(this, $el, config, defaultConfig);
+
+    this.$emailLink = this.$el.find('[data-dough-email-link]');
+    this.$detailsHeadingSummary = this.$el.find('[data-dough-details-heading-summary]');
+    this.$contributionsHeadingSummary = this.$el.find('[data-dough-contributions-heading-summary]');
+    this.$eligibleSalary = this.$el.find('[data-dough-eligible-salary]');
+    this.$resultsTables = this.$el.find('[data-dough-results-table]');
+    this.$frequencySelector = this.$el.find('[data-dough-selector]');
+  };
+
+  /**
+  * Inherit from base module, for shared methods and interface
+  */
+  DoughBaseComponent.extend(Email);
+
+  Email.componentName = 'Email';
+
+  Email.prototype.init = function(initialised) {
+    if (this.$emailLink.length > 0) {
+      this._initialisedSuccess(initialised);
+      this._setUpEvents();
+    }
+  };
+
+  Email.prototype._setUpEvents = function() {
+    var _this = this;
+
+    this._setUpLink();
+    this.$frequencySelector.change(function() {
+      _this._setUpLink();
+    });
+  }
+
+  Email.prototype._setUpLink = function() {
+    var message = this._getMessage();
+    var href = 'mailto:?body=' + message;
+
+    this.$emailLink.prop('href', href);
+  }
+
+  Email.prototype._getMessage = function() {
+    var message = '';
+    var i18nStrings = this.config.i18nStrings;
+
+    message += '1. ' + i18nStrings.detailsHeading + ': ' + this.$detailsHeadingSummary.text().trim() + '\n\n';
+    message += '2. ' + i18nStrings.contributionsHeading + ': ' + this.$contributionsHeadingSummary.text().trim() + '\n\n';
+    message += '3. ' + i18nStrings.resultsHeading + '\n';
+    message += i18nStrings.qualifyingEarningsHeading + ': ' + this.$eligibleSalary.text().trim() + '\n\n';
+
+    for (var i = 0, max = this.$resultsTables.length; i < max; i++) {
+      var resultTable = this.$resultsTables[i];
+
+      message += $(resultTable).find('[data-dough-results-period-title]').text().trim() + '\n';
+      message +=
+        $(resultTable).find('[data-dough-period-heading-yours]').text().trim() + ': ' +
+        $(resultTable).find('[data-dough-employee-contribution]').text().trim() + ' ' +
+        $(resultTable).find('[data-dough-tax-relief]').text().trim() + '\n';
+      message +=
+        $(resultTable).find('[data-dough-period-heading-employers]').text().trim() + ': ' +
+        $(resultTable).find('[data-dough-employer-contribution]').text().trim() + '\n';
+      message +=
+        $(resultTable).find('[data-dough-period-heading-total]').text().trim() + ': ' +
+        $(resultTable).find('[data-dough-total]').text().trim();
+
+      if (i !== max - 1) {
+        message += '\n\n';
+      }
+    }
+
+    return encodeURIComponent(message);
+  }
+
+  return Email;
+});

--- a/app/assets/javascripts/wpcc/require_config.js.erb
+++ b/app/assets/javascripts/wpcc/require_config.js.erb
@@ -13,6 +13,7 @@
 //= depend_on_asset wpcc/components/SalaryConditions
 //= depend_on_asset wpcc/components/ContributionConditions
 //= depend_on_asset wpcc/components/UpdateResults
+//= depend_on_asset wpcc/components/Email
 
 <%
   def requirejs_path(asset)
@@ -36,7 +37,8 @@
       ConditionalMessaging: requirejs_path('wpcc/components/ConditionalMessaging'),
       SalaryConditions: requirejs_path('wpcc/components/SalaryConditions'),
       ContributionConditions: requirejs_path('wpcc/components/ContributionConditions'),
-      UpdateResults: requirejs_path('wpcc/components/UpdateResults')
+      UpdateResults: requirejs_path('wpcc/components/UpdateResults'),
+      Email: requirejs_path('wpcc/components/Email')
     }
   }
 %>

--- a/app/views/layouts/wpcc/engine.html.erb
+++ b/app/views/layouts/wpcc/engine.html.erb
@@ -12,7 +12,17 @@
     <div class="l-container-tool">
       <div class="wpcc">
         <h1><%= t('wpcc.title') %></h1>
-        <main>
+        <main
+          data-dough-component="Email"
+          data-dough-email-config='{
+            "i18nStrings": {
+              "detailsHeading": "<%= t('wpcc.details.title') %>",
+              "contributionsHeading": "<%= t('wpcc.contributions.title') %>",
+              "resultsHeading": "<%= t('wpcc.results.title') %>",
+              "qualifyingEarningsHeading": "<%= t('wpcc.details.calculate.qualifying_earnings_title') %>"
+            }
+          }'
+        >
           <p class="wpcc__intro"><%= t('wpcc.intro') %></p>
           <%= yield %>
         </main>

--- a/app/views/wpcc/shared/_your_details.html.erb
+++ b/app/views/wpcc/shared/_your_details.html.erb
@@ -1,6 +1,6 @@
 <section class="section section--details details">
   <h2 class="section__heading details__heading">1. <%= t('wpcc.details.title') %>
-    <span class="section__heading-summary"><%= message_presenter.your_details_summary(session) %></span>
+    <span class="section__heading-summary" data-dough-details-heading-summary><%= message_presenter.your_details_summary(session) %></span>
     <span>
       <%= link_to(t('wpcc.edit'), new_your_detail_path, class: 'section__heading-edit') %>
     </span>

--- a/app/views/wpcc/your_results/_contributions_table.html.erb
+++ b/app/views/wpcc/your_results/_contributions_table.html.erb
@@ -1,9 +1,8 @@
 <div class="results__row">
   <% schedule.each do |period| %>
     <div class="results__period results__period-<%= period.name %>" data-dough-component="PopupTip" data-dough-results-table>
-      <h3 class="results__period-title"><%= period.title %></h3>
-      
-      <p class="results__period-heading">
+      <h3 class="results__period-title" data-dough-results-period-title><%= period.title %></h3>
+      <p class="results__period-heading" data-dough-period-heading-yours>
         <%= t('wpcc.results.period.contribution_heading.yours', salary_frequency: salary_frequency.to_adj) %>
       </p>
       <p class="results__period-details results__period-employee-contribution" data-dough-employee-contribution data-value="<%= period.employee_contribution %>">
@@ -23,14 +22,13 @@
         </p>
         <%= render 'wpcc/tooltips/close' %>
       </div>
-      <p class="results__period-heading">
+      <p class="results__period-heading" data-dough-period-heading-employers>
         <%= period.employer_frequency_heading(salary_frequency) %>
       </p>
       <p class="results__period-details results__period-employer-contribution" data-dough-employer-contribution data-value="<%= period.employer_contribution %>">
         <%= period.formatted_employer_contribution %>
-
       </p>
-      <p class="results__period-heading">
+      <p class="results__period-heading" data-dough-period-heading-total>
         <%= t('wpcc.results.period.contribution_heading.total', salary_frequency: salary_frequency.to_adj) %>
       </p>
       <p class="results__period-details results__period-total-contributions" data-dough-total>

--- a/app/views/wpcc/your_results/index.html.erb
+++ b/app/views/wpcc/your_results/index.html.erb
@@ -2,11 +2,7 @@
 
 <section class="section section--contributions">
   <h2 class="section__heading contributions__heading">2. <%= t('wpcc.contributions.title') %>
-    <span class="section__heading-summary">
-      <%= t('wpcc.results.contribution_changes.you') %>: 
-      <%= session[:employee_percent] %>%, 
-      <%= t('wpcc.results.contribution_changes.employer') %>: <%= session[:employer_percent] %>%
-    </span>
+    <span class="section__heading-summary" data-dough-contributions-heading-summary><%= t('wpcc.results.contribution_changes.you') %>: <%= session[:employee_percent] %>%, <%= t('wpcc.results.contribution_changes.employer') %>: <%= session[:employer_percent] %>%</span>
     <span>
       <%= link_to(t('wpcc.edit'), new_your_contribution_path, class: 'section__heading-edit') %>
     </span>
@@ -22,7 +18,7 @@
     data-dough-update-results-config='{"i18nStrings": {"parentheses": "<%= t('wpcc.results.period.tax_relief_parentheses') %>"}}'
   >
     <p>
-      <%= t('wpcc.results.description', eligible_salary: message_presenter.formatted_currency(session[:eligible_salary], precision: 0)) %>
+      <%= t('wpcc.results.description_html', eligible_salary: message_presenter.formatted_currency(session[:eligible_salary], precision: 0)) %>
       <%= period_filter_presenter.contribution_percents_explanation %>
     </p>
 
@@ -37,6 +33,7 @@
     <%= render 'period_percents_table' %>
 
     <p><a href="#" data-dough-component="Print"><%= t('wpcc.results.print_link') %></a></p>
+    <p><a href="mailto:?body=" data-dough-email-link><%= t('wpcc.results.email_link') %></a></p>
     <p><%= link_to(t('wpcc.results.reset_calculator'), your_detail_path(session), method: :delete) %></p>
   </div>
 

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -106,10 +106,10 @@ cy:
 
     results:
       title: Eich canlyniadau
-      description: |
+      description_html: |
         Bydd cyfraddau cyfraniadau pensiwn isaf yn cynyddu yn Ebrill 2018 ac eto yn Ebrill 2019.
         Bydd y ffigyrau hyn yn dangos sut y bydd hyn yn effeithio ar eich cyfraniadau.
-        Bydd cyfraniadau yn seiliedig ar eich enillion o %{eligible_salary} y flwyddyn.
+        Bydd cyfraniadau yn seiliedig ar eich enillion o <span data-dough-eligible-salary>%{eligible_salary}</span> y flwyddyn.
       large_contribution_percent_for_two_periods:
         Rydych chi a'ch cyflogwr eisoes yn talu mwy na'r isafswm newydd, felly rydym wedi dangos y cyfraniadau cyfredol yn unig. Ni fydd y rhain yn newid oni bai bod eich cyflog yn cynyddu neu rydych chi ac/neu eich cyflogwr yn dewis talu mwy.
       large_contribution_percent_for_middle_period:
@@ -138,8 +138,9 @@ cy:
       tax_relief_tooltip_html: Byddwch yn cael gostyngiad treth ar eich cyfraniadau pensiwn sy'n golygu y rhoddir peth o’r arian o'ch cyflog a fyddai wedi mynd i’r llywodraeth fel treth tuag at eich pensiwn yn hytrach. <a href="https://www.moneyadviceservice.org.uk/cy/articles/gostyngiad-treth-ar-gyfraniadau-pensiwn">Darllenwch fwy am sut i gael gostyngiad treth</a>.
       contribution_table_link: Darllen tabl sy’n dangos sut mae isafswm cyfraniadau cyfreithlon yn newid
       print_link: Argraffu eich canlyniadau
+      email_link: E-bostio eich canlyniadau
       reset_calculator: Ailosod y gyfrifiannell
-      next_steps: 
+      next_steps:
         heading: Y Camau Nesaf
         list:
           pension_calculator_html: Defnyddiwch ein <a href="https://www.moneyadviceservice.org.uk/cy/tools/cyfrifiannell-pensiwn">Cyfrifiannell Pensiwn</a> i weld faint o bensiwn y bydd eich cronfa yn ei chronni dros amser.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -106,10 +106,10 @@ en:
 
     results:
       title: Your Results
-      description: |
+      description_html: |
         Minimum pension contribution rates will increase in April 2018 and again in April 2019.
         These figures show how this will affect your contributions.
-        Contributions will be based on your earnings of %{eligible_salary} a year.
+        Contributions will be based on your earnings of <span data-dough-eligible-salary>%{eligible_salary}</span> a year
       large_contribution_percent_for_two_periods:
         "Both you and your employer are already paying above the new minimums so we have just shown the current contributions. These won't change unless your salary increases or you and/or your employer choose to pay more."
       large_contribution_percent_for_middle_period:
@@ -137,6 +137,7 @@ en:
       tax_relief_tooltip_html: You get tax relief on pension contributions which means some of the money from your pay that would have gone to the government as tax goes towards your pension instead. <a href="https://www.moneyadviceservice.org.uk/en/articles/tax-relief-on-pension-contributions">Read more about how you get tax relief</a>.
       contribution_table_link: View a table of how legal minimum contributions change
       print_link: Print your results
+      email_link: Email your results
       reset_calculator: Reset the calculator
       next_steps:
         heading: Next steps

--- a/spec/javascripts/fixtures/Email.html
+++ b/spec/javascripts/fixtures/Email.html
@@ -1,0 +1,61 @@
+<div>
+  <main data-dough-component="Email">
+    <section>
+      <h2 class="details__heading">1. Your details
+        <span class="section__heading-summary" data-dough-details-heading-summary>31 years, male, £50,000 per year, part salary</span>
+      </h2>
+    </section>
+
+    <section>
+      <h2 class="contributions__heading">2. Your contributions
+        <span class="section__heading-summary" data-dough-contributions-heading-summary>You: 1%, Your employer: 1%</span>
+      </h2>
+    </section>
+
+    <section class="section--results">
+      <h2 class="results__heading">3. Your Results</h2>
+      <div class="results__content">
+        <p>Minimum pension contribution rates will increase in April 2018 and again in April 2019. These figures show how this will affect your contributions. Contributions will be based on your earnings of <span data-dough-eligible-salary>£39,124</span> a year</p>
+
+        <div class="results__row">
+          <div>
+            <div data-dough-results-table>
+              <h3 data-dough-results-period-title>Now</h3>
+              <p data-dough-period-heading-yours>Your contribution</p>
+              <p data-dough-employee-contribution data-employee-contribution="">£32.60</p>
+              <p data-dough-tax-relief data-tax-relief="">(includes tax relief of £6.52)</p>
+              <p data-dough-period-heading-employers>Employer's contribution</p>
+              <p data-dough-employer-contribution data-employer-contribution="">£32.60</p>
+              <p data-dough-period-heading-total="">Total contributions</p>
+              <p data-dough-total>£65.20</p>
+            </div>
+
+            <div data-dough-results-table>
+              <h3 data-dough-results-period-title>April 2018 - March 2019</h3>
+              <p data-dough-period-heading-yours>Your contribution</p>
+              <p data-dough-employee-contribution data-employee-contribution="">£97.81</p>
+              <p data-dough-tax-relief data-tax-relief="">(includes tax relief of £19.56)</p>
+              <p data-dough-period-heading-employers>Employer's contribution</p>
+              <p data-dough-employer-contribution data-employer-contribution="">£65.21</p>
+              <p data-dough-period-heading-total="">Total contributions</p>
+              <p data-dough-total>£163.02</p>
+            </div>
+
+            <div data-dough-results-table>
+              <h3 data-dough-results-period-title>April 2019 onwards</h3>
+              <p data-dough-period-heading-yours>Your contribution</p>
+              <p data-dough-employee-contribution data-employee-contribution="">£163.02</p>
+              <p data-dough-tax-relief data-tax-relief="">(includes tax relief of £32.60)</p>
+              <p data-dough-period-heading-employers>Employer's contribution</p>
+              <p data-dough-employer-contribution data-employer-contribution="">£97.81</p>
+              <p data-dough-period-heading-total="">Total contributions</p>
+              <p data-dough-total>£260.83</p>
+            </div>
+          </div>
+        </div>
+
+        <p><a href="" data-dough-email-link>Email your results</a></p>
+      </div>
+    </section>
+  </main>
+</div>

--- a/spec/javascripts/test-main.js
+++ b/spec/javascripts/test-main.js
@@ -36,6 +36,7 @@ require.config({
     ConditionalMessaging: 'app/assets/javascripts/wpcc/components/ConditionalMessaging',
     SalaryConditions: 'app/assets/javascripts/wpcc/components/SalaryConditions',
     ContributionConditions: 'app/assets/javascripts/wpcc/components/ContributionConditions',
-    UpdateResults: 'app/assets/javascripts/wpcc/components/UpdateResults'
+    UpdateResults: 'app/assets/javascripts/wpcc/components/UpdateResults',
+    Email: 'app/assets/javascripts/wpcc/components/Email'
   }
 })

--- a/spec/javascripts/tests/Email_spec.js
+++ b/spec/javascripts/tests/Email_spec.js
@@ -1,0 +1,55 @@
+describe('Email', function() {
+  'use strict';
+
+  beforeEach(function(done) {
+    var _this = this;
+
+    requirejs(
+      ['jquery', 'Email'],
+      function($, Email) {
+        _this.$html = $(window.__html__['spec/javascripts/fixtures/Email.html']).appendTo('body');
+        _this.component = _this.$html.find('[data-dough-component="Email"]');
+        _this.email = Email;
+        _this.obj = new _this.email(_this.component);
+
+        _this.$emailLink = _this.component.find('[data-dough-email-link]');
+
+        done();
+    }, done);
+  });
+
+  afterEach(function() {
+    this.$html.remove();
+  });
+
+  describe('Creates email link href from results', function() {
+    beforeEach(function() {
+      this.obj.init();
+    });
+
+    it('Tests the email link is correct', function() {
+      var message = '';
+
+      message += '1. Your details: 31 years, male, £50,000 per year, part salary\n\n';
+      message += '2. Your contributions: You: 1%, Your employer: 1%\n\n';
+      message += '3. Your Results\n';
+      message += 'Qualifying earnings: £39,124\n\n';
+      message += 'Now\n';
+      message += 'Your contribution: £32.60 (includes tax relief of £6.52)\n';
+      message += 'Employer\'s contribution: £32.60\n';
+      message += 'Total contributions: £65.20\n\n';
+      message += 'April 2018 - March 2019\n';
+      message += 'Your contribution: £97.81 (includes tax relief of £19.56)\n';
+      message += 'Employer\'s contribution: £65.21\n';
+      message += 'Total contributions: £163.02\n\n';
+      message += 'April 2019 onwards\n';
+      message += 'Your contribution: £163.02 (includes tax relief of £32.60)\n';
+      message += 'Employer\'s contribution: £97.81\n';
+      message += 'Total contributions: £260.83';
+
+      var href = 'mailto:?body=' + encodeURIComponent(message);
+
+      expect(this.$emailLink.prop('href')).to.equal(href);
+    });
+  });
+});


### PR DESCRIPTION
This creates the component specified in [TP8213](https://moneyadviceservice.tpondemand.com/RestUI/Board.aspx?acid=6C17D8319C81AC3D36AFAD64CAE08A28#page=userstory/8507&appConfig=eyJhY2lkIjoiREI4ODcwRjkxMDNDRTM2NTlBMzhDNTRBRTVBNUU1N0UifQ==&searchPopup=userstory/8213) which gives the user the ability to email their results via a mail client. 

On the results page a link is added: 

![image](https://user-images.githubusercontent.com/6080548/29664370-402c9ab0-88c7-11e7-9f41-b880018d58d7.png)

This launches the user's mail client pre-populated with the results:

![image](https://user-images.githubusercontent.com/6080548/29664425-6c67b380-88c7-11e7-9779-b1ae917c35d9.png)
