### PR TITLE
8552 - Client side step 1 errors

### DIFF
--- a/app/assets/javascripts/wpcc/components/SalaryConditions.js
+++ b/app/assets/javascripts/wpcc/components/SalaryConditions.js
@@ -109,7 +109,7 @@ define(['jquery', 'DoughBaseComponent'], function($, DoughBaseComponent) {
 
         // Annual salary is between £5876 and £10000 and not empty
         gt5876_lt10000 = annualSalary >= 5876 &&
-                         annualSalary <= 9999 &&
+                         annualSalary <= 10000 &&
                          annualSalary != '';
 
     if (!lt5876 && !gt5876_lt10000) {

--- a/app/views/wpcc/your_details/new.html.erb
+++ b/app/views/wpcc/your_details/new.html.erb
@@ -8,7 +8,6 @@
       'data-dough-validation-config': '{"showValidationSummary": false}',
       'novalidate': true
     }) do |f| %>
-
     <h2 class="section__heading details__heading">1. <%= t('wpcc.details.title') %></h2>
     <div class="details__content">
       <div class="details__row">
@@ -79,7 +78,6 @@
           </div>
         </div>
       </div>
-
       <div class="details__row" data-dough-component="SalaryConditions PopupTip">
         <div class="details__field">
           <%= f.form_row :salary do %>
@@ -120,52 +118,50 @@
           <p data-dough-popup-content class="popup-tip__content"><%= t('wpcc.details.salary.tooltip_html') %></p>
           <%= render 'wpcc/tooltips/close' %>
         </div>
-      </div>
-
-      <div class="details__row" data-dough-component="PopupTip">
-        <fieldset>
-          <legend class="details__calculate-heading"><%= t('wpcc.details.calculate.legend') %></legend>
-          <p class="details__calculate-intro">
-            <%= t('wpcc.details.calculate.details_html_1') %>
-            <%= render 'wpcc/tooltips/trigger' %>
-            <%= t('wpcc.details.calculate.details_html_2') %>
-          </p>
-          <div data-dough-popup-container class="popup-tip__container details__helper details__helper--block">
-            <p data-dough-popup-content class="popup-tip__content">
-              <span class="details__helper-title--no-js">
-                <%= t('wpcc.details.calculate.qualifying_earnings_title') %>:
-              </span>
-              <%= t(
-                'wpcc.details.calculate.qualifying_earnings',
-                formatted_upper_earnings: @your_details_form.formatted_upper_earnings,
-                formatted_lower_earnings: @your_details_form.formatted_lower_earnings
-                ) %>
+        <div data-dough-component="PopupTip">
+          <fieldset>
+            <legend class="details__calculate-heading"><%= t('wpcc.details.calculate.legend') %></legend>
+            <p class="details__calculate-intro">
+              <%= t('wpcc.details.calculate.details_html_1') %>
+              <%= render 'wpcc/tooltips/trigger' %>
+              <%= t('wpcc.details.calculate.details_html_2') %>
             </p>
-            <%= render 'wpcc/tooltips/close' %>
-          </div>
-          <div class="details__callouts">
-            <div class="form__row details__callout <%= @your_details_form.activate_disabled_callout %>" data-dough-callout-radio-disabled>
-              <div class="callout">
-                <p><%= t('wpcc.details.callout__radiodisabled') %></p>
+            <div data-dough-popup-container class="popup-tip__container details__helper details__helper--block">
+              <p data-dough-popup-content class="popup-tip__content">
+                <span class="details__helper-title--no-js">
+                  <%= t('wpcc.details.calculate.qualifying_earnings_title') %>:
+                </span>
+                <%= t(
+                  'wpcc.details.calculate.qualifying_earnings',
+                  formatted_upper_earnings: @your_details_form.formatted_upper_earnings,
+                  formatted_lower_earnings: @your_details_form.formatted_lower_earnings
+                  ) %>
+              </p>
+              <%= render 'wpcc/tooltips/close' %>
+            </div>
+            <div class="details__callouts">
+              <div class="form__row details__callout <%= @your_details_form.activate_disabled_callout %>" data-dough-callout-radio-disabled>
+                <div class="callout">
+                  <p><%= t('wpcc.details.callout__radiodisabled') %></p>
+                </div>
               </div>
             </div>
-          </div>
-          <div class="details__row details__row--group">
-            <%= f.form_row :contribution_preference do %>
-              <%= f.errors_for :contribution_preference %>
-              <div class="form__group-item details__calculate-item">
-                <%= f.radio_button(:contribution_preference, 'minimum', class: 'details__calculate-item-select', 'data-dough-employer-part-radio': true) %>
-                <%= f.label(:contribution_preference_minimum, t('wpcc.details.options.contribution_preference.minimum'), class: 'details__calculate-item-label') %>
-              </div>
-              <div class="form__group-item details__calculate-item">
-                <%= f.radio_button(:contribution_preference, 'full', class: 'details__calculate-item-select', 'data-dough-employer-full-radio': true) %>
-                <%= f.label(:contribution_preference_full, t('wpcc.details.options.contribution_preference.full'), class: 'details__calculate-item-label') %>
-              </div>
-            <% end %>
-          </div>
-        </fieldset>
+            <div class="details__row details__row--group">
+              <%= f.form_row :contribution_preference do %>
+                <%= f.errors_for :contribution_preference %>
+                <div class="form__group-item details__calculate-item">
+                  <%= f.radio_button(:contribution_preference, 'minimum', class: 'details__calculate-item-select', 'data-dough-employer-part-radio': true) %>
+                  <%= f.label(:contribution_preference_minimum, t('wpcc.details.options.contribution_preference.minimum'), class: 'details__calculate-item-label') %>
+                </div>
+                <div class="form__group-item details__calculate-item">
+                  <%= f.radio_button(:contribution_preference, 'full', class: 'details__calculate-item-select', 'data-dough-employer-full-radio': true) %>
+                  <%= f.label(:contribution_preference_full, t('wpcc.details.options.contribution_preference.full'), class: 'details__calculate-item-label') %>
+                </div>
+              <% end %>
+            </div>
+          </fieldset>
+        </div>
       </div>
-      
       <div class="details__row">
         <div class="details__field">
           <div class="form__row">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -72,7 +72,7 @@ en:
       callout__gt74: You are not eligible to join a workplace pension because you are above the maximum age.
       callout__lt5876: Your employer will not automatically enrol you into a workplace pension scheme but you can choose to join. If you do so, your employer will not be obliged to make contributions.
       callout__radiodisabled: At your earnings level, you will have to make contributions based on your full salary.
-      callout__gt5876_lt10000: Your employer will not automatically enroll you into a workplace pension scheme but you can choose to join. If you do so, your employer will make contributions.
+      callout__gt5876_lt10000: Your employer will not automatically enrol you into a workplace pension scheme but you can choose to join. If you do so, your employer will make contributions.
 
       section__heading:
         age: '%{age} years'


### PR DESCRIPTION
## This PR fixes errors with client side validation on step 1:
 
1 - The salary conditional message for not being automatically enrolled does not trigger for a salary of £10,000 per year. 

2 - The Salary conditional message for users between £5876 - £10,000, inclusive, uses the spelling 'enroll'. This should be 'enrol'
 
3 - If I enter a salary under £5876 per year, the warning above the 'part salary/full salary' selection does not appear, and the 'part salary' button is not disabled, as per the ticket 8436

## Solution
Increase `annualSalary`ceiling from `9999` to `10000`.
Fix spelling in yaml file.
Nest the salary and employer contribution sections within the `SalaryConditions` dough component.

| Bug 1 - 2 | Bug 3|
| ---------| -------|
|<img alt="screen shot 2017-09-04 at 14 30 16" src="https://user-images.githubusercontent.com/2187295/30028663-d6ca18c6-917d-11e7-80ee-24de1878150c.png"> | <img alt="screen shot 2017-09-04 at 14 29 53" src="https://user-images.githubusercontent.com/2187295/30028673-e8a44ae4-917d-11e7-835c-65c62265c66d.png"> |


