### PR TITLE
[DEV APPROVED] 8299 Tax relief warning message

### DIFF
--- a/app/controllers/wpcc/your_contributions_controller.rb
+++ b/app/controllers/wpcc/your_contributions_controller.rb
@@ -85,6 +85,7 @@ module Wpcc
       Wpcc::SalaryMessage.new(
         salary: session[:salary].to_f.round(2),
         salary_frequency: session[:salary_frequency],
+        employee_percent: session[:employee_percent],
         text: :manually_opt_in
       )
     end

--- a/app/controllers/wpcc/your_results_controller.rb
+++ b/app/controllers/wpcc/your_results_controller.rb
@@ -76,7 +76,8 @@ module Wpcc
     def salary_message
       Wpcc::SalaryMessage.new(
         salary: session[:salary].to_f.round(2),
-        salary_frequency: session[:salary_frequency]
+        salary_frequency: session[:salary_frequency],
+        employee_percent: session[:employee_percent]
       )
     end
   end

--- a/app/models/wpcc/salary_message.rb
+++ b/app/models/wpcc/salary_message.rb
@@ -1,10 +1,11 @@
 module Wpcc
   class SalaryMessage
     include ActiveModel::Model
-    attr_accessor :salary, :salary_frequency, :text
+    attr_accessor :salary, :salary_frequency, :employee_percent, :text
 
     OPT_IN_SALARY_LOWER_LIMIT = 5_876
     OPT_IN_SALARY_UPPER_LIMIT = 10_000
+    TAX_RELIEF_MAX_CONTRIBUTION = 40_000
     TAX_RELIEF_THRESHOLD_RATE = {
       year: 11_500,
       month: 958.33,
@@ -20,6 +21,10 @@ module Wpcc
       valid_salary_frequency? && salary_below_frequency_threshold?
     end
 
+    def above_max_contribution?
+      employee_contribution > TAX_RELIEF_MAX_CONTRIBUTION
+    end
+
     private
 
     def valid_salary_frequency?
@@ -28,6 +33,11 @@ module Wpcc
 
     def salary_below_frequency_threshold?
       salary < TAX_RELIEF_THRESHOLD_RATE[salary_frequency.to_sym]
+    end
+
+    def employee_contribution
+      frequency = Wpcc::SalaryFrequencyConverter.convert(salary_frequency)
+      frequency * salary * employee_percent.to_i / 100
     end
   end
 end

--- a/app/presenters/wpcc/message_presenter.rb
+++ b/app/presenters/wpcc/message_presenter.rb
@@ -27,5 +27,18 @@ module Wpcc
         t("wpcc.details.section__heading.contribution_#{preference}")
       ].join(', ')
     end
+
+    def show_above_max_contribution?
+      above_max_contribution?
+    end
+
+    def above_max_contribution
+      amount = formatted_currency(
+        Wpcc::SalaryMessage::TAX_RELIEF_MAX_CONTRIBUTION,
+        precision: 0
+      )
+
+      t('wpcc.contributions.contribution_gt40000_warning', amount: amount)
+    end
   end
 end

--- a/app/views/wpcc/shared/_your_contributions.html.erb
+++ b/app/views/wpcc/shared/_your_contributions.html.erb
@@ -1,0 +1,17 @@
+<section class="section section--contributions">
+  <h2 class="section__heading contributions__heading">2. <%= t('wpcc.contributions.title') %>
+    <span class="section__heading-summary" data-dough-contributions-heading-summary>
+      <%= t('wpcc.results.contribution_changes.you') %>: <%= session[:employee_percent] %>%, <%= t('wpcc.results.contribution_changes.employer') %>: <%= session[:employer_percent] %>%
+    </span>
+    <span>
+      <%= link_to(t('wpcc.edit'), new_your_contribution_path, class: 'section__heading-edit') %>
+    </span>
+  </h2>
+  <% if message_presenter.show_above_max_contribution? %>
+    <div class="contributions__row">
+      <div class="callout">
+        <p><%= message_presenter.above_max_contribution %></p>
+      </div>
+    </div>
+  <% end %>
+</section>

--- a/app/views/wpcc/your_contributions/new.html.erb
+++ b/app/views/wpcc/your_contributions/new.html.erb
@@ -54,11 +54,7 @@
       <div class="contributions__row">
         <div class="form__row details__callout details__callout--inactive" data-dough-callout-contribution-gt40000>
           <div class="callout">
