### PR TITLE
[DEV APPROVED] 8531 - WPCC: Amend Salary label and Salary tooltip

### DIFF
--- a/app/views/wpcc/your_details/new.html.erb
+++ b/app/views/wpcc/your_details/new.html.erb
@@ -103,21 +103,21 @@
               </div>
             </div>
           <% end %>
-          <div class="details__callouts">
-            <div class="form__row details__callout details__callout--inactive" data-dough-callout-lt5876>
-              <div class="callout">
-                <p><%= t('wpcc.details.callout__lt5876') %></p>
-              </div>
+        </div>
+        <div class="details__callouts">
+          <div class="form__row details__callout details__callout--inactive" data-dough-callout-lt5876>
+            <div class="callout">
+              <p><%= t('wpcc.details.callout__lt5876') %></p>
             </div>
-            <div class="form__row details__callout details__callout--inactive" data-dough-callout-gt5876_lt10000>
-              <div class="callout">
-                <p><%= t('wpcc.details.callout__gt5876_lt10000') %></p>
-              </div>
+          </div>
+          <div class="form__row details__callout details__callout--inactive" data-dough-callout-gt5876_lt10000>
+            <div class="callout">
+              <p><%= t('wpcc.details.callout__gt5876_lt10000') %></p>
             </div>
           </div>
         </div>
         <div data-dough-popup-container class="popup-tip__container details__helper">
-          <p data-dough-popup-content class="popup-tip__content"><%= t('wpcc.details.salary.tooltip') %></p>
+          <p data-dough-popup-content class="popup-tip__content"><%= t('wpcc.details.salary.tooltip_html') %></p>
           <%= render 'wpcc/tooltips/close' %>
         </div>
       </div>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -37,8 +37,8 @@ cy:
         validation: Dewiswch eich rhywedd
 
       salary:
-        label: Eich cyflog sylfaenol
-        tooltip: Mae arnom angen eich cyflog i gyfrifo cyfraniadau misol ar eich cyfer chi a’ch cyflogwr.
+        label: Eich cyflog
+        tooltip_html: Rhowch eich cyflog cyn i’r dreth nag unrhyw ddidyniadau eraill gael eu tynnu. Gelwir hyn yn gyflog gros. <a href="/cy/articles/cofrestru-awtomatig-pam-fydd-gennych-fwy-nag-un-swydd">Os oes gennych fwy nag un swydd</a>, bydd raid i chi roi pob cyflog ar wahân.
         validation: Nodwch eich cyflog
         frequency:
           label: Frequency

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -37,8 +37,8 @@ en:
         validation: Please select your gender
 
       salary:
-        label: Your basic salary
-        tooltip: We need your salary to calculate monthly contributions for you and your employer
+        label: Your salary
+        tooltip_html: Enter your salary before tax or other deductions are taken off.  This is known as your gross salary.  <a href="/en/articles/automatic-enrolment-when-you-have-more-than-one-job">If you have more than one job</a>, you will have to enter each salary separately. 
         validation: Please enter your salary
         frequency:
           label: Frequency

--- a/lib/wpcc/version.rb
+++ b/lib/wpcc/version.rb
@@ -2,7 +2,7 @@ module Wpcc
   module Version
     MAJOR = 1
     MINOR = 8
-    PATCH = 0
+    PATCH = 1
 
     STRING = [MAJOR, MINOR, PATCH].join('.')
   end


### PR DESCRIPTION
# 8531 - WPCC: Amend Salary label and Salary tooltip

[TP Link](https://moneyadviceservice.tpondemand.com/entity/8531)

- Updates the salary input label to read "Your Salary" in English and "Eich cyflog" in Welsh
- Updates tooltip copy to read:

En:
 
"Enter your salary before tax or other deductions are taken off.  This is known as your gross salary.  If you have more than one job, you will have to enter each salary separately."

Cy:

"Rhowch eich cyflog cyn i’r dreth nag unrhyw ddidyniadau eraill gael eu tynnu. Gelwir hyn yn gyflog gros.  Os oes gennych fwy nag un swydd, bydd raid i chi roi pob cyflog ar wahân."

**Screenshots**

| English | Welsh |
|--------|--------|
|![image](https://user-images.githubusercontent.com/13165846/30019995-3e371bae-915a-11e7-8a87-ce80529b4756.png)|![image](https://user-images.githubusercontent.com/13165846/30020017-53791cce-915a-11e7-9587-44cffce71b93.png)|

