### PR TITLE
[DEV APPROVED] 8526 - Frontend/Backend Frequency titles in results table

### DIFF
--- a/app/assets/javascripts/wpcc/components/UpdateResults.js
+++ b/app/assets/javascripts/wpcc/components/UpdateResults.js
@@ -58,8 +58,9 @@ define(['jquery', 'DoughBaseComponent'], function($, DoughBaseComponent) {
   // Display recalculated values in tables
   UpdateResults.prototype._displayValues = function() {
     var unitConverter = this._unitConverter();
+    var titleContributions = this.frequencySelector.find('option:selected').attr('data-frequency-adjective');
 
-    // calculate & display new values
+    // calculate & display new values & titles
     for (var i = 0, max = this.resultsTables.length; i < max; i++) {
       var employeeContributions = (this.values.employeeContributions[i] / unitConverter).toFixed(2);
       var employerContributions = (this.values.employerContributions[i] / unitConverter).toFixed(2);
@@ -74,6 +75,7 @@ define(['jquery', 'DoughBaseComponent'], function($, DoughBaseComponent) {
       $(this.resultsTables[i]).find('[data-dough-employer-contribution]').html(employerContributions_html);
       $(this.resultsTables[i]).find('[data-dough-tax-relief]').html(taxRelief_html);
       $(this.resultsTables[i]).find('[data-dough-total]').html(total_html);
+      $(this.resultsTables[i]).find('[data-dough-title-frequency]').html(titleContributions); 
     };
   }
 

--- a/app/presenters/wpcc/period_contribution_presenter.rb
+++ b/app/presenters/wpcc/period_contribution_presenter.rb
@@ -37,8 +37,8 @@ module Wpcc
       default_i18n_key = 'wpcc.results.period.contribution_heading.employers'
 
       I18n.t(
-        "#{default_i18n_key}_#{salary_frequency.to_s}",
-        default: :"#{default_i18n_key}",
+        "#{default_i18n_key}_#{salary_frequency.to_s}_html",
+        default: :"#{default_i18n_key}_html",
         salary_frequency: salary_frequency.to_adj
       )
       # rubocop:enable Lint/StringConversionInInterpolation

--- a/app/presenters/wpcc/presenter.rb
+++ b/app/presenters/wpcc/presenter.rb
@@ -8,15 +8,19 @@ module Wpcc
       super(object)
       @view_context = args[:view_context]
       @object = object
+      @converter = Wpcc::SalaryFrequencyConverter
     end
 
     def salary_frequency_options
-      Wpcc::SalaryFrequencyConverter::SALARY_FREQUENCIES
+      @converter::SALARY_FREQUENCIES
         .map do |frequency, frequency_number|
           [
             text_for('salary_frequency', frequency),
             frequency,
-            data: { unit_converter: frequency_number }
+            data: {
+              unit_converter: frequency_number,
+              frequency_adjective: frequency_adjective(frequency)
+            }
           ]
         end
     end
@@ -43,6 +47,10 @@ module Wpcc
 
     def text_for(option, value)
       t("wpcc.details.options.#{option}.#{value}")
+    end
+
+    def frequency_adjective(frequency)
+      @converter.adjectives[I18n.locale.to_s][frequency]
     end
   end
 end

--- a/app/views/wpcc/your_results/_contributions_table.html.erb
+++ b/app/views/wpcc/your_results/_contributions_table.html.erb
@@ -1,9 +1,10 @@
 <div class="results__row">
   <% schedule.each do |period| %>
     <div class="results__period results__period-<%= period.name %>" data-dough-component="PopupTip" data-dough-results-table>
-      <h3 class="results__period-title" data-dough-results-period-title><%= period.title %></h3>
-      <p class="results__period-heading" data-dough-period-heading-yours>
-        <%= t('wpcc.results.period.contribution_heading.yours', salary_frequency: salary_frequency.to_adj) %>
+      <h3 class="results__period-title"><%= period.title %></h3>
+      
+      <p class="results__period-heading">
+        <%= t('wpcc.results.period.contribution_heading.yours_html', salary_frequency: salary_frequency.to_adj) %>
       </p>
       <p class="results__period-details results__period-employee-contribution" data-dough-employee-contribution data-value="<%= period.employee_contribution %>">
         <%= period.formatted_employee_contribution %>
@@ -23,13 +24,13 @@
         <%= render 'wpcc/tooltips/close' %>
       </div>
       <p class="results__period-heading" data-dough-period-heading-employers>
-        <%= period.employer_frequency_heading(salary_frequency) %>
+        <%= period.employer_frequency_heading(salary_frequency).html_safe %>
       </p>
       <p class="results__period-details results__period-employer-contribution" data-dough-employer-contribution data-value="<%= period.employer_contribution %>">
         <%= period.formatted_employer_contribution %>
       </p>
-      <p class="results__period-heading" data-dough-period-heading-total>
-        <%= t('wpcc.results.period.contribution_heading.total', salary_frequency: salary_frequency.to_adj) %>
+      <p class="results__period-heading">
+        <%= t('wpcc.results.period.contribution_heading.total_html', salary_frequency: salary_frequency.to_adj) %>
       </p>
       <p class="results__period-details results__period-total-contributions" data-dough-total>
         <%= period.formatted_total_contributions %>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -132,10 +132,10 @@ cy:
         after_april_2019: O Ebrill 2019 ymlaen
       period:
         contribution_heading:
-          yours: Eich cyfraniad %{salary_frequency}
-          employers: Cyfraniad %{salary_frequency} y cyflogwr
-          employers_fourweeks: Cyfraniad y cyflogwr %{salary_frequency}
-          total: Cyfanswm y cyfraniad %{salary_frequency}
+          yours_html: Eich cyfraniad <span data-dough-title-frequency>%{salary_frequency}</span>
+          employers_html: Cyfraniad <span data-dough-title-frequency>%{salary_frequency}</span> y cyflogwr
+          employers_fourweeks_html: Cyfraniad y cyflogwr <span data-dough-title-frequency>%{salary_frequency}</span>
+          total_html: Cyfanswm y cyfraniad <span data-dough-title-frequency>%{salary_frequency}</span>
         tax_relief_parentheses: yn cynnwys gostyngiad treth o £
       tax_relief_warning_html: Os nad ydych chi'n talu treth incwm ar eich enillion, fyddwch chi ddim ond yn cael gostyngiad treth ar eich cyfraniadau os bydd eich cynllun pensiwn yn casglu cyfraniadau yn defnyddio'r gostyngiad treth yn y ffynhonnell. Rydym wedi tybio bod eich cynllun yn gwneud hyn. Darllenwch ragor yn ein canllaw am <a href="https://www.moneyadviceservice.org.uk/cy/articles/gostyngiad-treth-ar-gyfraniadau-pensiwn">ostyngiadau treth ar gyfraniadau pensiwn</a>.
       tax_relief_warning: Os nad ydych chi'n talu treth incwm ar eich enillion, fyddwch chi ddim ond yn cael gostyngiad treth ar eich cyfraniadau os bydd eich cynllun pensiwn yn casglu cyfraniadau yn defnyddio'r gostyngiad treth yn y ffynhonnell. Rydym wedi tybio bod eich cynllun yn gwneud hyn. Darllenwch ragor yn ein canllaw am ostyngiadau treth ar gyfraniadau pensiwn.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -132,9 +132,9 @@ en:
         after_april_2019: April 2019 onwards
       period:
         contribution_heading:
-          yours: Your %{salary_frequency} contribution
-          employers: Employer's %{salary_frequency} contribution
-          total: Total %{salary_frequency} contributions
+          yours_html: Your %{salary_frequency} contribution
+          employers_html: Employer's %{salary_frequency} contribution
+          total_html: Total %{salary_frequency} contributions
         tax_relief_parentheses: includes tax relief of £
       tax_relief_warning_html: If you don’t pay income tax on your earnings, you will only receive tax relief on your pension contributions if your pension scheme collects contributions using the tax relief at source method. We have assumed your scheme does. Read more in our guide about <a href="https://www.moneyadviceservice.org.uk/en/articles/tax-relief-on-pension-contributions">tax relief on pension contributions</a>.
       tax_relief_warning: If you don’t pay income tax on your earnings, you will only receive tax relief on your pension contributions if your pension scheme collects contributions using the tax relief at source method.  We have assumed your scheme does. Read more in our guide about tax relief on pension contributions.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -132,9 +132,9 @@ en:
         after_april_2019: April 2019 onwards
       period:
         contribution_heading:
-          yours_html: Your %{salary_frequency} contribution
-          employers_html: Employer's %{salary_frequency} contribution
-          total_html: Total %{salary_frequency} contributions
+          yours_html: Your <span data-dough-title-frequency>%{salary_frequency}</span> contribution
+          employers_html: Employer's <span data-dough-title-frequency>%{salary_frequency}</span> contribution
+          total_html: Total <span data-dough-title-frequency>%{salary_frequency}</span> contributions
         tax_relief_parentheses: includes tax relief of £
       tax_relief_warning_html: If you don’t pay income tax on your earnings, you will only receive tax relief on your pension contributions if your pension scheme collects contributions using the tax relief at source method. We have assumed your scheme does. Read more in our guide about <a href="https://www.moneyadviceservice.org.uk/en/articles/tax-relief-on-pension-contributions">tax relief on pension contributions</a>.
       tax_relief_warning: If you don’t pay income tax on your earnings, you will only receive tax relief on your pension contributions if your pension scheme collects contributions using the tax relief at source method.  We have assumed your scheme does. Read more in our guide about tax relief on pension contributions.

--- a/features/step_definitions/your_results_steps.rb
+++ b/features/step_definitions/your_results_steps.rb
@@ -104,11 +104,13 @@ Then(/^I should( not)? see the manually_opt_in "([^"]*)"$/) do |should_not, mess
 end
 
 Then(/^my results should have "([^"]*)" "([^"]*)" and "([^"]*)"$/) do |your_heading, employer_heading, total_heading|
-  headings = [your_heading, employer_heading, total_heading]
-  headings = your_results_page.results_period_headings[0..2].map do |heading|
+  expected_headings = [your_heading, employer_heading, total_heading]
+
+  actual_headings = your_results_page.results_period_headings[0..2].map do |heading|
     ActionView::Base.full_sanitizer.sanitize(heading.text)
   end
-  expect(headings).to eq(headings)
+
+  expect(actual_headings).to eq(expected_headings)
 end
 
 Then(/^I should see a link to the legal minimum contributions table$/) do

--- a/features/step_definitions/your_results_steps.rb
+++ b/features/step_definitions/your_results_steps.rb
@@ -105,7 +105,10 @@ end
 
 Then(/^my results should have "([^"]*)" "([^"]*)" and "([^"]*)"$/) do |your_heading, employer_heading, total_heading|
   headings = [your_heading, employer_heading, total_heading]
-  expect(your_results_page.results_period_headings[0..2].map(&:text)).to eq(headings)
+  headings = your_results_page.results_period_headings[0..2].map do |heading|
+    ActionView::Base.full_sanitizer.sanitize(heading.text)
+  end
+  expect(headings).to eq(headings)
 end
 
 Then(/^I should see a link to the legal minimum contributions table$/) do

--- a/spec/javascripts/fixtures/UpdateResults.html
+++ b/spec/javascripts/fixtures/UpdateResults.html
@@ -3,10 +3,10 @@
     <div>
       <form>
         <select data-dough-selector>
-          <option value="year" data-unit-converter="1">per Year</option>
-          <option value="month" data-unit-converter="12">per Month</option>
-          <option value="fourweeks" data-unit-converter="13">per 4 weeks</option>
-          <option value="week" data-unit-converter="52">per Week</option>
+          <option value="year" data-unit-converter="1" data-frequency-adjective="yearly">per Year</option>
+          <option value="month" data-unit-converter="12" data-frequency-adjective="monthly">per Month</option>
+          <option value="fourweeks" data-unit-converter="13" data-frequency-adjective="four-weekly">per 4 weeks</option>
+          <option value="week" data-unit-converter="52" data-frequency-adjective="weekly">per Week</option>
         </select>
       </form>
     </div>
@@ -18,6 +18,7 @@
         <p data-dough-employer-contribution data-employer-contribution=""></p>
         <p data-dough-total></p>
         <p data-dough-tax-relief data-tax-relief=""></p>
+        <p data-dough-title-frequency=""></p>
       </div>
 
       <div data-dough-results-table>
@@ -26,6 +27,7 @@
         <p data-dough-employer-contribution data-employer-contribution=""></p>
         <p data-dough-total></p>
         <p data-dough-tax-relief data-tax-relief=""></p>
+        <p data-dough-title-frequency=""></p>
       </div>
 
       <div data-dough-results-table>
@@ -34,6 +36,7 @@
         <p data-dough-employer-contribution data-employer-contribution=""></p>
         <p data-dough-total></p>
         <p data-dough-tax-relief data-tax-relief=""></p>
+        <p data-dough-title-frequency=""></p>
       </div>
     </div>
   </div>

--- a/spec/javascripts/tests/UpdateResults_spec.js
+++ b/spec/javascripts/tests/UpdateResults_spec.js
@@ -108,14 +108,16 @@ describe('Update Results', function() {
         }
 
         function testExpected(frequency, values) {
-          it('Initial frequency set to ' + initialFrequency + ', changed to ' + frequency, function() {
+          it('Initial value and title frequency set to ' + initialFrequency + ', changed to ' + frequency, function() {
             this.triggerChange(this.frequencySelector, frequency);
+            var titleContributions = this.frequencySelector.find('option:selected').attr('data-frequency-adjective');
 
             for (var i = 0, max = this.resultsTables.length; i < max; i++) {
               expect($(this.resultsTables[i]).find('[data-dough-employee-contribution]').html()).to.equal(values.employeeContributions[i]);
               expect($(this.resultsTables[i]).find('[data-dough-tax-relief]').html()).to.equal(values.taxRelief[i]);
               expect($(this.resultsTables[i]).find('[data-dough-employer-contribution]').html()).to.equal(values.employerContributions[i]);
               expect($(this.resultsTables[i]).find('[data-dough-total]').html()).to.equal(values.total[i]);
+              expect($(this.resultsTables[i]).find('[data-dough-title-frequency]').html()).to.equal(titleContributions);
             };
           });
         }

--- a/spec/presenters/period_contribution_presenter_spec.rb
+++ b/spec/presenters/period_contribution_presenter_spec.rb
@@ -57,8 +57,10 @@ RSpec.describe Wpcc::PeriodContributionPresenter do
     context 'for english fourweekly salary frequency' do
       let(:locale) { 'en' }
       it 'returns the english translation for 4-weekly' do
+        # rubocop:disable LineLength
         expect(subject.employer_frequency_heading(salary_frequency))
-          .to eq('Employer\'s 4-weekly contribution')
+          .to eq('Employer\'s <span data-dough-title-frequency>4-weekly</span> contribution')
+        # rubocop:enable LineLength
       end
     end
 
@@ -69,8 +71,10 @@ RSpec.describe Wpcc::PeriodContributionPresenter do
       after { I18n.locale = :en }
 
       it 'returns the welsh translation for 4-weekly' do
+        # rubocop:disable LineLength
         expect(subject.employer_frequency_heading(salary_frequency))
-          .to eq('Cyfraniad y cyflogwr bob 4 wythnos')
+          .to eq('Cyfraniad y cyflogwr <span data-dough-title-frequency>bob 4 wythnos</span>')
+        # rubocop:enable LineLength
       end
     end
   end

--- a/spec/presenters/presenter_spec.rb
+++ b/spec/presenters/presenter_spec.rb
@@ -9,14 +9,18 @@ RSpec.describe Wpcc::Presenter do
   describe '#salary_frequency_options' do
     let(:expected_result) do
       [
-        ['per Year',    'year',      { data: { unit_converter: 1 } }],
-        ['per Month',   'month',     { data: { unit_converter: 12 } }],
-        ['per 4 weeks', 'fourweeks', { data: { unit_converter: 13 } }],
-        ['per Week',    'week',      { data: { unit_converter: 52 } }]
+        ['per Year', 'year',
+         { data: { unit_converter: 1, frequency_adjective: 'annual' } }],
+        ['per Month', 'month',
+         { data: { unit_converter: 12, frequency_adjective: 'monthly' } }],
+        ['per 4 weeks', 'fourweeks',
+         { data: { unit_converter: 13, frequency_adjective: '4-weekly' } }],
+        ['per Week', 'week',
+         { data: { unit_converter: 52, frequency_adjective: 'weekly' } }]
       ]
     end
 
-    it 'returns an array of translation keys for salary_frequencies' do
+    it 'returns translation keys and data-attributes for salary_frequencies' do
       expect(subject.salary_frequency_options).to eq(expected_result)
     end
   end


### PR DESCRIPTION
## Issue
As a user trying to work out the impact of my contributions on my take-home pay I need to see the frequency that is being displayed clearly on my results so that I fully understand what I will be paying and how often.

[TP](https://moneyadviceservice.tpondemand.com/entity/8526)

## Solution

Add a word to indicate frequency within each results table to indicate what frequency the figure is displaying.

Attach the `data-frequency-adjective` value generated by back end logic to a js object.
Update titles by targeting `data-dough-title-frequency` rendered into the view from our yaml file.

|English    |  Welsh |
|--------- |-------- |
|<img src="https://user-images.githubusercontent.com/2187295/29931166-5d606e1c-8e68-11e7-878f-66cd506d4e88.png"> | <img src="https://user-images.githubusercontent.com/2187295/29931177-66ee062e-8e68-11e7-821e-e6fc3ac3eb73.png"> |