-            <p>
-              <%= t('wpcc.contributions.contribution_gt40000_warning', 
-                formatted_upper_earnings: @your_contribution.formatted_upper_earnings)
-              %>
-            </p>
+            <p><%= @message_presenter.above_max_contribution %></p>
           </div>
         </div>
         <%= f.submit(t('wpcc.contributions.calculate_button'), class: 'button button--primary', 'data-dough-submit': true) %>

--- a/app/views/wpcc/your_results/index.html.erb
+++ b/app/views/wpcc/your_results/index.html.erb
@@ -1,13 +1,5 @@
 <%= render 'wpcc/shared/your_details' %>
-
-<section class="section section--contributions">
-  <h2 class="section__heading contributions__heading">2. <%= t('wpcc.contributions.title') %>
-    <span class="section__heading-summary" data-dough-contributions-heading-summary><%= t('wpcc.results.contribution_changes.you') %>: <%= session[:employee_percent] %>%, <%= t('wpcc.results.contribution_changes.employer') %>: <%= session[:employer_percent] %>%</span>
-    <span>
-      <%= link_to(t('wpcc.edit'), new_your_contribution_path, class: 'section__heading-edit') %>
-    </span>
-  </h2>
-</section>
+<%= render 'wpcc/shared/your_contributions', message_presenter: message_presenter %>
 
 <section class="section section--results">
   <h2 class="section__heading results__heading">3. <%= t('wpcc.results.title') %></h2>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -96,7 +96,7 @@ cy:
       employer_contribution_tip: Yr isafswm cyfreithiol yw 1%
       input_of_label: '% o'
       calculate_button: Cyfrifwch eich cyfraniadau
-      contribution_gt40000_warning: Rhoddir gostyngiad treth ar gyfraniadau hyd at %{formatted_upper_earnings} y flwyddyn yn unig, neu 100% o’ch enillion, pa bynnag un sydd leiaf.
+      contribution_gt40000_warning: Rhoddir gostyngiad treth ar gyfraniadau hyd at %{amount} y flwyddyn yn unig, neu 100% o’ch enillion, pa bynnag un sydd leiaf.
       employee_validation:
         blank: Rhowch eich cyfraniad
         out_of_range: Rhaid i'ch cyfraniad fod yn yr ystod 0 - 100%

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -96,7 +96,7 @@ en:
       employer_contribution_tip: The legal minimum is 1%
       input_of_label: '% of'
       calculate_button: Calculate your contributions
-      contribution_gt40000_warning: Tax relief is only applied to contributions of up to %{formatted_upper_earnings} per year or 100% of your earnings, whichever is lower.
+      contribution_gt40000_warning: Tax relief is only applied to contributions of up to %{amount} per year or 100% of your earnings, whichever is lower.
       employee_validation:
         blank: Please enter your contribution
         out_of_range: Your contribution must be in the range 0% - 100%

--- a/features/_your_results/contributions_above_maximum_message.feature
+++ b/features/_your_results/contributions_above_maximum_message.feature
@@ -1,0 +1,27 @@
+Feature: Limit Tax Relief
+  In order to get a clear picture of the impact on my take-home pay.
+  As an employee contributing greater than £40,000 per year to my pension
+  I want the results to reflect the fact that I will not get tax relief
+  for any contribution over £40,000 per year.
+
+  Scenario Outline: Employee contributing more than the equivalent of £40,000 per year to pension
+    Given I am on the Your Details step
+    When I enter "<salary>" "<salary_frequency>" with contributions greater than the maximum for tax relief
+    And I move on to the results page
+    Then I should see the contribution above maximum "<message>"
+
+    Examples:
+      | salary  | salary_frequency | message |
+      | 80000   | per Year         | Tax relief is only applied to contributions of up to £40,000 per year or 100% of your earnings, whichever is lower. |
+      | 40000   | per Month        | Tax relief is only applied to contributions of up to £40,000 per year or 100% of your earnings, whichever is lower. |
+      | 45000   | per 4 weeks      | Tax relief is only applied to contributions of up to £40,000 per year or 100% of your earnings, whichever is lower. |
+      | 12000   | per Week         | Tax relief is only applied to contributions of up to £40,000 per year or 100% of your earnings, whichever is lower. |
+
+    @welsh
+    Examples:
+      | salary  | salary_frequency | message |
+      | 80000   | y Flwyddyn       | Rhoddir gostyngiad treth ar gyfraniadau hyd at £40,000 y flwyddyn yn unig, neu 100% o’ch enillion, pa bynnag un sydd leiaf. |
+      | 40000   | y Mis            | Rhoddir gostyngiad treth ar gyfraniadau hyd at £40,000 y flwyddyn yn unig, neu 100% o’ch enillion, pa bynnag un sydd leiaf. |
+      | 45000   | fesul 4 wythnos  | Rhoddir gostyngiad treth ar gyfraniadau hyd at £40,000 y flwyddyn yn unig, neu 100% o’ch enillion, pa bynnag un sydd leiaf. |
+      | 12000   | y Wythnos        | Rhoddir gostyngiad treth ar gyfraniadau hyd at £40,000 y flwyddyn yn unig, neu 100% o’ch enillion, pa bynnag un sydd leiaf. |
+

