### PR TITLE
[DEV APPROVED] Refactors naming of data- attributes

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,6 @@
+## 1.9.2: 
+* Refactors data attributes for internal components
+
 ## 1.9.1: 
 * TP-8556: Fixes Popuptips and div floating issue in step 1
 

--- a/app/assets/javascripts/wpcc/components/ConditionalMessaging.js
+++ b/app/assets/javascripts/wpcc/components/ConditionalMessaging.js
@@ -7,12 +7,12 @@ define(['jquery', 'DoughBaseComponent'], function($, DoughBaseComponent) {
   ConditionalMessaging = function($el, config) {
     ConditionalMessaging.baseConstructor.call(this, $el, config, defaultConfig);
 
-    this.$ageField = this.$el.find('[data-dough-age-field]');
-    this.$genderSelect = this.$el.find('[data-dough-gender-select]');
-    this.$callout_lt16 = this.$el.find('[data-dough-callout-lt16]');
-    this.$callout_optIn = this.$el.find('[data-dough-callout-optIn]');
-    this.$callout_gt74 = this.$el.find('[data-dough-callout-gt74]');
-    this.$submit = this.$el.find('[data-dough-submit]');
+    this.$ageField = this.$el.find('[data-wpcc-age-field]');
+    this.$genderSelect = this.$el.find('[data-wpcc-gender-select]');
+    this.$callout_lt16 = this.$el.find('[data-wpcc-callout-lt16]');
+    this.$callout_optIn = this.$el.find('[data-wpcc-callout-optIn]');
+    this.$callout_gt74 = this.$el.find('[data-wpcc-callout-gt74]');
+    this.$submit = this.$el.find('[data-wpcc-submit]');
   };
 
   /**

--- a/app/assets/javascripts/wpcc/components/ContributionConditions.js
+++ b/app/assets/javascripts/wpcc/components/ContributionConditions.js
@@ -7,9 +7,9 @@ define(['jquery', 'DoughBaseComponent'], function($, DoughBaseComponent) {
   ContributionConditions = function($el, config) {
     ContributionConditions.baseConstructor.call(this, $el, config, defaultConfig);
 
-    this.$employeeContributions = this.$el.find('[data-dough-employee-contributions]');
-    this.$eligibleSalary = this.$el.find('[data-dough-contribution-salary]');
-    this.$contributionWarning = this.$el.find('[data-dough-callout-contribution-gt40000]');
+    this.$employeeContributions = this.$el.find('[data-wpcc-employee-contributions]');
+    this.$eligibleSalary = this.$el.find('[data-wpcc-contribution-salary]');
+    this.$contributionWarning = this.$el.find('[data-wpcc-callout-contribution-gt40000]');
 
   };
 

--- a/app/assets/javascripts/wpcc/components/Email.js
+++ b/app/assets/javascripts/wpcc/components/Email.js
@@ -14,12 +14,12 @@ define(['jquery', 'DoughBaseComponent'], function($, DoughBaseComponent) {
   Email = function($el, config) {
     Email.baseConstructor.call(this, $el, config, defaultConfig);
 
-    this.$emailLink = this.$el.find('[data-dough-email-link]');
-    this.$detailsHeadingSummary = this.$el.find('[data-dough-details-heading-summary]');
-    this.$contributionsHeadingSummary = this.$el.find('[data-dough-contributions-heading-summary]');
-    this.$eligibleSalary = this.$el.find('[data-dough-eligible-salary]');
-    this.$resultsTables = this.$el.find('[data-dough-results-table]');
-    this.$frequencySelector = this.$el.find('[data-dough-selector]');
+    this.$emailLink = this.$el.find('[data-wpcc-email-link]');
+    this.$detailsHeadingSummary = this.$el.find('[data-wpcc-details-heading-summary]');
+    this.$contributionsHeadingSummary = this.$el.find('[data-wpcc-contributions-heading-summary]');
+    this.$eligibleSalary = this.$el.find('[data-wpcc-eligible-salary]');
+    this.$resultsTables = this.$el.find('[data-wpcc-results-table]');
+    this.$frequencySelector = this.$el.find('[data-wpcc-selector]');
   };
 
   /**
@@ -64,17 +64,17 @@ define(['jquery', 'DoughBaseComponent'], function($, DoughBaseComponent) {
     for (var i = 0, max = this.$resultsTables.length; i < max; i++) {
       var resultTable = this.$resultsTables[i];
 
-      message += $(resultTable).find('[data-dough-results-period-title]').text().trim() + '\n';
+      message += $(resultTable).find('[data-wpcc-results-period-title]').text().trim() + '\n';
       message +=
-        $(resultTable).find('[data-dough-period-heading-yours]').text().trim() + ': ' +
-        $(resultTable).find('[data-dough-employee-contribution]').text().trim() + ' ' +
-        $(resultTable).find('[data-dough-tax-relief]').text().trim() + '\n';
+        $(resultTable).find('[data-wpcc-period-heading-yours]').text().trim() + ': ' +
+        $(resultTable).find('[data-wpcc-employee-contribution]').text().trim() + ' ' +
+        $(resultTable).find('[data-wpcc-tax-relief]').text().trim() + '\n';
       message +=
-        $(resultTable).find('[data-dough-period-heading-employers]').text().trim() + ': ' +
-        $(resultTable).find('[data-dough-employer-contribution]').text().trim() + '\n';
+        $(resultTable).find('[data-wpcc-period-heading-employers]').text().trim() + ': ' +
+        $(resultTable).find('[data-wpcc-employer-contribution]').text().trim() + '\n';
       message +=
-        $(resultTable).find('[data-dough-period-heading-total]').text().trim() + ': ' +
-        $(resultTable).find('[data-dough-total]').text().trim();
+        $(resultTable).find('[data-wpcc-period-heading-total]').text().trim() + ': ' +
+        $(resultTable).find('[data-wpcc-total]').text().trim();
 
       if (i !== max - 1) {
         message += '\n\n';

--- a/app/assets/javascripts/wpcc/components/SalaryConditions.js
+++ b/app/assets/javascripts/wpcc/components/SalaryConditions.js
@@ -8,21 +8,21 @@ define(['jquery', 'DoughBaseComponent'], function($, DoughBaseComponent) {
     SalaryConditions.baseConstructor.call(this, $el, config, defaultConfig);
 
     // Step 1 - Details
-    this.$salaryField = this.$el.find('[data-dough-salary-input]');
-    this.$salaryFrequency = this.$el.find('[data-dough-frequency-select]');
-    this.$callout_lt5876 = this.$el.find('[data-dough-callout-lt5876]');
-    this.$callout_gt5876_lt10000 = this.$el.find('[data-dough-callout-gt5876_lt10000]');
-    this.$radioDisabled = this.$el.find('[data-dough-callout-radio-disabled]');
-    this.$employerPartRadio = this.$el.find('[data-dough-employer-part-radio]');
-    this.$employerFullRadio = this.$el.find('[data-dough-employer-full-radio]');
+    this.$salaryField = this.$el.find('[data-wpcc-salary-input]');
+    this.$salaryFrequency = this.$el.find('[data-wpcc-frequency-select]');
+    this.$callout_lt5876 = this.$el.find('[data-wpcc-callout-lt5876]');
+    this.$callout_gt5876_lt10000 = this.$el.find('[data-wpcc-callout-gt5876_lt10000]');
+    this.$radioDisabled = this.$el.find('[data-wpcc-callout-radio-disabled]');
+    this.$employerPartRadio = this.$el.find('[data-wpcc-employer-part-radio]');
+    this.$employerFullRadio = this.$el.find('[data-wpcc-employer-full-radio]');
     this.contribution = 'full';
 
     // Step 2 - Contributions
-    this.$employeeTip = this.$el.find('[data-dough-employee-tip]');
-    this.$employeeTip_lt5876 = this.$el.find('[data-dough-employee-tip-lt5876]');
-    this.$employerTip = this.$el.find('[data-dough-employer-tip]');
-    this.$employeeContributions = this.$el.find('[data-dough-employee-contributions]');
-    this.$employerContributions = this.$el.find('[data-dough-employer-contributions]');
+    this.$employeeTip = this.$el.find('[data-wpcc-employee-tip]');
+    this.$employeeTip_lt5876 = this.$el.find('[data-wpcc-employee-tip-lt5876]');
+    this.$employerTip = this.$el.find('[data-wpcc-employer-tip]');
+    this.$employeeContributions = this.$el.find('[data-wpcc-employee-contributions]');
+    this.$employerContributions = this.$el.find('[data-wpcc-employer-contributions]');
   };
 
   DoughBaseComponent.extend(SalaryConditions);

--- a/app/assets/javascripts/wpcc/components/UpdateResults.js
+++ b/app/assets/javascripts/wpcc/components/UpdateResults.js
@@ -6,8 +6,8 @@ define(['jquery', 'DoughBaseComponent'], function($, DoughBaseComponent) {
   UpdateResults = function($el, config) {
     UpdateResults.baseConstructor.call(this, $el, config);
 
-    this.frequencySelector = this.$el.find('[data-dough-selector]');
-    this.resultsTables = this.$el.find('[data-dough-results-table]')
+    this.frequencySelector = this.$el.find('[data-wpcc-selector]');
+    this.resultsTables = this.$el.find('[data-wpcc-results-table]')
     this.values = {
       employeeContributions: [],
       employerContributions: [],
@@ -44,9 +44,9 @@ define(['jquery', 'DoughBaseComponent'], function($, DoughBaseComponent) {
     var unitConverter = this._unitConverter();
 
     this.resultsTables.each(function() {
-      _this.values.employeeContributions.push($(this).find('[data-dough-employee-contribution]').attr('data-value') * unitConverter);
-      _this.values.employerContributions.push($(this).find('[data-dough-employer-contribution]').attr('data-value') * unitConverter);
-      _this.values.taxRelief.push($(this).find('[data-dough-tax-relief]').attr('data-value') * unitConverter);
+      _this.values.employeeContributions.push($(this).find('[data-wpcc-employee-contribution]').attr('data-value') * unitConverter);
+      _this.values.employerContributions.push($(this).find('[data-wpcc-employer-contribution]').attr('data-value') * unitConverter);
+      _this.values.taxRelief.push($(this).find('[data-wpcc-tax-relief]').attr('data-value') * unitConverter);
     });
   }
 
@@ -67,11 +67,11 @@ define(['jquery', 'DoughBaseComponent'], function($, DoughBaseComponent) {
       var taxRelief_html = '£' + taxRelief;
       var total_html = '£' + total.toFixed(2).replace(/\B(?=(\d{3})+(?!\d))/g, ",");
 
-      $(this.resultsTables[i]).find('[data-dough-employee-contribution]').html(employeeContributions_html);
-      $(this.resultsTables[i]).find('[data-dough-employer-contribution]').html(employerContributions_html);
-      $(this.resultsTables[i]).find('[data-dough-tax-relief-value]').text(taxRelief_html);
-      $(this.resultsTables[i]).find('[data-dough-total]').html(total_html);
-      $(this.resultsTables[i]).find('[data-dough-title-frequency]').html(titleContributions);
+      $(this.resultsTables[i]).find('[data-wpcc-employee-contribution]').html(employeeContributions_html);
+      $(this.resultsTables[i]).find('[data-wpcc-employer-contribution]').html(employerContributions_html);
+      $(this.resultsTables[i]).find('[data-wpcc-tax-relief-value]').text(taxRelief_html);
+      $(this.resultsTables[i]).find('[data-wpcc-total]').html(total_html);
+      $(this.resultsTables[i]).find('[data-wpcc-title-frequency]').html(titleContributions);
     };
   }
 

--- a/app/views/wpcc/shared/_your_contributions.html.erb
+++ b/app/views/wpcc/shared/_your_contributions.html.erb
@@ -1,6 +1,6 @@
 <section class="section section--contributions">
   <h2 class="section__heading contributions__heading">2. <%= t('wpcc.contributions.title') %>
-    <span class="section__heading-summary" data-dough-contributions-heading-summary>
+    <span class="section__heading-summary" data-wpcc-contributions-heading-summary>
       <%= t('wpcc.results.contribution_changes.you') %>: <%= session[:employee_percent] %>%, <%= t('wpcc.results.contribution_changes.employer') %>: <%= session[:employer_percent] %>%
     </span>
     <span>

--- a/app/views/wpcc/shared/_your_details.html.erb
+++ b/app/views/wpcc/shared/_your_details.html.erb
@@ -1,6 +1,6 @@
 <section class="section section--details details">
   <h2 class="section__heading details__heading">1. <%= t('wpcc.details.title') %>
-    <span class="section__heading-summary" data-dough-details-heading-summary><%= message_presenter.your_details_summary(session) %></span>
+    <span class="section__heading-summary" data-wpcc-details-heading-summary><%= message_presenter.your_details_summary(session) %></span>
     <span>
       <%= link_to(t('wpcc.edit'), new_your_detail_path, class: 'section__heading-edit') %>
     </span>

--- a/app/views/wpcc/your_contributions/new.html.erb
+++ b/app/views/wpcc/your_contributions/new.html.erb
@@ -19,31 +19,31 @@
       <div class="contributions__row">
         <div class="contributions__source contributions__source--employee form__row">
           <h3 class="contributions__source-title"><%= t('wpcc.contributions.your_contribution_title') %></h3>
-          <p data-dough-employee-tip><%= t('wpcc.contributions.your_contribution_tip') %></p>
-          <p data-dough-employee-tip-lt5876 class="is-hidden"><%= t('wpcc.contributions.your_contribution_tip_lt5876') %></p>
+          <p data-wpcc-employee-tip><%= t('wpcc.contributions.your_contribution_tip') %></p>
+          <p data-wpcc-employee-tip-lt5876 class="is-hidden"><%= t('wpcc.contributions.your_contribution_tip_lt5876') %></p>
           <%= f.number_field :employee_percent,
             class: "contributions__source-input",
             required: true,
             min: 0,
             max: 100,
-            'data-dough-employee-contributions': true,
+            'data-wpcc-employee-contributions': true,
             'data-dough-validation-empty': t('wpcc.contributions.employee_validation.blank'),
             'data-dough-validation-invalid': t('wpcc.contributions.employee_validation.out_of_range')
           %>
           <%= t('wpcc.contributions.input_of_label') %>
           <span>
-            <span data-dough-contribution-salary><%= @your_contribution.formatted_eligible_salary %></span>
+            <span data-wpcc-contribution-salary><%= @your_contribution.formatted_eligible_salary %></span>
           </span>
         </div>
         <div class="contributions__source contributions__source--employer form__row">
           <h3 class="contributions__source-title"><%= t('wpcc.contributions.employer_contribution_title') %></h3>
-          <p data-dough-employer-tip><%= t('wpcc.contributions.employer_contribution_tip') %></p>
+          <p data-wpcc-employer-tip><%= t('wpcc.contributions.employer_contribution_tip') %></p>
           <%= f.number_field :employer_percent,
             class: "contributions__source-input",
             required: true,
             min: 0,
             max: 100,
-            'data-dough-employer-contributions': true,
+            'data-wpcc-employer-contributions': true,
             'data-dough-validation-empty': t('wpcc.contributions.employer_validation.blank'),
             'data-dough-validation-invalid': t('wpcc.contributions.employee_validation.out_of_range')
           %>
@@ -52,12 +52,12 @@
         </div>
       </div>
       <div class="contributions__row">
-        <div class="form__row details__callout details__callout--inactive" data-dough-callout-contribution-gt40000>
+        <div class="form__row details__callout details__callout--inactive" data-wpcc-callout-contribution-gt40000>
           <div class="callout">
             <p><%= @message_presenter.above_max_contribution %></p>
           </div>
         </div>
-        <%= f.submit(t('wpcc.contributions.calculate_button'), class: 'button button--primary', 'data-dough-submit': true) %>
+        <%= f.submit(t('wpcc.contributions.calculate_button'), class: 'button button--primary', 'data-wpcc-submit': true) %>
       </div>
     </div>
   <% end %>

--- a/app/views/wpcc/your_details/new.html.erb
+++ b/app/views/wpcc/your_details/new.html.erb
@@ -24,7 +24,7 @@
             </div>
             <%= f.errors_for :age %>
             <%= f.text_field :age,
-              'data-dough-age-field': true,
+              'data-wpcc-age-field': true,
               required: true,
               'data-dough-validation-empty': t('wpcc.details.age.validation')
             %>
@@ -48,7 +48,7 @@
             <%= f.select :gender,
               options_for_select(@your_details_form.gender_options, @your_details_form.gender),
               {prompt: t('wpcc.details.prompt')},
-              'data-dough-gender-select': true,
+              'data-wpcc-gender-select': true,
               required: true,
               'data-dough-validation-empty': t('wpcc.details.gender.validation')
             %>
@@ -61,17 +61,17 @@
       </div>
       <div class="details__row">
         <div class="details__callouts">
-          <div class="form__row details__callout details__callout--inactive" data-dough-callout-lt16>
+          <div class="form__row details__callout details__callout--inactive" data-wpcc-callout-lt16>
             <div class="callout">
               <p><%= t('wpcc.details.callout__lt16') %></p>
             </div>
           </div>
-          <div class="form__row details__callout details__callout--inactive" data-dough-callout-optIn>
+          <div class="form__row details__callout details__callout--inactive" data-wpcc-callout-optIn>
             <div class="callout">
               <p><%= t('wpcc.details.callout__optIn') %></p>
             </div>
           </div>
-          <div class="form__row details__callout details__callout--inactive" data-dough-callout-gt74>
+          <div class="form__row details__callout details__callout--inactive" data-wpcc-callout-gt74>
             <div class="callout">
               <p><%= t('wpcc.details.callout__gt74') %></p>
             </div>
@@ -93,23 +93,23 @@
                 <%= f.text_field :salary,
                   required: true,
                   'data-dough-validation-empty': t('wpcc.details.salary.validation'),
-                  'data-dough-salary-input': true
+                  'data-wpcc-salary-input': true
                 %>
                 </div>
                 <div class="details__salary-frequency">
                   <%= f.label :salary_frequency, t('wpcc.details.salary.frequency.label'), class: 'form__label-heading details__field-label visually-hidden' %>
-                <%= f.select(:salary_frequency, options_for_select(@your_details_form.salary_frequency_options, @your_details_form.salary_frequency), {}, {'data-dough-frequency-select': true}) %>
+                <%= f.select(:salary_frequency, options_for_select(@your_details_form.salary_frequency_options, @your_details_form.salary_frequency), {}, {'data-wpcc-frequency-select': true}) %>
                 </div>
               </div>
             <% end %>
           </div>
           <div class="details__callouts">
-            <div class="form__row details__callout details__callout--inactive" data-dough-callout-lt5876>
+            <div class="form__row details__callout details__callout--inactive" data-wpcc-callout-lt5876>
               <div class="callout">
                 <p><%= t('wpcc.details.callout__lt5876') %></p>
               </div>
             </div>
-            <div class="form__row details__callout details__callout--inactive" data-dough-callout-gt5876_lt10000>
+            <div class="form__row details__callout details__callout--inactive" data-wpcc-callout-gt5876_lt10000>
               <div class="callout">
                 <p><%= t('wpcc.details.callout__gt5876_lt10000') %></p>
               </div>
@@ -142,7 +142,7 @@
               <%= render 'wpcc/tooltips/close' %>
             </div>
             <div class="details__callouts">
-              <div class="form__row details__callout <%= @your_details_form.activate_disabled_callout %>" data-dough-callout-radio-disabled>
+              <div class="form__row details__callout <%= @your_details_form.activate_disabled_callout %>" data-wpcc-callout-radio-disabled>
                 <div class="callout">
                   <p><%= t('wpcc.details.callout__radiodisabled') %></p>
                 </div>
@@ -152,11 +152,11 @@
               <%= f.form_row :contribution_preference do %>
                 <%= f.errors_for :contribution_preference %>
                 <div class="form__group-item details__calculate-item">
-                  <%= f.radio_button(:contribution_preference, 'minimum', class: 'details__calculate-item-select', 'data-dough-employer-part-radio': true) %>
+                  <%= f.radio_button(:contribution_preference, 'minimum', class: 'details__calculate-item-select', 'data-wpcc-employer-part-radio': true) %>
                   <%= f.label(:contribution_preference_minimum, t('wpcc.details.options.contribution_preference.minimum'), class: 'details__calculate-item-label') %>
                 </div>
                 <div class="form__group-item details__calculate-item">
-                  <%= f.radio_button(:contribution_preference, 'full', class: 'details__calculate-item-select', 'data-dough-employer-full-radio': true) %>
+                  <%= f.radio_button(:contribution_preference, 'full', class: 'details__calculate-item-select', 'data-wpcc-employer-full-radio': true) %>
                   <%= f.label(:contribution_preference_full, t('wpcc.details.options.contribution_preference.full'), class: 'details__calculate-item-label') %>
                 </div>
               <% end %>
@@ -167,7 +167,7 @@
       <div class="details__row">
         <div class="details__field">
           <div class="form__row">
-            <%= f.submit(t('wpcc.details.next'), class: 'button button--primary', 'data-dough-submit': true) %>
+            <%= f.submit(t('wpcc.details.next'), class: 'button button--primary', 'data-wpcc-submit': true) %>
           </div>
         </div>
       </div>

--- a/app/views/wpcc/your_results/_contributions_table.html.erb
+++ b/app/views/wpcc/your_results/_contributions_table.html.erb
@@ -1,17 +1,16 @@
 <div class="results__row">
   <% schedule.each do |period| %>
-    <div class="results__period results__period-<%= period.name %>" data-dough-component="PopupTip" data-dough-results-table>
-      <h3 class="results__period-title" data-dough-results-period-title><%= period.title %></h3>
+    <div class="results__period results__period-<%= period.name %>" data-dough-component="PopupTip" data-wpcc-results-table>
+      <h3 class="results__period-title" data-wpcc-results-period-title><%= period.title %></h3>
 
-      <p class="results__period-heading" data-dough-period-heading-yours>
+      <p class="results__period-heading" data-wpcc-period-heading-yours>
         <%= t('wpcc.results.period.contribution_heading.yours_html', salary_frequency: salary_frequency.to_adj) %>
       </p>
 
-      <p class="results__period-details results__period-employee-contribution" data-dough-employee-contribution data-value="<%= period.employee_contribution %>">
+      <p class="results__period-details results__period-employee-contribution" data-wpcc-employee-contribution data-value="<%= period.employee_contribution %>">
         <%= period.formatted_employee_contribution %>
       </p>
-
-      <p class="results__period-parenthesis" data-dough-tax-relief data-value="<%= period.tax_relief %>">
+      <p class="results__period-parenthesis" data-wpcc-tax-relief data-value="<%= period.tax_relief %>">
         <span class="results__period-tax-relief">
           <%= period.formatted_tax_relief %>
         </span>
@@ -25,19 +24,19 @@
         <%= render 'wpcc/tooltips/close' %>
       </div>
 
-      <p class="results__period-heading" data-dough-period-heading-employers>
+      <p class="results__period-heading" data-wpcc-period-heading-employers>
         <%= period.employer_frequency_heading(salary_frequency).html_safe %>
       </p>
 
-      <p class="results__period-details results__period-employer-contribution" data-dough-employer-contribution data-value="<%= period.employer_contribution %>">
+      <p class="results__period-details results__period-employer-contribution" data-wpcc-employer-contribution data-value="<%= period.employer_contribution %>">
         <%= period.formatted_employer_contribution %>
       </p>
 
-      <p class="results__period-heading" data-dough-period-heading-total>
+      <p class="results__period-heading" data-wpcc-period-heading-total>
         <%= t('wpcc.results.period.contribution_heading.total_html', salary_frequency: salary_frequency.to_adj) %>
       </p>
 
-      <p class="results__period-details results__period-total-contributions" data-dough-total>
+      <p class="results__period-details results__period-total-contributions" data-wpcc-total>
         <%= period.formatted_total_contributions %>
       </p>
     </div>

--- a/app/views/wpcc/your_results/_frequency_selector_form.html.erb
+++ b/app/views/wpcc/your_results/_frequency_selector_form.html.erb
@@ -7,7 +7,7 @@
         message_presenter.salary_frequency_options,
         salary_frequency.to_s
       ),
-        'data-dough-selector': true
+        'data-wpcc-selector': true
     ) %>
 
     <%= submit_tag t('wpcc.results.edit_frequency.button'), class: 'results__salary-frequency-submit' %>

--- a/app/views/wpcc/your_results/index.html.erb
+++ b/app/views/wpcc/your_results/index.html.erb
@@ -22,7 +22,7 @@
     <%= render 'period_percents_table' %>
 
     <p><a href="#" data-dough-component="Print"><%= t('wpcc.results.print_link') %></a></p>
-    <p><a href="mailto:?body=" data-dough-email-link><%= t('wpcc.results.email_link') %></a></p>
+    <p><a href="mailto:?body=" data-wpcc-email-link><%= t('wpcc.results.email_link') %></a></p>
     <p><%= link_to(t('wpcc.results.reset_calculator'), your_detail_path(session), method: :delete) %></p>
   </div>
 

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -114,9 +114,9 @@ cy:
         Bydd cyfraddau cyfraniadau pensiwn isaf yn cynyddu yn Ebrill 2018 ac eto yn Ebrill 2019.
         Bydd y ffigyrau hyn yn dangos sut y bydd hyn yn effeithio ar eich cyfraniadau.
       description_full:
-        Bydd cyfraniadau yn seiliedig ar eich cyflog o <span data-dough-eligible-salary>%{eligible_salary}</span> y flwyddyn.
+        Bydd cyfraniadau yn seiliedig ar eich cyflog o <span data-wpcc-eligible-salary>%{eligible_salary}</span> y flwyddyn.
       description_minimum:
-        Bydd cyfraniadau yn seiliedig ar eich enillion cymwys o <span data-dough-eligible-salary>%{eligible_salary}</span> y flwyddyn.
+        Bydd cyfraniadau yn seiliedig ar eich enillion cymwys o <span data-wpcc-eligible-salary>%{eligible_salary}</span> y flwyddyn.
       large_contribution_percent_for_two_periods:
         Rydych chi a'ch cyflogwr eisoes yn talu mwy na'r isafswm newydd, felly rydym wedi dangos y cyfraniadau cyfredol yn unig. Ni fydd y rhain yn newid oni bai bod eich cyflog yn cynyddu neu rydych chi ac/neu eich cyflogwr yn dewis talu mwy.
       large_contribution_percent_for_middle_period:
@@ -135,11 +135,11 @@ cy:
         after_april_2019: O Ebrill 2019 ymlaen
       period:
         contribution_heading:
-          yours_html: Eich cyfraniad <span data-dough-title-frequency>%{salary_frequency}</span>
-          employers_html: Cyfraniad <span data-dough-title-frequency>%{salary_frequency}</span> y cyflogwr
-          employers_fourweeks_html: Cyfraniad y cyflogwr <span data-dough-title-frequency>%{salary_frequency}</span>
-          total_html: Cyfanswm y cyfraniad <span data-dough-title-frequency>%{salary_frequency}</span>
-        tax_relief_html: (yn cynnwys gostyngiad treth o <span data-dough-tax-relief-value>%{formatted_tax_relief}</span>)
+          yours_html: Eich cyfraniad <span data-wpcc-title-frequency>%{salary_frequency}</span>
+          employers_html: Cyfraniad <span data-wpcc-title-frequency>%{salary_frequency}</span> y cyflogwr
+          employers_fourweeks_html: Cyfraniad y cyflogwr <span data-wpcc-title-frequency>%{salary_frequency}</span>
+          total_html: Cyfanswm y cyfraniad <span data-wpcc-title-frequency>%{salary_frequency}</span>
+        tax_relief_html: (yn cynnwys gostyngiad treth o <span data-wpcc-tax-relief-value>%{formatted_tax_relief}</span>)
       tax_relief_warning_html: Os nad ydych chi'n talu treth incwm ar eich enillion, fyddwch chi ddim ond yn cael gostyngiad treth ar eich cyfraniadau os bydd eich cynllun pensiwn yn casglu cyfraniadau yn defnyddio'r gostyngiad treth yn y ffynhonnell. Rydym wedi tybio bod eich cynllun yn gwneud hyn. Darllenwch ragor yn ein canllaw am <a href="https://www.moneyadviceservice.org.uk/cy/articles/gostyngiad-treth-ach-pensiwn-gweithle">ostyngiadau treth ar gyfraniadau pensiwn</a>.
       tax_relief_warning: Os nad ydych chi'n talu treth incwm ar eich enillion, fyddwch chi ddim ond yn cael gostyngiad treth ar eich cyfraniadau os bydd eich cynllun pensiwn yn casglu cyfraniadau yn defnyddio'r gostyngiad treth yn y ffynhonnell. Rydym wedi tybio bod eich cynllun yn gwneud hyn. Darllenwch ragor yn ein canllaw am ostyngiadau treth ar gyfraniadau pensiwn.
       tax_relief_tooltip_html: Byddwch yn cael gostyngiad treth ar eich cyfraniadau pensiwn sy'n golygu y rhoddir peth o’r arian o'ch cyflog a fyddai wedi mynd i’r llywodraeth fel treth tuag at eich pensiwn yn hytrach. <a href="https://www.moneyadviceservice.org.uk/cy/articles/gostyngiad-treth-ach-pensiwn-gweithle">Darllenwch fwy am sut i gael gostyngiad treth</a>.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -114,9 +114,9 @@ en:
         Minimum pension contribution rates will increase in April 2018 and again in April 2019.
         These figures show how this will affect your contributions.
       description_full:
-        Contributions will be based on your salary of <span data-dough-eligible-salary>%{eligible_salary}</span> per year.
+        Contributions will be based on your salary of <span data-wpcc-eligible-salary>%{eligible_salary}</span> per year.
       description_minimum:
-        Contributions will be based on your qualifying earnings of <span data-dough-eligible-salary>%{eligible_salary}</span> per year.
+        Contributions will be based on your qualifying earnings of <span data-wpcc-eligible-salary>%{eligible_salary}</span> per year.
       large_contribution_percent_for_two_periods:
         "Both you and your employer are already paying above the new minimums so we have just shown the current contributions. These won't change unless your salary increases or you and/or your employer choose to pay more."
       large_contribution_percent_for_middle_period:
@@ -135,10 +135,10 @@ en:
         after_april_2019: April 2019 onwards
       period:
         contribution_heading:
-          yours_html: Your <span data-dough-title-frequency>%{salary_frequency}</span> contribution
-          employers_html: Employer's <span data-dough-title-frequency>%{salary_frequency}</span> contribution
-          total_html: Total <span data-dough-title-frequency>%{salary_frequency}</span> contributions
-        tax_relief_html: (includes tax relief of <span data-dough-tax-relief-value>%{formatted_tax_relief}</span>)
+          yours_html: Your <span data-wpcc-title-frequency>%{salary_frequency}</span> contribution
+          employers_html: Employer's <span data-wpcc-title-frequency>%{salary_frequency}</span> contribution
+          total_html: Total <span data-wpcc-title-frequency>%{salary_frequency}</span> contributions
+        tax_relief_html: (includes tax relief of <span data-wpcc-tax-relief-value>%{formatted_tax_relief}</span>)
       tax_relief_warning_html: If you don’t pay income tax on your earnings, you will only receive tax relief on your pension contributions if your pension scheme collects contributions using the tax relief at source method. We have assumed your scheme does. Read more in our guide about <a href="https://www.moneyadviceservice.org.uk/en/articles/tax-relief-and-your-workplace-pension">tax relief on pension contributions</a>.
       tax_relief_warning: If you don’t pay income tax on your earnings, you will only receive tax relief on your pension contributions if your pension scheme collects contributions using the tax relief at source method.  We have assumed your scheme does. Read more in our guide about tax relief on pension contributions.
       tax_relief_tooltip_html: You get tax relief on pension contributions which means some of the money from your pay that would have gone to the government as tax goes towards your pension instead. <a href="https://www.moneyadviceservice.org.uk/en/articles/tax-relief-and-your-workplace-pension">Read more about how you get tax relief</a>.

--- a/features/support/ui/your_details.rb
+++ b/features/support/ui/your_details.rb
@@ -12,7 +12,7 @@ module UI
     element :minimum_contribution_button, '#your_details_form_contribution_preference_minimum'
     element :full_contribution_button, '#your_details_form_contribution_preference_full'
 
-    element :salary_below_threshold_callout, '[data-dough-callout-radio-disabled]'
+    element :salary_below_threshold_callout, '[data-wpcc-callout-radio-disabled]'
 
     element :next_button, "input[type='submit']"
   end

--- a/lib/wpcc/version.rb
+++ b/lib/wpcc/version.rb
@@ -2,7 +2,7 @@ module Wpcc
   module Version
     MAJOR = 1
     MINOR = 9
-    PATCH = 1
+    PATCH = 2
 
     STRING = [MAJOR, MINOR, PATCH].join('.')
   end

--- a/spec/javascripts/fixtures/ConditionalMessaging.html
+++ b/spec/javascripts/fixtures/ConditionalMessaging.html
@@ -1,19 +1,19 @@
 <div>
   <section data-dough-component="ConditionalMessaging">
-    <input data-dough-age-field>
+    <input data-wpcc-age-field>
 
-    <select data-dough-gender-select>
+    <select data-wpcc-gender-select>
       <option value="">Please choose</option>
       <option value="male">male</option>
       <option value="female">female</option>
     </select>
 
-    <div class="details__callout--inactive" data-dough-callout-lt16></div>
+    <div class="details__callout--inactive" data-wpcc-callout-lt16></div>
 
-    <div class="details__callout--inactive" data-dough-callout-optin></div>
+    <div class="details__callout--inactive" data-wpcc-callout-optin></div>
 
-    <div class="details__callout--inactive" data-dough-callout-gt74></div>
+    <div class="details__callout--inactive" data-wpcc-callout-gt74></div>
 
-    <input type="submit" data-dough-submit>
+    <input type="submit" data-wpcc-submit>
   </section>
 </div>

--- a/spec/javascripts/fixtures/ContributionConditions.html
+++ b/spec/javascripts/fixtures/ContributionConditions.html
@@ -1,11 +1,11 @@
 <div>
   <section data-dough-component="ContributionConditions">
 
-    <input data-dough-employee-contributions type="number">
+    <input data-wpcc-employee-contributions type="number">
 
-    <span data-dough-contribution-salary></span>
+    <span data-wpcc-contribution-salary></span>
 
-    <div class="details__callout--inactive" data-dough-callout-contribution-gt40000></div>
+    <div class="details__callout--inactive" data-wpcc-callout-contribution-gt40000></div>
 
   </section>
 </div>

--- a/spec/javascripts/fixtures/Email.html
+++ b/spec/javascripts/fixtures/Email.html
@@ -2,59 +2,59 @@
   <main data-dough-component="Email">
     <section>
       <h2 class="details__heading">1. Your details
-        <span class="section__heading-summary" data-dough-details-heading-summary>31 years, male, £50,000 per year, part salary</span>
+        <span class="section__heading-summary" data-wpcc-details-heading-summary>31 years, male, £50,000 per year, part salary</span>
       </h2>
     </section>
 
     <section>
       <h2 class="contributions__heading">2. Your contributions
-        <span class="section__heading-summary" data-dough-contributions-heading-summary>You: 1%, Your employer: 1%</span>
+        <span class="section__heading-summary" data-wpcc-contributions-heading-summary>You: 1%, Your employer: 1%</span>
       </h2>
     </section>
 
     <section class="section--results">
       <h2 class="results__heading">3. Your Results</h2>
       <div class="results__content">
-        <p>Minimum pension contribution rates will increase in April 2018 and again in April 2019. These figures show how this will affect your contributions. Contributions will be based on your earnings of <span data-dough-eligible-salary>£39,124</span> a year</p>
+        <p>Minimum pension contribution rates will increase in April 2018 and again in April 2019. These figures show how this will affect your contributions. Contributions will be based on your earnings of <span data-wpcc-eligible-salary>£39,124</span> a year</p>
 
         <div class="results__row">
           <div>
-            <div data-dough-results-table>
-              <h3 data-dough-results-period-title>Now</h3>
-              <p data-dough-period-heading-yours>Your contribution</p>
-              <p data-dough-employee-contribution data-employee-contribution="">£32.60</p>
-              <p data-dough-tax-relief data-tax-relief="">(includes tax relief of £6.52)</p>
-              <p data-dough-period-heading-employers>Employer's contribution</p>
-              <p data-dough-employer-contribution data-employer-contribution="">£32.60</p>
-              <p data-dough-period-heading-total>Total contributions</p>
-              <p data-dough-total>£65.20</p>
+            <div data-wpcc-results-table>
+              <h3 data-wpcc-results-period-title>Now</h3>
+              <p data-wpcc-period-heading-yours>Your contribution</p>
+              <p data-wpcc-employee-contribution data-employee-contribution="">£32.60</p>
+              <p data-wpcc-tax-relief data-tax-relief="">(includes tax relief of £6.52)</p>
+              <p data-wpcc-period-heading-employers>Employer's contribution</p>
+              <p data-wpcc-employer-contribution data-employer-contribution="">£32.60</p>
+              <p data-wpcc-period-heading-total>Total contributions</p>
+              <p data-wpcc-total>£65.20</p>
             </div>
 
-            <div data-dough-results-table>
-              <h3 data-dough-results-period-title>April 2018 - March 2019</h3>
-              <p data-dough-period-heading-yours>Your contribution</p>
-              <p data-dough-employee-contribution data-employee-contribution="">£97.81</p>
-              <p data-dough-tax-relief data-tax-relief="">(includes tax relief of £19.56)</p>
-              <p data-dough-period-heading-employers>Employer's contribution</p>
-              <p data-dough-employer-contribution data-employer-contribution="">£65.21</p>
-              <p data-dough-period-heading-total>Total contributions</p>
-              <p data-dough-total>£163.02</p>
+            <div data-wpcc-results-table>
+              <h3 data-wpcc-results-period-title>April 2018 - March 2019</h3>
+              <p data-wpcc-period-heading-yours>Your contribution</p>
+              <p data-wpcc-employee-contribution data-employee-contribution="">£97.81</p>
+              <p data-wpcc-tax-relief data-tax-relief="">(includes tax relief of £19.56)</p>
+              <p data-wpcc-period-heading-employers>Employer's contribution</p>
+              <p data-wpcc-employer-contribution data-employer-contribution="">£65.21</p>
+              <p data-wpcc-period-heading-total>Total contributions</p>
+              <p data-wpcc-total>£163.02</p>
             </div>
 
-            <div data-dough-results-table>
-              <h3 data-dough-results-period-title>April 2019 onwards</h3>
-              <p data-dough-period-heading-yours>Your contribution</p>
-              <p data-dough-employee-contribution data-employee-contribution="">£163.02</p>
-              <p data-dough-tax-relief data-tax-relief="">(includes tax relief of £32.60)</p>
-              <p data-dough-period-heading-employers>Employer's contribution</p>
-              <p data-dough-employer-contribution data-employer-contribution="">£97.81</p>
-              <p data-dough-period-heading-total>Total contributions</p>
-              <p data-dough-total>£260.83</p>
+            <div data-wpcc-results-table>
+              <h3 data-wpcc-results-period-title>April 2019 onwards</h3>
+              <p data-wpcc-period-heading-yours>Your contribution</p>
+              <p data-wpcc-employee-contribution data-employee-contribution="">£163.02</p>
+              <p data-wpcc-tax-relief data-tax-relief="">(includes tax relief of £32.60)</p>
+              <p data-wpcc-period-heading-employers>Employer's contribution</p>
+              <p data-wpcc-employer-contribution data-employer-contribution="">£97.81</p>
+              <p data-wpcc-period-heading-total>Total contributions</p>
+              <p data-wpcc-total>£260.83</p>
             </div>
           </div>
         </div>
 
-        <p><a href="" data-dough-email-link>Email your results</a></p>
+        <p><a href="" data-wpcc-email-link>Email your results</a></p>
       </div>
     </section>
   </main>

--- a/spec/javascripts/fixtures/SalaryConditions.html
+++ b/spec/javascripts/fixtures/SalaryConditions.html
@@ -1,31 +1,31 @@
 <div>
   <div data-dough-component="SalaryConditions">
 
-    <input data-dough-salary-input type="text" />
-    <select data-dough-frequency-select>
+    <input data-wpcc-salary-input type="text" />
+    <select data-wpcc-frequency-select>
       <option value="year">per Year</option>
       <option value="month">per Month</option>
       <option value="fourweeks">per 4 weeks</option>
       <option value="week">per Week</option>
     </select>
-    <div class="details__callout--inactive" data-dough-callout-lt5876>
+    <div class="details__callout--inactive" data-wpcc-callout-lt5876>
     </div>
 
-    <div class="details__callout--inactive" data-dough-callout-gt5876_lt10000>
+    <div class="details__callout--inactive" data-wpcc-callout-gt5876_lt10000>
     </div>
 
-    <div class="details__callout--inactive" data-dough-callout-radio-disabled>
+    <div class="details__callout--inactive" data-wpcc-callout-radio-disabled>
     </div>
 
-    <input data-dough-employer-part-radio="true" name="your_details_form[contribution_preference]" type="radio" value="minimum" checked="true">
-    <input data-dough-employer-full-radio="true" name="your_details_form[contribution_preference]" type="radio" value="full">
+    <input data-wpcc-employer-part-radio="true" name="your_details_form[contribution_preference]" type="radio" value="minimum" checked="true">
+    <input data-wpcc-employer-full-radio="true" name="your_details_form[contribution_preference]" type="radio" value="full">
 
-    <p data-dough-employee-tip-lt5876 class="is-hidden"></p>
-    <p data-dough-employee-tip></p>
-    <p data-dough-employer-tip></p>
+    <p data-wpcc-employee-tip-lt5876 class="is-hidden"></p>
+    <p data-wpcc-employee-tip></p>
+    <p data-wpcc-employer-tip></p>
 
-    <input data-dough-employee-contributions type="number" value="1" />
-    <input data-dough-employer-contributions type="number" value="1" />
+    <input data-wpcc-employee-contributions type="number" value="1" />
+    <input data-wpcc-employer-contributions type="number" value="1" />
 
   </div>
 </div>

--- a/spec/javascripts/fixtures/UpdateResults.html
+++ b/spec/javascripts/fixtures/UpdateResults.html
@@ -2,7 +2,7 @@
   <div data-dough-component="UpdateResults">
     <div>
       <form>
-        <select data-dough-selector>
+        <select data-wpcc-selector>
           <option value="year" data-unit-converter="1" data-frequency-adjective="yearly">per Year</option>
           <option value="month" data-unit-converter="12" data-frequency-adjective="monthly">per Month</option>
           <option value="fourweeks" data-unit-converter="13" data-frequency-adjective="four-weekly">per 4 weeks</option>
@@ -12,34 +12,32 @@
     </div>
 
     <div>
-      <div data-dough-results-table>
-        <p data-dough-employee-contribution data-employee-contribution=""></p>
-        <p data-dough-tax-relief data-tax-relief="">
-          <span data-dough-tax-relief-value=""></span>
+      <div data-wpcc-results-table>
+        <p data-wpcc-employee-contribution data-employee-contribution=""></p>
+        <p data-wpcc-tax-relief data-tax-relief="">
+          <span data-wpcc-tax-relief-value=""></span>
         </p>
-        <p data-dough-employer-contribution data-employer-contribution=""></p>
-        <p data-dough-total></p>
-        <p data-dough-title-frequency=""></p>
+        <p data-wpcc-employer-contribution data-employer-contribution=""></p>
+        <p data-wpcc-total></p>
+        <p data-wpcc-title-frequency=""></p>
       </div>
-
-      <div data-dough-results-table>
-        <p data-dough-employee-contribution data-employee-contribution=""></p>
-        <p data-dough-tax-relief data-tax-relief="">
-          <span data-dough-tax-relief-value=""></span>
+      <div data-wpcc-results-table>
+        <p data-wpcc-employee-contribution data-employee-contribution=""></p>
+        <p data-wpcc-tax-relief data-tax-relief="">
+          <span data-wpcc-tax-relief-value=""></span>
         </p>
-        <p data-dough-employer-contribution data-employer-contribution=""></p>
-        <p data-dough-total></p>
-        <p data-dough-title-frequency=""></p>
+        <p data-wpcc-employer-contribution data-employer-contribution=""></p>
+        <p data-wpcc-total></p>
+        <p data-wpcc-title-frequency=""></p>
       </div>
-
-      <div data-dough-results-table>
-        <p data-dough-employee-contribution data-employee-contribution=""></p>
-        <p data-dough-tax-relief data-tax-relief="">
-          <span data-dough-tax-relief-value=""></span>
+      <div data-wpcc-results-table>
+        <p data-wpcc-employee-contribution data-employee-contribution=""></p>
+        <p data-wpcc-tax-relief data-tax-relief="">
+          <span data-wpcc-tax-relief-value=""></span>
         </p>
-        <p data-dough-employer-contribution data-employer-contribution=""></p>
-        <p data-dough-total></p>
-        <p data-dough-title-frequency=""></p>
+        <p data-wpcc-employer-contribution data-employer-contribution=""></p>
+        <p data-wpcc-total></p>
+        <p data-wpcc-title-frequency=""></p>
       </div>
     </div>
   </div>

--- a/spec/javascripts/tests/ConditionalMessaging_spec.js
+++ b/spec/javascripts/tests/ConditionalMessaging_spec.js
@@ -35,12 +35,12 @@ describe('Conditional Messaging', function() {
         element.trigger(e);
       };
 
-      this.ageField = this.component.find('[data-dough-age-field]');
-      this.genderField = this.component.find('[data-dough-gender-select]');
-      this.callout_lt16 = this.component.find('[data-dough-callout-lt16]');
-      this.callout_optIn = this.component.find('[data-dough-callout-optIn]');
-      this.callout_gt74 = this.component.find('[data-dough-callout-gt74]');
-      this.submit = this.component.find('[data-dough-submit]');
+      this.ageField = this.component.find('[data-wpcc-age-field]');
+      this.genderField = this.component.find('[data-wpcc-gender-select]');
+      this.callout_lt16 = this.component.find('[data-wpcc-callout-lt16]');
+      this.callout_optIn = this.component.find('[data-wpcc-callout-optIn]');
+      this.callout_gt74 = this.component.find('[data-wpcc-callout-gt74]');
+      this.submit = this.component.find('[data-wpcc-submit]');
 
       this.obj.init();
     });

--- a/spec/javascripts/tests/ContributionConditions_spec.js
+++ b/spec/javascripts/tests/ContributionConditions_spec.js
@@ -22,9 +22,9 @@ describe('Contribution Conditions', function() {
   describe('When an employee contribution percentage is entered', function() {
     
     beforeEach(function() {
-      this.employeeContributions = this.component.find('[data-dough-employee-contributions]');
-      this.eligibleSalary = this.component.find('[data-dough-contribution-salary]');
-      this.contributionWarning = this.component.find('[data-dough-callout-contribution-gt40000]');
+      this.employeeContributions = this.component.find('[data-wpcc-employee-contributions]');
+      this.eligibleSalary = this.component.find('[data-wpcc-contribution-salary]');
+      this.contributionWarning = this.component.find('[data-wpcc-callout-contribution-gt40000]');
 
       this.obj.init();
     });

--- a/spec/javascripts/tests/Email_spec.js
+++ b/spec/javascripts/tests/Email_spec.js
@@ -12,7 +12,7 @@ describe('Email', function() {
         _this.email = Email;
         _this.obj = new _this.email(_this.component);
 
-        _this.$emailLink = _this.component.find('[data-dough-email-link]');
+        _this.$emailLink = _this.component.find('[data-wpcc-email-link]');
 
         done();
     }, done);

--- a/spec/javascripts/tests/SalaryConditions_spec.js
+++ b/spec/javascripts/tests/SalaryConditions_spec.js
@@ -25,13 +25,13 @@ describe('Salary Conditions', function() {
     var clock;
 
     beforeEach(function() {
-      this.salaryField = this.component.find('[data-dough-salary-input]');
-      this.salaryFrequency = this.component.find('[data-dough-frequency-select]');
-      this.callout_lt5876 = this.component.find('[data-dough-callout-lt5876]');
-      this.callout_gt5876_lt10000 = this.component.find('[data-dough-callout-gt5876_lt10000]');
-      this.radioDisabled = this.component.find('[data-dough-callout-radio-disabled]');
-      this.employerPartRadio = this.component.find('[data-dough-employer-part-radio]');
-      this.employerFullRadio = this.component.find('[data-dough-employer-full-radio]');
+      this.salaryField = this.component.find('[data-wpcc-salary-input]');
+      this.salaryFrequency = this.component.find('[data-wpcc-frequency-select]');
+      this.callout_lt5876 = this.component.find('[data-wpcc-callout-lt5876]');
+      this.callout_gt5876_lt10000 = this.component.find('[data-wpcc-callout-gt5876_lt10000]');
+      this.radioDisabled = this.component.find('[data-wpcc-callout-radio-disabled]');
+      this.employerPartRadio = this.component.find('[data-wpcc-employer-part-radio]');
+      this.employerFullRadio = this.component.find('[data-wpcc-employer-full-radio]');
 
       clock = sinon.useFakeTimers();
 
@@ -179,11 +179,11 @@ describe('Salary Conditions', function() {
         element.trigger(e);
       };
 
-      this.salaryField = this.component.find('[data-dough-salary-input]');
-      this.salaryFrequency = this.component.find('[data-dough-frequency-select]');
-      this.callout_lt5876 = this.component.find('[data-dough-callout-lt5876]');
-      this.callout_gt5876_lt10000 = this.component.find('[data-dough-callout-gt5876_lt10000]');
-      this.radioDisabled = this.component.find('[data-dough-callout-radio-disabled]');
+      this.salaryField = this.component.find('[data-wpcc-salary-input]');
+      this.salaryFrequency = this.component.find('[data-wpcc-frequency-select]');
+      this.callout_lt5876 = this.component.find('[data-wpcc-callout-lt5876]');
+      this.callout_gt5876_lt10000 = this.component.find('[data-wpcc-callout-gt5876_lt10000]');
+      this.radioDisabled = this.component.find('[data-wpcc-callout-radio-disabled]');
       clock = sinon.useFakeTimers();
       this.obj.init();
     });
@@ -246,12 +246,12 @@ describe('Salary Conditions', function() {
     var clock;
 
     beforeEach(function() {
-      this.salaryField = this.component.find('[data-dough-salary-input]');
-      this.employeeTip = this.component.find('[data-dough-employee-tip]');
-      this.employeeTip_lt5876 = this.component.find('[data-dough-employee-tip-lt5876]');
-      this.employerTip = this.component.find('[data-dough-employer-tip]');
-      this.employeeContributions = this.component.find('[data-dough-employee-contributions]');
-      this.employerContributions = this.component.find('[data-dough-employer-contributions]');
+      this.salaryField = this.component.find('[data-wpcc-salary-input]');
+      this.employeeTip = this.component.find('[data-wpcc-employee-tip]');
+      this.employeeTip_lt5876 = this.component.find('[data-wpcc-employee-tip-lt5876]');
+      this.employerTip = this.component.find('[data-wpcc-employer-tip]');
+      this.employeeContributions = this.component.find('[data-wpcc-employee-contributions]');
+      this.employerContributions = this.component.find('[data-wpcc-employer-contributions]');
       clock = sinon.useFakeTimers();
       this.obj.init();
     });
@@ -302,12 +302,12 @@ describe('Salary Conditions', function() {
     var clock;
 
     beforeEach(function() {
-      this.salaryField = this.component.find('[data-dough-salary-input]');
-      this.employeeContributions = this.component.find('[data-dough-employee-contributions]');
-      this.employerContributions = this.component.find('[data-dough-employer-contributions]');
-      this.employeeTip = this.component.find('[data-dough-employee-tip]');
-      this.employeeTip_lt5876 = this.component.find('[data-dough-employee-tip-lt5876]');
-      this.employerTip = this.component.find('[data-dough-employer-tip]');
+      this.salaryField = this.component.find('[data-wpcc-salary-input]');
+      this.employeeContributions = this.component.find('[data-wpcc-employee-contributions]');
+      this.employerContributions = this.component.find('[data-wpcc-employer-contributions]');
+      this.employeeTip = this.component.find('[data-wpcc-employee-tip]');
+      this.employeeTip_lt5876 = this.component.find('[data-wpcc-employee-tip-lt5876]');
+      this.employerTip = this.component.find('[data-wpcc-employer-tip]');
       clock = sinon.useFakeTimers();
       this.obj.init();
     });

--- a/spec/javascripts/tests/UpdateResults_spec.js
+++ b/spec/javascripts/tests/UpdateResults_spec.js
@@ -18,8 +18,8 @@ describe('Update Results', function() {
         _this.component = _this.$html.find('[data-dough-component="UpdateResults"]');
         _this.updateResults = UpdateResults;
         _this.obj = new _this.updateResults(_this.component);
-        _this.frequencySelector = _this.$html.find('[data-dough-selector]');
-        _this.resultsTables = _this.$html.find('[data-dough-results-table]');
+        _this.frequencySelector = _this.$html.find('[data-wpcc-selector]');
+        _this.resultsTables = _this.$html.find('[data-wpcc-results-table]');
 
         done();
     }, done);
@@ -62,9 +62,9 @@ describe('Update Results', function() {
       beforeEach(function () {
         // add intial values to fixture
         for (var i = 0, max = this.resultsTables.length; i < max; i++) {
-          $(this.resultsTables[i]).find('[data-dough-employee-contribution]').attr('data-value', values.employeeContributions[i]);
-          $(this.resultsTables[i]).find('[data-dough-tax-relief]').attr('data-value', values.taxRelief[i]);
-          $(this.resultsTables[i]).find('[data-dough-employer-contribution]').attr('data-value', values.employerContributions[i]);
+          $(this.resultsTables[i]).find('[data-wpcc-employee-contribution]').attr('data-value', values.employeeContributions[i]);
+          $(this.resultsTables[i]).find('[data-wpcc-tax-relief]').attr('data-value', values.taxRelief[i]);
+          $(this.resultsTables[i]).find('[data-wpcc-employer-contribution]').attr('data-value', values.employerContributions[i]);
         }
 
         // intialise the component
@@ -113,11 +113,11 @@ describe('Update Results', function() {
             var titleContributions = this.frequencySelector.find('option:selected').attr('data-frequency-adjective');
 
             for (var i = 0, max = this.resultsTables.length; i < max; i++) {
-              expect($(this.resultsTables[i]).find('[data-dough-employee-contribution]').html()).to.equal(values.employeeContributions[i]);
-              expect($(this.resultsTables[i]).find('[data-dough-tax-relief-value]').html()).to.equal(values.taxRelief[i]);
-              expect($(this.resultsTables[i]).find('[data-dough-employer-contribution]').html()).to.equal(values.employerContributions[i]);
-              expect($(this.resultsTables[i]).find('[data-dough-total]').html()).to.equal(values.total[i]);
-              expect($(this.resultsTables[i]).find('[data-dough-title-frequency]').html()).to.equal(titleContributions);
+              expect($(this.resultsTables[i]).find('[data-wpcc-employee-contribution]').html()).to.equal(values.employeeContributions[i]);
+              expect($(this.resultsTables[i]).find('[data-wpcc-tax-relief-value]').html()).to.equal(values.taxRelief[i]);
+              expect($(this.resultsTables[i]).find('[data-wpcc-employer-contribution]').html()).to.equal(values.employerContributions[i]);
+              expect($(this.resultsTables[i]).find('[data-wpcc-total]').html()).to.equal(values.total[i]);
+              expect($(this.resultsTables[i]).find('[data-wpcc-title-frequency]').html()).to.equal(titleContributions);
             };
           });
         }

--- a/spec/presenters/period_contribution_presenter_spec.rb
+++ b/spec/presenters/period_contribution_presenter_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Wpcc::PeriodContributionPresenter do
   describe '#formatted_tax_relief' do
     it 'returns a message with the formatted value' do
       period_contribution.tax_relief = 1.99
-      data_attribute = 'data-dough-tax-relief-value'
+      data_attribute = 'data-wpcc-tax-relief-value'
 
       expect(subject.formatted_tax_relief).to eq(
         "(includes tax relief of <span #{data_attribute}>£1.99</span>)"
@@ -47,7 +47,7 @@ RSpec.describe Wpcc::PeriodContributionPresenter do
 
   describe '#employer_frequency_heading' do
     let(:salary_frequency) { Wpcc::SalaryFrequency.new(attributes) }
-    let(:data_attribute) { 'data-dough-title-frequency' }
+    let(:data_attribute) { 'data-wpcc-title-frequency' }
     let(:attributes) do
       {
         locale: locale,


### PR DESCRIPTION
# Refactors naming of data- attributes to distinguish between core dough and project specific components

We had a conversation about the naming of some of our dough component element selectors.  We currently use ``data-dough-component="ComponentName"`` to specify a component.  And then within the component we use similar selectors to select elements used in the component (eg.. ``data-dough-salary-input``).

This has raised the question regarding how clear this approach is to anyone reading the code, using the current format (in the example above), it suggests that the component is strictly a dough component and lives within dough.

The proposed solution is to refactor the selectors and attributes relating the the **internal** WPCC components (That dont live within dough itself):

- We would specify the dough component as we do now:

```
<div data-dough-component="ComponentName">
  ...
</div>
```

This will enable the component to be handled by the dough base component and the dough component loader, I think this is ok and a good approach as at this point, the component is dependent on dough.

We would then use **project specific** data- attributes for selectors which are used in the component:

```
<div data-dough-component="ComponentName">
  <input data-wpcc-component-input />
  <button data-wpcc-component-button>Submit</button>
</div>
```

This tells us that the JS (or any other code) relating to this component is **_within_** the project, in this case WPCC.

As always this is completely open to opinions and feedback :+1:
