### PR TITLE
Tidying markup

### DIFF
--- a/app/assets/stylesheets/wpcc/section/_details.scss
+++ b/app/assets/stylesheets/wpcc/section/_details.scss
@@ -3,7 +3,6 @@
   position: relative;
   clear: both;
 
-
   @include respond-to($mq-l) {
     @include column(8);
     margin: 0;
@@ -126,7 +125,5 @@
   background-color: $color-white;
   padding: $baseline-unit*6 $baseline-unit*2 $baseline-unit*2;
   display: block;
-  text-align: center;
-
-  
+  text-align: center;  
 }

--- a/app/assets/stylesheets/wpcc/section/_details.scss
+++ b/app/assets/stylesheets/wpcc/section/_details.scss
@@ -3,6 +3,7 @@
   position: relative;
   clear: both;
 
+
   @include respond-to($mq-l) {
     @include column(8);
     margin: 0;

--- a/app/views/wpcc/your_details/new.html.erb
+++ b/app/views/wpcc/your_details/new.html.erb
@@ -11,13 +11,11 @@
 
     <h2 class="section__heading details__heading">1. <%= t('wpcc.details.title') %></h2>
     <div class="details__content">
-
       <div class="details__row">
         <div class="details__error-summary">
           <%= f.errors_summary %>
         </div>
       </div>
-
       <div class="details__row" data-dough-component="PopupTip">
         <div class="details__field">
           <%= f.form_row :age do %>
@@ -81,35 +79,30 @@
           </div>
         </div>
       </div>
-      <div data-dough-component="SalaryConditions">
-        <div class="details__row" data-dough-component="PopupTip">
-          <div class="details__field">
-            <%= f.form_row :salary do %>
-              <div class="details__field-label">
-                <%= f.label :salary, t('wpcc.details.salary.label'), class: 'form__label-heading' %>
-                <%= render 'wpcc/tooltips/trigger' %>
-              </div>
-              <%= f.errors_for :salary %>
-              <%= f.errors_for :salary_frequency %>
-              <div class="details__salary">
-                <div class="details__salary-amount">
-                <%= f.text_field :salary,
-                  required: true,
-                  'data-dough-validation-empty': t('wpcc.details.salary.validation'),
-                  'data-dough-salary-input': true
-                %>
-                </div>
-                <div class="details__salary-frequency">
-                  <%= f.label :salary_frequency, t('wpcc.details.salary.frequency.label'), class: 'form__label-heading details__field-label visually-hidden' %>
 
-                <%= f.select(:salary_frequency, options_for_select(@your_details_form.salary_frequency_options, @your_details_form.salary_frequency), {}, {'data-dough-frequency-select': true}) %>
+      <div class="details__row" data-dough-component="SalaryConditions PopupTip">
+        <div class="details__field">
+          <%= f.form_row :salary do %>
+            <div class="details__field-label">
+              <%= f.label :salary, t('wpcc.details.salary.label'), class: 'form__label-heading' %>
+              <%= render 'wpcc/tooltips/trigger' %>
+            </div>
+            <%= f.errors_for :salary %>
+            <%= f.errors_for :salary_frequency %>
+            <div class="details__salary">
+              <div class="details__salary-amount">
+              <%= f.text_field :salary,
+                required: true,
+                'data-dough-validation-empty': t('wpcc.details.salary.validation'),
+                'data-dough-salary-input': true
+              %>
               </div>
-            <% end %>
-          </div>
-          <div data-dough-popup-container class="popup-tip__container details__helper">
-            <p data-dough-popup-content class="popup-tip__content"><%= t('wpcc.details.salary.tooltip') %></p>
-            <%= render 'wpcc/tooltips/close' %>
-          </div>
+              <div class="details__salary-frequency">
+                <%= f.label :salary_frequency, t('wpcc.details.salary.frequency.label'), class: 'form__label-heading details__field-label visually-hidden' %>
+              <%= f.select(:salary_frequency, options_for_select(@your_details_form.salary_frequency_options, @your_details_form.salary_frequency), {}, {'data-dough-frequency-select': true}) %>
+              </div>
+            </div>
+          <% end %>
           <div class="details__callouts">
             <div class="form__row details__callout details__callout--inactive" data-dough-callout-lt5876>
               <div class="callout">
@@ -123,52 +116,56 @@
             </div>
           </div>
         </div>
-        <div class="details__row" data-dough-component="PopupTip">
-         <fieldset>
-            <legend class="details__calculate-heading"><%= t('wpcc.details.calculate.legend') %></legend>
-            <p class="details__calculate-intro">
-              <%= t('wpcc.details.calculate.details_html_1') %>
-              <%= render 'wpcc/tooltips/trigger' %>
-              <%= t('wpcc.details.calculate.details_html_2') %>
-            </p>
-
-            <div data-dough-popup-container class="popup-tip__container details__helper details__helper--block">
-              <p data-dough-popup-content class="popup-tip__content">
-                <span class="details__helper-title--no-js">
-                  <%= t('wpcc.details.calculate.qualifying_earnings_title') %>:
-                </span>
-                <%= t(
-                  'wpcc.details.calculate.qualifying_earnings',
-                  formatted_upper_earnings: @your_details_form.formatted_upper_earnings,
-                  formatted_lower_earnings: @your_details_form.formatted_lower_earnings
-                  ) %>
-              </p>
-              <%= render 'wpcc/tooltips/close' %>
-            </div>
-
-            <div class="details__callouts">
-              <div class="form__row details__callout <%= @your_details_form.activate_disabled_callout %>" data-dough-callout-radio-disabled>
-                <div class="callout">
-                  <p><%= t('wpcc.details.callout__radiodisabled') %></p>
-                </div>
-              </div>
-            </div>
-            <div class="details__row details__row--group">
-              <%= f.form_row :contribution_preference do %>
-                <%= f.errors_for :contribution_preference %>
-                <div class="form__group-item details__calculate-item">
-                  <%= f.radio_button(:contribution_preference, 'minimum', class: 'details__calculate-item-select', 'data-dough-employer-part-radio': true) %>
-                  <%= f.label(:contribution_preference_minimum, t('wpcc.details.options.contribution_preference.minimum'), class: 'details__calculate-item-label') %>
-                </div>
-                <div class="form__group-item details__calculate-item">
-                  <%= f.radio_button(:contribution_preference, 'full', class: 'details__calculate-item-select', 'data-dough-employer-full-radio': true) %>
-                  <%= f.label(:contribution_preference_full, t('wpcc.details.options.contribution_preference.full'), class: 'details__calculate-item-label') %>
-                </div>
-              <% end %>
-            </div>
-          </fieldset>
+        <div data-dough-popup-container class="popup-tip__container details__helper">
+          <p data-dough-popup-content class="popup-tip__content"><%= t('wpcc.details.salary.tooltip') %></p>
+          <%= render 'wpcc/tooltips/close' %>
         </div>
       </div>
+
+      <div class="details__row" data-dough-component="PopupTip">
+        <fieldset>
+          <legend class="details__calculate-heading"><%= t('wpcc.details.calculate.legend') %></legend>
+          <p class="details__calculate-intro">
+            <%= t('wpcc.details.calculate.details_html_1') %>
+            <%= render 'wpcc/tooltips/trigger' %>
+            <%= t('wpcc.details.calculate.details_html_2') %>
+          </p>
+          <div data-dough-popup-container class="popup-tip__container details__helper details__helper--block">
+            <p data-dough-popup-content class="popup-tip__content">
+              <span class="details__helper-title--no-js">
+                <%= t('wpcc.details.calculate.qualifying_earnings_title') %>:
+              </span>
+              <%= t(
+                'wpcc.details.calculate.qualifying_earnings',
+                formatted_upper_earnings: @your_details_form.formatted_upper_earnings,
+                formatted_lower_earnings: @your_details_form.formatted_lower_earnings
+                ) %>
+            </p>
+            <%= render 'wpcc/tooltips/close' %>
+          </div>
+          <div class="details__callouts">
+            <div class="form__row details__callout <%= @your_details_form.activate_disabled_callout %>" data-dough-callout-radio-disabled>
+              <div class="callout">
+                <p><%= t('wpcc.details.callout__radiodisabled') %></p>
+              </div>
+            </div>
+          </div>
+          <div class="details__row details__row--group">
+            <%= f.form_row :contribution_preference do %>
+              <%= f.errors_for :contribution_preference %>
+              <div class="form__group-item details__calculate-item">
+                <%= f.radio_button(:contribution_preference, 'minimum', class: 'details__calculate-item-select', 'data-dough-employer-part-radio': true) %>
+                <%= f.label(:contribution_preference_minimum, t('wpcc.details.options.contribution_preference.minimum'), class: 'details__calculate-item-label') %>
+              </div>
+              <div class="form__group-item details__calculate-item">
+                <%= f.radio_button(:contribution_preference, 'full', class: 'details__calculate-item-select', 'data-dough-employer-full-radio': true) %>
+                <%= f.label(:contribution_preference_full, t('wpcc.details.options.contribution_preference.full'), class: 'details__calculate-item-label') %>
+              </div>
+            <% end %>
+          </div>
+        </fieldset>
+      </div>
+      
       <div class="details__row">
         <div class="details__field">
           <div class="form__row">

--- a/lib/wpcc/version.rb
+++ b/lib/wpcc/version.rb
@@ -2,7 +2,7 @@ module Wpcc
   module Version
     MAJOR = 1
     MINOR = 6
-    PATCH = 0
+    PATCH = 1
 
     STRING = [MAJOR, MINOR, PATCH].join('.')
   end


### PR DESCRIPTION
# Markup tidy

- Tidies the markup
- Corrects popuptip location for salary and contributions sections

Examples:

### No JS field help text in incorrect place

| Before | After |
|--------|------|
|![image](https://user-images.githubusercontent.com/13165846/29826262-c1f8f498-8cce-11e7-84e2-2ff1be95feea.png)|![image](https://user-images.githubusercontent.com/13165846/29826214-9ddc7a3a-8cce-11e7-903b-75664f424a9a.png)|

### Tooltips appearing in wrong place, and 2 at once:

| Before | After |
|-------|------|
|![image](https://user-images.githubusercontent.com/13165846/29826488-58b539fa-8ccf-11e7-96bd-5ae1c910d3bb.png)|![image](https://user-images.githubusercontent.com/13165846/29826550-73f5d814-8ccf-11e7-93b6-ab8120c1ab91.png)|