--- a/features/step_definitions/your_details_steps.rb
+++ b/features/step_definitions/your_details_steps.rb
@@ -45,7 +45,7 @@ end
 
 When(/^I enter my details$/) do
   step %{I enter my age as "35"}
-  step %{I select my gender as "Female"}
+  step %{I select my gender as "#{I18n.translate('wpcc.details.options.gender.female')}"}
 end
 
 When(/^I enter my personal details$/) do
@@ -58,6 +58,13 @@ Given(/^my salary is "([^"]*)" "([^"]*)" with "([^"]*)" contribution$/) do |sala
   step %{I enter my salary as "#{salary}"}
   step %{I select my salary frequency as "#{salary_frequency}"}
   step %{I choose my contribution preference as "#{contribution}"}
+end
+
+When(/^I enter "([^"]*)" "([^"]*)" with contributions greater than the maximum for tax relief$/) do |salary, salary_frequency|
+  step %{I enter my details}
+  step %{my salary is "#{salary}" "#{salary_frequency}" with "Full" contribution}
+  step %{I click the Next button}
+  step %{my contribution is "60" percent}
 end
 
 When(/^I fill in my details$/) do

--- a/features/step_definitions/your_results_steps.rb
+++ b/features/step_definitions/your_results_steps.rb
@@ -108,6 +108,10 @@ Then(/^I should( not)? see the manually_opt_in "([^"]*)"$/) do |should_not, mess
   end
 end
 
+Then(/^I should see the contribution above maximum "([^"]*)"$/) do |message|
+  expect(page).to have_content(message)
+end
+
 Then(/^my results should have "([^"]*)" "([^"]*)" and "([^"]*)"$/) do |your_heading, employer_heading, total_heading|
   expected_headings = [your_heading, employer_heading, total_heading]
 

--- a/spec/controllers/your_contributions_controller_spec.rb
+++ b/spec/controllers/your_contributions_controller_spec.rb
@@ -97,6 +97,7 @@ module Wpcc
             .with(
               salary: salary,
               salary_frequency: salary_frequency,
+              employee_percent: 10,
               text: :manually_opt_in
             )
             .and_return(salary_message)

--- a/spec/controllers/your_results_controller_spec.rb
+++ b/spec/controllers/your_results_controller_spec.rb
@@ -100,7 +100,8 @@ RSpec.describe Wpcc::YourResultsController do
         .to receive(:new)
         .with(
           salary: 25_000.00,
-          salary_frequency: 'week'
+          salary_frequency: 'week',
+          employee_percent: nil
         )
         .and_return(salary_message)
 


### PR DESCRIPTION
This pr addresses [TP User Story 8299](https://moneyadviceservice.tpondemand.com/RestUI/Board.aspx?acid=DDD7F3A626844AB8D1BEE3F06EC28EFA#page=board/5624876525867731357&appConfig=eyJhY2lkIjoiREI4ODcwRjkxMDNDRTM2NTlBMzhDNTRBRTVBNUU1N0UifQ==&boardPopup=userstory/8299/silent).
### Objective
If employee_contributions are above the amount for which tax relief is applicable, display an appropriate message in the your_contributions section on the results view.

### Technical
* new method in SalaryMessage to make this check
* method in messagePresenter which gets the translation text using the max amount
* correct figure to pass to the translation
* move your_contributions markup in your_results view into a partial