### PR TITLE
[DEV APPROVED] 8551 Add Welsh translation for tax-relief

### DIFF
--- a/app/assets/javascripts/wpcc/components/UpdateResults.js
+++ b/app/assets/javascripts/wpcc/components/UpdateResults.js
@@ -1,15 +1,10 @@
 define(['jquery', 'DoughBaseComponent'], function($, DoughBaseComponent) {
   'use strict';
 
-  var UpdateResults,
-    defaultConfig = {
-      i18nStrings: {
-        parentheses: 'includes tax relief of £'
-      }
-    };
+  var UpdateResults;
 
   UpdateResults = function($el, config) {
-    UpdateResults.baseConstructor.call(this, $el, config, defaultConfig);
+    UpdateResults.baseConstructor.call(this, $el, config);
 
     this.frequencySelector = this.$el.find('[data-dough-selector]');
     this.resultsTables = this.$el.find('[data-dough-results-table]')
@@ -62,18 +57,19 @@ define(['jquery', 'DoughBaseComponent'], function($, DoughBaseComponent) {
 
     // calculate & display new values & titles
     for (var i = 0, max = this.resultsTables.length; i < max; i++) {
+
       var employeeContributions = (this.values.employeeContributions[i] / unitConverter).toFixed(2);
       var employerContributions = (this.values.employerContributions[i] / unitConverter).toFixed(2);
       var taxRelief = (this.values.taxRelief[i] / unitConverter).toFixed(2);
       var total = parseFloat(employeeContributions) + parseFloat(employerContributions);
       var employeeContributions_html = '£' + employeeContributions.replace(/\B(?=(\d{3})+(?!\d))/g, ",");
       var employerContributions_html = '£' + employerContributions.replace(/\B(?=(\d{3})+(?!\d))/g, ",");
-      var taxRelief_html = '(' + this.config.i18nStrings.parentheses + taxRelief + ')';
+      var taxRelief_html = '£' + taxRelief;
       var total_html = '£' + total.toFixed(2).replace(/\B(?=(\d{3})+(?!\d))/g, ",");
 
       $(this.resultsTables[i]).find('[data-dough-employee-contribution]').html(employeeContributions_html);
       $(this.resultsTables[i]).find('[data-dough-employer-contribution]').html(employerContributions_html);
-      $(this.resultsTables[i]).find('[data-dough-tax-relief]').html(taxRelief_html);
+      $(this.resultsTables[i]).find('[data-dough-tax-relief] span').text(taxRelief_html);
       $(this.resultsTables[i]).find('[data-dough-total]').html(total_html);
       $(this.resultsTables[i]).find('[data-dough-title-frequency]').html(titleContributions); 
     };

--- a/app/assets/javascripts/wpcc/components/UpdateResults.js
+++ b/app/assets/javascripts/wpcc/components/UpdateResults.js
@@ -69,9 +69,9 @@ define(['jquery', 'DoughBaseComponent'], function($, DoughBaseComponent) {
 
       $(this.resultsTables[i]).find('[data-dough-employee-contribution]').html(employeeContributions_html);
       $(this.resultsTables[i]).find('[data-dough-employer-contribution]').html(employerContributions_html);
-      $(this.resultsTables[i]).find('[data-dough-tax-relief] span').text(taxRelief_html);
+      $(this.resultsTables[i]).find('[data-dough-tax-relief-value]').text(taxRelief_html);
       $(this.resultsTables[i]).find('[data-dough-total]').html(total_html);
-      $(this.resultsTables[i]).find('[data-dough-title-frequency]').html(titleContributions); 
+      $(this.resultsTables[i]).find('[data-dough-title-frequency]').html(titleContributions);
     };
   }
 

--- a/app/presenters/wpcc/period_contribution_presenter.rb
+++ b/app/presenters/wpcc/period_contribution_presenter.rb
@@ -25,7 +25,10 @@ module Wpcc
     end
 
     def formatted_tax_relief
-      "(includes tax relief of #{formatted_contribution(object.tax_relief)})"
+      t(
+        'wpcc.results.period.tax_relief_html',
+        formatted_tax_relief: formatted_contribution(object.tax_relief)
+      )
     end
 
     def formatted_total_contributions

--- a/app/views/wpcc/your_results/_contributions_table.html.erb
+++ b/app/views/wpcc/your_results/_contributions_table.html.erb
@@ -11,8 +11,8 @@
         <%= period.formatted_employee_contribution %>
       </p>
 
-      <p class="results__period-parenthesis">
-        <span class="results__period-tax-relief" data-dough-tax-relief data-value="<%= period.tax_relief %>">
+      <p class="results__period-parenthesis" data-dough-tax-relief data-value="<%= period.tax_relief %>">
+        <span class="results__period-tax-relief">
           <%= period.formatted_tax_relief %>
         </span>
         <%= render 'wpcc/tooltips/trigger' %>

--- a/app/views/wpcc/your_results/index.html.erb
+++ b/app/views/wpcc/your_results/index.html.erb
@@ -12,11 +12,7 @@
 <section class="section section--results">
   <h2 class="section__heading results__heading">3. <%= t('wpcc.results.title') %></h2>
 
-  <div
-    class="results__content"
-    data-dough-component="UpdateResults"
-    data-dough-update-results-config='{"i18nStrings": {"parentheses": "<%= t('wpcc.results.period.tax_relief_parentheses') %>"}}'
-  >
+  <div class="results__content" data-dough-component="UpdateResults">
     <p>
       <%= t('wpcc.results.description_html') %>
       <%= your_results_presenter.earnings_description.html_safe %>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -139,7 +139,7 @@ cy:
           employers_html: Cyfraniad <span data-dough-title-frequency>%{salary_frequency}</span> y cyflogwr
           employers_fourweeks_html: Cyfraniad y cyflogwr <span data-dough-title-frequency>%{salary_frequency}</span>
           total_html: Cyfanswm y cyfraniad <span data-dough-title-frequency>%{salary_frequency}</span>
-        tax_relief_parentheses: yn cynnwys gostyngiad treth o £
+        tax_relief_html: (yn cynnwys gostyngiad treth o <span>%{formatted_tax_relief}</span>)
       tax_relief_warning_html: Os nad ydych chi'n talu treth incwm ar eich enillion, fyddwch chi ddim ond yn cael gostyngiad treth ar eich cyfraniadau os bydd eich cynllun pensiwn yn casglu cyfraniadau yn defnyddio'r gostyngiad treth yn y ffynhonnell. Rydym wedi tybio bod eich cynllun yn gwneud hyn. Darllenwch ragor yn ein canllaw am <a href="https://www.moneyadviceservice.org.uk/cy/articles/gostyngiad-treth-ach-pensiwn-gweithle">ostyngiadau treth ar gyfraniadau pensiwn</a>.
       tax_relief_warning: Os nad ydych chi'n talu treth incwm ar eich enillion, fyddwch chi ddim ond yn cael gostyngiad treth ar eich cyfraniadau os bydd eich cynllun pensiwn yn casglu cyfraniadau yn defnyddio'r gostyngiad treth yn y ffynhonnell. Rydym wedi tybio bod eich cynllun yn gwneud hyn. Darllenwch ragor yn ein canllaw am ostyngiadau treth ar gyfraniadau pensiwn.
       tax_relief_tooltip_html: Byddwch yn cael gostyngiad treth ar eich cyfraniadau pensiwn sy'n golygu y rhoddir peth o’r arian o'ch cyflog a fyddai wedi mynd i’r llywodraeth fel treth tuag at eich pensiwn yn hytrach. <a href="https://www.moneyadviceservice.org.uk/cy/articles/gostyngiad-treth-ach-pensiwn-gweithle">Darllenwch fwy am sut i gael gostyngiad treth</a>.

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -139,7 +139,7 @@ cy:
           employers_html: Cyfraniad <span data-dough-title-frequency>%{salary_frequency}</span> y cyflogwr
           employers_fourweeks_html: Cyfraniad y cyflogwr <span data-dough-title-frequency>%{salary_frequency}</span>
           total_html: Cyfanswm y cyfraniad <span data-dough-title-frequency>%{salary_frequency}</span>
-        tax_relief_html: (yn cynnwys gostyngiad treth o <span>%{formatted_tax_relief}</span>)
+        tax_relief_html: (yn cynnwys gostyngiad treth o <span data-dough-tax-relief-value>%{formatted_tax_relief}</span>)
       tax_relief_warning_html: Os nad ydych chi'n talu treth incwm ar eich enillion, fyddwch chi ddim ond yn cael gostyngiad treth ar eich cyfraniadau os bydd eich cynllun pensiwn yn casglu cyfraniadau yn defnyddio'r gostyngiad treth yn y ffynhonnell. Rydym wedi tybio bod eich cynllun yn gwneud hyn. Darllenwch ragor yn ein canllaw am <a href="https://www.moneyadviceservice.org.uk/cy/articles/gostyngiad-treth-ach-pensiwn-gweithle">ostyngiadau treth ar gyfraniadau pensiwn</a>.
       tax_relief_warning: Os nad ydych chi'n talu treth incwm ar eich enillion, fyddwch chi ddim ond yn cael gostyngiad treth ar eich cyfraniadau os bydd eich cynllun pensiwn yn casglu cyfraniadau yn defnyddio'r gostyngiad treth yn y ffynhonnell. Rydym wedi tybio bod eich cynllun yn gwneud hyn. Darllenwch ragor yn ein canllaw am ostyngiadau treth ar gyfraniadau pensiwn.
       tax_relief_tooltip_html: Byddwch yn cael gostyngiad treth ar eich cyfraniadau pensiwn sy'n golygu y rhoddir peth o’r arian o'ch cyflog a fyddai wedi mynd i’r llywodraeth fel treth tuag at eich pensiwn yn hytrach. <a href="https://www.moneyadviceservice.org.uk/cy/articles/gostyngiad-treth-ach-pensiwn-gweithle">Darllenwch fwy am sut i gael gostyngiad treth</a>.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -38,7 +38,7 @@ en:
 
       salary:
         label: Your salary
-        tooltip_html: Enter your salary before tax or other deductions are taken off.  This is known as your gross salary.  <a href="/en/articles/automatic-enrolment-into-a-workplace-pension#automatic-enrolment-when-you-have-more-than-one-job">If you have more than one job</a>, you will have to enter each salary separately. 
+        tooltip_html: Enter your salary before tax or other deductions are taken off.  This is known as your gross salary.  <a href="/en/articles/automatic-enrolment-into-a-workplace-pension#automatic-enrolment-when-you-have-more-than-one-job">If you have more than one job</a>, you will have to enter each salary separately.
         validation: Please enter your salary
         frequency:
           label: Frequency
@@ -138,7 +138,7 @@ en:
           yours_html: Your <span data-dough-title-frequency>%{salary_frequency}</span> contribution
           employers_html: Employer's <span data-dough-title-frequency>%{salary_frequency}</span> contribution
           total_html: Total <span data-dough-title-frequency>%{salary_frequency}</span> contributions
-        tax_relief_html: (includes tax relief of <span>%{formatted_tax_relief}</span>)
+        tax_relief_html: (includes tax relief of <span data-dough-tax-relief-value>%{formatted_tax_relief}</span>)
       tax_relief_warning_html: If you don’t pay income tax on your earnings, you will only receive tax relief on your pension contributions if your pension scheme collects contributions using the tax relief at source method. We have assumed your scheme does. Read more in our guide about <a href="https://www.moneyadviceservice.org.uk/en/articles/tax-relief-and-your-workplace-pension">tax relief on pension contributions</a>.
       tax_relief_warning: If you don’t pay income tax on your earnings, you will only receive tax relief on your pension contributions if your pension scheme collects contributions using the tax relief at source method.  We have assumed your scheme does. Read more in our guide about tax relief on pension contributions.
       tax_relief_tooltip_html: You get tax relief on pension contributions which means some of the money from your pay that would have gone to the government as tax goes towards your pension instead. <a href="https://www.moneyadviceservice.org.uk/en/articles/tax-relief-and-your-workplace-pension">Read more about how you get tax relief</a>.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -138,7 +138,7 @@ en:
           yours_html: Your <span data-dough-title-frequency>%{salary_frequency}</span> contribution
           employers_html: Employer's <span data-dough-title-frequency>%{salary_frequency}</span> contribution
           total_html: Total <span data-dough-title-frequency>%{salary_frequency}</span> contributions
-        tax_relief_parentheses: includes tax relief of £
+        tax_relief_html: (includes tax relief of <span>%{formatted_tax_relief}</span>)
       tax_relief_warning_html: If you don’t pay income tax on your earnings, you will only receive tax relief on your pension contributions if your pension scheme collects contributions using the tax relief at source method. We have assumed your scheme does. Read more in our guide about <a href="https://www.moneyadviceservice.org.uk/en/articles/tax-relief-and-your-workplace-pension">tax relief on pension contributions</a>.
       tax_relief_warning: If you don’t pay income tax on your earnings, you will only receive tax relief on your pension contributions if your pension scheme collects contributions using the tax relief at source method.  We have assumed your scheme does. Read more in our guide about tax relief on pension contributions.
       tax_relief_tooltip_html: You get tax relief on pension contributions which means some of the money from your pay that would have gone to the government as tax goes towards your pension instead. <a href="https://www.moneyadviceservice.org.uk/en/articles/tax-relief-and-your-workplace-pension">Read more about how you get tax relief</a>.

--- a/spec/javascripts/fixtures/UpdateResults.html
+++ b/spec/javascripts/fixtures/UpdateResults.html
@@ -14,28 +14,31 @@
     <div>
       <div data-dough-results-table>
         <p data-dough-employee-contribution data-employee-contribution=""></p>
-        <p data-dough-tax-relief data-tax-relief=""><span></span></p>
+        <p data-dough-tax-relief data-tax-relief="">
+          <span data-dough-tax-relief-value=""></span>
+        </p>
         <p data-dough-employer-contribution data-employer-contribution=""></p>
         <p data-dough-total></p>
-        <p data-dough-tax-relief data-tax-relief=""></p>
         <p data-dough-title-frequency=""></p>
       </div>
 
       <div data-dough-results-table>
         <p data-dough-employee-contribution data-employee-contribution=""></p>
-        <p data-dough-tax-relief data-tax-relief=""><span></span></p>
+        <p data-dough-tax-relief data-tax-relief="">
+          <span data-dough-tax-relief-value=""></span>
+        </p>
         <p data-dough-employer-contribution data-employer-contribution=""></p>
         <p data-dough-total></p>
-        <p data-dough-tax-relief data-tax-relief=""></p>
         <p data-dough-title-frequency=""></p>
       </div>
 
       <div data-dough-results-table>
         <p data-dough-employee-contribution data-employee-contribution=""></p>
-        <p data-dough-tax-relief data-tax-relief=""><span></span></p>
+        <p data-dough-tax-relief data-tax-relief="">
+          <span data-dough-tax-relief-value=""></span>
+        </p>
         <p data-dough-employer-contribution data-employer-contribution=""></p>
         <p data-dough-total></p>
-        <p data-dough-tax-relief data-tax-relief=""></p>
         <p data-dough-title-frequency=""></p>
       </div>
     </div>

--- a/spec/javascripts/fixtures/UpdateResults.html
+++ b/spec/javascripts/fixtures/UpdateResults.html
@@ -14,7 +14,7 @@
     <div>
       <div data-dough-results-table>
         <p data-dough-employee-contribution data-employee-contribution=""></p>
-        <p data-dough-tax-relief data-tax-relief=""></p>
+        <p data-dough-tax-relief data-tax-relief=""><span></span></p>
         <p data-dough-employer-contribution data-employer-contribution=""></p>
         <p data-dough-total></p>
         <p data-dough-tax-relief data-tax-relief=""></p>
@@ -23,7 +23,7 @@
 
       <div data-dough-results-table>
         <p data-dough-employee-contribution data-employee-contribution=""></p>
-        <p data-dough-tax-relief data-tax-relief=""></p>
+        <p data-dough-tax-relief data-tax-relief=""><span></span></p>
         <p data-dough-employer-contribution data-employer-contribution=""></p>
         <p data-dough-total></p>
         <p data-dough-tax-relief data-tax-relief=""></p>
@@ -32,7 +32,7 @@
 
       <div data-dough-results-table>
         <p data-dough-employee-contribution data-employee-contribution=""></p>
-        <p data-dough-tax-relief data-tax-relief=""></p>
+        <p data-dough-tax-relief data-tax-relief=""><span></span></p>
         <p data-dough-employer-contribution data-employer-contribution=""></p>
         <p data-dough-total></p>
         <p data-dough-tax-relief data-tax-relief=""></p>

--- a/spec/javascripts/tests/UpdateResults_spec.js
+++ b/spec/javascripts/tests/UpdateResults_spec.js
@@ -76,25 +76,25 @@ describe('Update Results', function() {
         var expectedValues = {
           year: {
             employeeContributions: ['£191.24', '£573.72', '£956.20'],
-            taxRelief: ['(includes tax relief of £38.25)', '(includes tax relief of £114.74)', '(includes tax relief of £191.24)'],
+            taxRelief: ['<span>£38.25</span>', '<span>£114.74</span>', '<span>£191.24</span>'],
             employerContributions: ['£191.24', '£382.48', '£573.72'],
             total: ['£382.48', '£956.20', '£1,529.92']
           },
           month: {
             employeeContributions: ['£15.94', '£47.81', '£79.68'],
-            taxRelief: ['(includes tax relief of £3.19)', '(includes tax relief of £9.56)', '(includes tax relief of £15.94)'],
+            taxRelief: ['<span>£3.19</span>', '<span>£9.56</span>', '<span>£15.94</span>'],
             employerContributions: ['£15.94', '£31.87', '£47.81'],
             total: ['£31.88', '£79.68', '£127.49']
           },
           fourweeks: {
             employeeContributions: ['£14.71', '£44.13', '£73.55'],
-            taxRelief: ['(includes tax relief of £2.94)', '(includes tax relief of £8.83)', '(includes tax relief of £14.71)'],
+            taxRelief: ['<span>£2.94</span>', '<span>£8.83</span>', '<span>£14.71</span>'],
             employerContributions: ['£14.71', '£29.42', '£44.13'],
             total: ['£29.42', '£73.55', '£117.68']
           },
           week: {
             employeeContributions: ['£3.68', '£11.03', '£18.39'],
-            taxRelief: ['(includes tax relief of £0.74)', '(includes tax relief of £2.21)', '(includes tax relief of £3.68)'],
+            taxRelief: ['<span>£0.74</span>', '<span>£2.21</span>', '<span>£3.68</span>'],
             employerContributions: ['£3.68', '£7.36', '£11.03'],
             total: ['£7.36', '£18.39', '£29.42']
           }

--- a/spec/javascripts/tests/UpdateResults_spec.js
+++ b/spec/javascripts/tests/UpdateResults_spec.js
@@ -76,25 +76,25 @@ describe('Update Results', function() {
         var expectedValues = {
           year: {
             employeeContributions: ['£191.24', '£573.72', '£956.20'],
-            taxRelief: ['<span>£38.25</span>', '<span>£114.74</span>', '<span>£191.24</span>'],
+            taxRelief: ['£38.25', '£114.74', '£191.24'],
             employerContributions: ['£191.24', '£382.48', '£573.72'],
             total: ['£382.48', '£956.20', '£1,529.92']
           },
           month: {
             employeeContributions: ['£15.94', '£47.81', '£79.68'],
-            taxRelief: ['<span>£3.19</span>', '<span>£9.56</span>', '<span>£15.94</span>'],
+            taxRelief: ['£3.19', '£9.56', '£15.94'],
             employerContributions: ['£15.94', '£31.87', '£47.81'],
             total: ['£31.88', '£79.68', '£127.49']
           },
           fourweeks: {
             employeeContributions: ['£14.71', '£44.13', '£73.55'],
-            taxRelief: ['<span>£2.94</span>', '<span>£8.83</span>', '<span>£14.71</span>'],
+            taxRelief: ['£2.94', '£8.83', '£14.71'],
             employerContributions: ['£14.71', '£29.42', '£44.13'],
             total: ['£29.42', '£73.55', '£117.68']
           },
           week: {
             employeeContributions: ['£3.68', '£11.03', '£18.39'],
-            taxRelief: ['<span>£0.74</span>', '<span>£2.21</span>', '<span>£3.68</span>'],
+            taxRelief: ['£0.74', '£2.21', '£3.68'],
             employerContributions: ['£3.68', '£7.36', '£11.03'],
             total: ['£7.36', '£18.39', '£29.42']
           }
@@ -114,7 +114,7 @@ describe('Update Results', function() {
 
             for (var i = 0, max = this.resultsTables.length; i < max; i++) {
               expect($(this.resultsTables[i]).find('[data-dough-employee-contribution]').html()).to.equal(values.employeeContributions[i]);
-              expect($(this.resultsTables[i]).find('[data-dough-tax-relief]').html()).to.equal(values.taxRelief[i]);
+              expect($(this.resultsTables[i]).find('[data-dough-tax-relief-value]').html()).to.equal(values.taxRelief[i]);
               expect($(this.resultsTables[i]).find('[data-dough-employer-contribution]').html()).to.equal(values.employerContributions[i]);
               expect($(this.resultsTables[i]).find('[data-dough-total]').html()).to.equal(values.total[i]);
               expect($(this.resultsTables[i]).find('[data-dough-title-frequency]').html()).to.equal(titleContributions);

--- a/spec/presenters/period_contribution_presenter_spec.rb
+++ b/spec/presenters/period_contribution_presenter_spec.rb
@@ -37,14 +37,17 @@ RSpec.describe Wpcc::PeriodContributionPresenter do
   describe '#formatted_tax_relief' do
     it 'returns a message with the formatted value' do
       period_contribution.tax_relief = 1.99
+      data_attribute = 'data-dough-tax-relief-value'
+
       expect(subject.formatted_tax_relief).to eq(
-        '(includes tax relief of <span>£1.99</span>)'
+        "(includes tax relief of <span #{data_attribute}>£1.99</span>)"
       )
     end
   end
 
   describe '#employer_frequency_heading' do
     let(:salary_frequency) { Wpcc::SalaryFrequency.new(attributes) }
+    let(:data_attribute) { 'data-dough-title-frequency' }
     let(:attributes) do
       {
         locale: locale,
@@ -56,10 +59,9 @@ RSpec.describe Wpcc::PeriodContributionPresenter do
     context 'for english fourweekly salary frequency' do
       let(:locale) { 'en' }
       it 'returns the english translation for 4-weekly' do
-        # rubocop:disable LineLength
-        expect(subject.employer_frequency_heading(salary_frequency))
-          .to eq('Employer\'s <span data-dough-title-frequency>4-weekly</span> contribution')
-        # rubocop:enable LineLength
+        expect(subject.employer_frequency_heading(salary_frequency)).to eq(
+          "Employer's <span #{data_attribute}>4-weekly</span> contribution"
+        )
       end
     end
 
@@ -70,10 +72,9 @@ RSpec.describe Wpcc::PeriodContributionPresenter do
       after { I18n.locale = :en }
 
       it 'returns the welsh translation for 4-weekly' do
-        # rubocop:disable LineLength
-        expect(subject.employer_frequency_heading(salary_frequency))
-          .to eq('Cyfraniad y cyflogwr <span data-dough-title-frequency>bob 4 wythnos</span>')
-        # rubocop:enable LineLength
+        expect(subject.employer_frequency_heading(salary_frequency)).to eq(
+          "Cyfraniad y cyflogwr <span #{data_attribute}>bob 4 wythnos</span>"
+        )
       end
     end
   end

--- a/spec/presenters/period_contribution_presenter_spec.rb
+++ b/spec/presenters/period_contribution_presenter_spec.rb
@@ -35,11 +35,10 @@ RSpec.describe Wpcc::PeriodContributionPresenter do
   end
 
   describe '#formatted_tax_relief' do
-    let(:period_contribution) { double(tax_relief: 1.99) }
-
     it 'returns a message with the formatted value' do
+      period_contribution.tax_relief = 1.99
       expect(subject.formatted_tax_relief).to eq(
-        '(includes tax relief of £1.99)'
+        '(includes tax relief of <span>£1.99</span>)'
       )
     end
   end


### PR DESCRIPTION
This pr addresses [TP User Story 8551](https://moneyadviceservice.tpondemand.com/RestUI/Board.aspx?acid=DDD7F3A626844AB8D1BEE3F06EC28EFA#page=board/5624876525867731357&appConfig=eyJhY2lkIjoiREI4ODcwRjkxMDNDRTM2NTlBMzhDNTRBRTVBNUU1N0UifQ==&searchPopup=UserStory/8551).

### Objective
Include the welsh translation for the text 'includes tax relief'.

### Technical
* Amend the presenter to get the text from the translation file rather than include the text in the presenter
* Add a span to the translation to enable the javascript to update the tax-relief amount when the salary_frequency is changed.