### PR TITLE
8556 - Fixes bug in step 1 view

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,7 @@
-# 1.9.0
+## 1.9.1: 
+* TP-8556: Fixes Popuptips and div floating issue in step 1
+
+## 1.9.0
 * TP-8541: Add conditional intro text to results page
 * TP-8555: Amend salary tooltip url
 * TP-8554: Add url link to tax relief guide

--- a/app/views/wpcc/your_details/new.html.erb
+++ b/app/views/wpcc/your_details/new.html.erb
@@ -78,45 +78,47 @@
           </div>
         </div>
       </div>
-      <div class="details__row" data-dough-component="SalaryConditions PopupTip">
-        <div class="details__field">
-          <%= f.form_row :salary do %>
-            <div class="details__field-label">
-              <%= f.label :salary, t('wpcc.details.salary.label'), class: 'form__label-heading' %>
-              <%= render 'wpcc/tooltips/trigger' %>
-            </div>
-            <%= f.errors_for :salary %>
-            <%= f.errors_for :salary_frequency %>
-            <div class="details__salary">
-              <div class="details__salary-amount">
-              <%= f.text_field :salary,
-                required: true,
-                'data-dough-validation-empty': t('wpcc.details.salary.validation'),
-                'data-dough-salary-input': true
-              %>
+      <div class="details__row" data-dough-component="SalaryConditions">
+        <div data-dough-component="PopupTip">
+          <div class="details__field">
+            <%= f.form_row :salary do %>
+              <div class="details__field-label">
+                <%= f.label :salary, t('wpcc.details.salary.label'), class: 'form__label-heading' %>
+                <%= render 'wpcc/tooltips/trigger' %>
               </div>
-              <div class="details__salary-frequency">
-                <%= f.label :salary_frequency, t('wpcc.details.salary.frequency.label'), class: 'form__label-heading details__field-label visually-hidden' %>
-              <%= f.select(:salary_frequency, options_for_select(@your_details_form.salary_frequency_options, @your_details_form.salary_frequency), {}, {'data-dough-frequency-select': true}) %>
+              <%= f.errors_for :salary %>
+              <%= f.errors_for :salary_frequency %>
+              <div class="details__salary">
+                <div class="details__salary-amount">
+                <%= f.text_field :salary,
+                  required: true,
+                  'data-dough-validation-empty': t('wpcc.details.salary.validation'),
+                  'data-dough-salary-input': true
+                %>
+                </div>
+                <div class="details__salary-frequency">
+                  <%= f.label :salary_frequency, t('wpcc.details.salary.frequency.label'), class: 'form__label-heading details__field-label visually-hidden' %>
+                <%= f.select(:salary_frequency, options_for_select(@your_details_form.salary_frequency_options, @your_details_form.salary_frequency), {}, {'data-dough-frequency-select': true}) %>
+                </div>
+              </div>
+            <% end %>
+          </div>
+          <div class="details__callouts">
+            <div class="form__row details__callout details__callout--inactive" data-dough-callout-lt5876>
+              <div class="callout">
+                <p><%= t('wpcc.details.callout__lt5876') %></p>
               </div>
             </div>
-          <% end %>
-        </div>
-        <div class="details__callouts">
-          <div class="form__row details__callout details__callout--inactive" data-dough-callout-lt5876>
-            <div class="callout">
-              <p><%= t('wpcc.details.callout__lt5876') %></p>
+            <div class="form__row details__callout details__callout--inactive" data-dough-callout-gt5876_lt10000>
+              <div class="callout">
+                <p><%= t('wpcc.details.callout__gt5876_lt10000') %></p>
+              </div>
             </div>
           </div>
-          <div class="form__row details__callout details__callout--inactive" data-dough-callout-gt5876_lt10000>
-            <div class="callout">
-              <p><%= t('wpcc.details.callout__gt5876_lt10000') %></p>
-            </div>
+          <div data-dough-popup-container class="popup-tip__container details__helper">
+            <p data-dough-popup-content class="popup-tip__content"><%= t('wpcc.details.salary.tooltip_html') %></p>
+            <%= render 'wpcc/tooltips/close' %>
           </div>
-        </div>
-        <div data-dough-popup-container class="popup-tip__container details__helper">
-          <p data-dough-popup-content class="popup-tip__content"><%= t('wpcc.details.salary.tooltip_html') %></p>
-          <%= render 'wpcc/tooltips/close' %>
         </div>
         <div data-dough-component="PopupTip">
           <fieldset>

--- a/app/views/wpcc/your_details/new.html.erb
+++ b/app/views/wpcc/your_details/new.html.erb
@@ -120,7 +120,7 @@
             <%= render 'wpcc/tooltips/close' %>
           </div>
         </div>
-        <div data-dough-component="PopupTip">
+        <div class="details__row--group" data-dough-component="PopupTip">
           <fieldset>
             <legend class="details__calculate-heading"><%= t('wpcc.details.calculate.legend') %></legend>
             <p class="details__calculate-intro">
@@ -148,7 +148,7 @@
                 </div>
               </div>
             </div>
-            <div class="details__row details__row--group">
+            <div>
               <%= f.form_row :contribution_preference do %>
                 <%= f.errors_for :contribution_preference %>
                 <div class="form__group-item details__calculate-item">

--- a/lib/wpcc/version.rb
+++ b/lib/wpcc/version.rb
@@ -2,7 +2,7 @@ module Wpcc
   module Version
     MAJOR = 1
     MINOR = 9
-    PATCH = 0
+    PATCH = 1
 
     STRING = [MAJOR, MINOR, PATCH].join('.')
   end


### PR DESCRIPTION
## Issue
Due to front end refactoring the last two Popuptips are displaying together when either of them are triggered.
Float issue in view

## Solution:
- The `Popuptip` dough component is now assigned individually to to each trigger.
- `details__row--group` is assigned to the parent of the entire section and removed from the salary contribution radio buttons. 