### PR TITLE
[DEV APPROVED] 8408 Reset the calculator

### DIFF
--- a/app/controllers/wpcc/your_details_controller.rb
+++ b/app/controllers/wpcc/your_details_controller.rb
@@ -2,6 +2,8 @@ module Wpcc
   class YourDetailsController < EngineController
     protect_from_forgery
 
+    before_action SessionResetter, only: :destroy
+
     def new
       @your_details_form = present(Wpcc::YourDetailsForm.new(session_params))
     end
@@ -18,6 +20,8 @@ module Wpcc
         render 'new'
       end
     end
+
+    def destroy; end
 
     private
 

--- a/app/filters/wpcc/session_resetter.rb
+++ b/app/filters/wpcc/session_resetter.rb
@@ -1,0 +1,8 @@
+module Wpcc
+  class SessionResetter < SessionExpirer
+    def filter
+      expire_wpcc_session
+      controller.redirect_to controller.new_your_detail_path
+    end
+  end
+end

--- a/app/views/wpcc/your_results/index.html.erb
+++ b/app/views/wpcc/your_results/index.html.erb
@@ -37,6 +37,7 @@
     <%= render 'period_percents_table' %>
 
     <p><a href="#" data-dough-component="Print"><%= t('wpcc.results.print_link') %></a></p>
+    <p><%= link_to(t('wpcc.results.reset_calculator'), your_detail_path(session), method: :delete) %></p>
   </div>
 
   <div class="next-steps">

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -138,6 +138,7 @@ cy:
       tax_relief_tooltip_html: Byddwch yn cael gostyngiad treth ar eich cyfraniadau pensiwn sy'n golygu y rhoddir peth o’r arian o'ch cyflog a fyddai wedi mynd i’r llywodraeth fel treth tuag at eich pensiwn yn hytrach. <a href="https://www.moneyadviceservice.org.uk/cy/articles/gostyngiad-treth-ar-gyfraniadau-pensiwn">Darllenwch fwy am sut i gael gostyngiad treth</a>.
       contribution_table_link: Darllen tabl sy’n dangos sut mae isafswm cyfraniadau cyfreithlon yn newid
       print_link: Argraffu eich canlyniadau
+      reset_calculator: Ailosod y gyfrifiannell
       next_steps: 
         heading: Y Camau Nesaf
         list:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -137,6 +137,7 @@ en:
       tax_relief_tooltip_html: You get tax relief on pension contributions which means some of the money from your pay that would have gone to the government as tax goes towards your pension instead. <a href="https://www.moneyadviceservice.org.uk/en/articles/tax-relief-on-pension-contributions">Read more about how you get tax relief</a>.
       contribution_table_link: View a table of how legal minimum contributions change
       print_link: Print your results
+      reset_calculator: Reset the calculator
       next_steps:
         heading: Next steps
         list:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Wpcc::Engine.routes.draw do
-  resources :your_details, only: %i[new create]
+  resources :your_details, only: %i[new create destroy]
   resources :your_contributions, only: %i[new create]
   resources :your_results, only: %i[index]
 

--- a/features/_your_results/reset_calculator.feature
+++ b/features/_your_results/reset_calculator.feature
@@ -1,0 +1,11 @@
+Feature: Reset the calculator
+  In order that another user can not see my inputs,
+  As a user working on a shared machine using the WPCC tool,
+  I want to be able to clear my inputs of sensitive information (e.g. salary)
+
+  Scenario:
+    Given I have valid details
+    And I have valid contributions
+    When I click the reset the calculator button
+    Then I should return to the Your Details step
+    And The form should be reset to its default values

--- a/features/step_definitions/your_details_steps.rb
+++ b/features/step_definitions/your_details_steps.rb
@@ -186,3 +186,11 @@ end
 Then(/^I should see the salary below threshold "([^"]*)"$/) do |callout_message|
   expect(your_details_page.salary_below_threshold_callout).to have_content(callout_message)
 end
+
+Then(/^The form should be reset to its default values$/) do
+  expect(your_details_page.age.value).to be_nil
+  expect(your_details_page.genders.value).to eq("")
+  expect(your_details_page.salary.value).to be_nil
+  expect(your_details_page.salary_frequencies.value).to eq('year')
+  expect(your_details_page.minimum_contribution_button).to be_truthy
+end

--- a/features/step_definitions/your_results_steps.rb
+++ b/features/step_definitions/your_results_steps.rb
@@ -23,6 +23,10 @@ When(/^I press recalculate$/) do
   your_results_page.recalculate_button.click
 end
 
+When(/^I click the reset the calculator button$/) do
+  your_results_page.reset_calculator_link.click
+end
+
 Then(/^I should see "([^"]*)" in the Recalculate Salary Frequency selector dropdown$/) do |selected_frequency|
   expect(your_results_page).to have_select('salary_frequency', selected: selected_frequency)
 end

--- a/features/support/ui/your_results.rb
+++ b/features/support/ui/your_results.rb
@@ -20,6 +20,7 @@ module UI
 
     element :salary_frequencies, "select[name='salary_frequency']"
     element :recalculate_button, "input[type='submit']"
+    element :reset_calculator_link, "a", text: "Reset the calculator"
 
     element :legal_contributions_table_link, 'p.contribution-changes__trigger'
     elements :percent_table_headings, 'table.contribution-changes__table th'

--- a/spec/filters/session_resetter_spec.rb
+++ b/spec/filters/session_resetter_spec.rb
@@ -1,0 +1,36 @@
+RSpec.describe Wpcc::SessionResetter do
+  describe '#filter' do
+    subject(:filter) { described_class.new(controller).filter }
+    let(:controller) { double(session: session) }
+    let(:session) do
+      {
+        'age' => 34,
+        'salary' => 30_000,
+        'gender' => 'female',
+        'salary_frequency' => 'month',
+        'contribution_preference' => 'full',
+        'eligible_salary' => 19_524,
+        'employee_percent' => 1,
+        'employer_percent' => 2
+      }
+    end
+
+    it 'expires the session and redirects to Step 1' do
+      expect(controller).to receive(:new_your_detail_path)
+      expect(controller).to receive(:redirect_to)
+
+      filter
+
+      expect(session.except(:wpcc_expires_at)).to eq(
+        'age' => nil,
+        'salary' => nil,
+        'gender' => nil,
+        'salary_frequency' => nil,
+        'contribution_preference' => nil,
+        'eligible_salary' => nil,
+        'employee_percent' => nil,
+        'employer_percent' => nil
+      )
+    end
+  end
+end


### PR DESCRIPTION
This pr addresses [TP User Story 8408](https://moneyadviceservice.tpondemand.com/restui/board.aspx?acid=ddd7f3a626844ab8d1bee3f06ec28efa#page=board/5624876525867731357&appConfig=eyJhY2lkIjoiREI4ODcwRjkxMDNDRTM2NTlBMzhDNTRBRTVBNUU1N0UifQ==&boardPopup=userstory/8408/silent).

### Objective
Give the user the option to clear the data he has input in the Step 1 form. If the user is using the tool on a shared machine it allows him to reset the form so any sensitive data can't be viewed by the next user. 

### Technical
* In the view, add a link which goes to the your_details_controller destroy action.
* Add a before filter, SessionResetter, to the your_details_controller destroy action.
* A new 'filter', SessionResetter, expires the session and redirects to the your_details new action.