### PR TITLE
[DEV APPROVED] 8555 - Amend url for salary tooltip

### DIFF
--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -38,7 +38,7 @@ cy:
 
       salary:
         label: Eich cyflog
-        tooltip_html: Rhowch eich cyflog cyn i’r dreth nag unrhyw ddidyniadau eraill gael eu tynnu. Gelwir hyn yn gyflog gros. <a href="/cy/articles/cofrestru-awtomatig-pam-fydd-gennych-fwy-nag-un-swydd">Os oes gennych fwy nag un swydd</a>, bydd raid i chi roi pob cyflog ar wahân.
+        tooltip_html: Rhowch eich cyflog cyn i’r dreth nag unrhyw ddidyniadau eraill gael eu tynnu. Gelwir hyn yn gyflog gros. <a href="/cy/articles/cofrestriad-awtomatig-ar-bensiwn-man-gwaith#cofrestru-awtomatig-pam-fydd-gennych-fwy-nag-un-swydd">Os oes gennych fwy nag un swydd</a>, bydd raid i chi roi pob cyflog ar wahân.
         validation: Nodwch eich cyflog
         frequency:
           label: Frequency

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -38,7 +38,7 @@ en:
 
       salary:
         label: Your salary
-        tooltip_html: Enter your salary before tax or other deductions are taken off.  This is known as your gross salary.  <a href="/en/articles/automatic-enrolment-when-you-have-more-than-one-job">If you have more than one job</a>, you will have to enter each salary separately. 
+        tooltip_html: Enter your salary before tax or other deductions are taken off.  This is known as your gross salary.  <a href="/en/articles/automatic-enrolment-into-a-workplace-pension#automatic-enrolment-when-you-have-more-than-one-job">If you have more than one job</a>, you will have to enter each salary separately. 
         validation: Please enter your salary
         frequency:
           label: Frequency


### PR DESCRIPTION
This pr addresses [TP User Story](https://moneyadviceservice.tpondemand.com/restui/board.aspx?acid=ddd7f3a626844ab8d1bee3f06ec28efa#page=board/5624876525867731357&appConfig=eyJhY2lkIjoiREI4ODcwRjkxMDNDRTM2NTlBMzhDNTRBRTVBNUU1N0UifQ==&boardPopup=userstory/8555/silent).

The content team have provided a new url to be linked to in the tooltip for information about the salary field on the form on Step 1. This pr updates the url accordingly.