### PR TITLE
[DEV APPROVED] 8563 - Fixes regex compilation bug in step 2

### DIFF
--- a/app/assets/javascripts/wpcc/components/ContributionConditions.js
+++ b/app/assets/javascripts/wpcc/components/ContributionConditions.js
@@ -40,7 +40,7 @@ define(['jquery', 'DoughBaseComponent'], function($, DoughBaseComponent) {
   //if more than 40k call display function otherwise call the hide function
   ContributionConditions.prototype._calculateContribution = function() {
     var $this = this,
-    salaryNumber = this.$eligibleSalary.text().replace(/[\£,]/g, ''),
+    salaryNumber = this.$eligibleSalary.text().replace(/[£,]/g, ''),
     salaryToNumber = parseInt(salaryNumber),
     salaryContributionAmount = (salaryToNumber/100)*this.$employeeContributions.val();
     


### PR DESCRIPTION
## Issue

An issue was discovered where regex in `ContributionConditions` component was being improperly compiled in the asset pipeline. This prevented the component from working.

[TP](https://moneyadviceservice.tpondemand.com/entity/8563)

**Output after compilation:**
this.$eligibleSalary.text().replace(/[\\xa3,]/g, "")

**Original regex call:**
this.$eligibleSalary.text().replace(/[\£,]/g, ''),

**The regex change lead to the £ symbol not being removed from the string which caused the script to return Nan:**
Salary number: £100000
Salary to number: Nan
salaryContributionAmount: Nan

## Solution

Remove `/` character from the component regex string. This character was being improperly parsed by the asset pipeline, which caused the component to not function properly.


