### PR TITLE
[DEV APPROVED] Fix messages based on the displayed results table

### DIFF
--- a/app/presenters/wpcc/period_filter_presenter.rb
+++ b/app/presenters/wpcc/period_filter_presenter.rb
@@ -23,18 +23,18 @@ module Wpcc
     end
 
     def user_inputs_between_2nd_and_3rd_period_legal_minimums?
-      user_input_employee_percent > @second_period.employee_percent &&
+      user_input_employee_percent >= @second_period.employee_percent &&
         user_input_employee_percent < @last_period.employee_percent &&
-        user_input_employer_percent > @second_period.employer_percent &&
+        user_input_employer_percent >= @second_period.employer_percent &&
         user_input_employer_percent < @last_period.employer_percent
     end
 
     def user_input_for_employee_percent_greater_than_legal_minimums?
-      user_input_employee_percent > @last_period.employee_percent
+      user_input_employee_percent >= @last_period.employee_percent
     end
 
     def user_input_for_employer_percent_greater_than_legal_minimums?
-      user_input_employer_percent > @last_period.employer_percent
+      user_input_employer_percent >= @last_period.employer_percent
     end
   end
 end

--- a/features/_your_results/message_based_on_contribution_percents.feature
+++ b/features/_your_results/message_based_on_contribution_percents.feature
@@ -9,7 +9,7 @@ Feature: Display messaging based on results table shown in results
   Scenario Outline: Employee and Employer contributions are greater than the minimum for 2018 AND 2019
     Given I fill in my contributions:
       | your_contribution | employer_contribution |
-      | 6                 | 4                     |
+      | 5                 | 3                     |
     When I move on to the results page
     Then I should see a contribution explanation "<message>"
 
@@ -25,7 +25,7 @@ Feature: Display messaging based on results table shown in results
   Scenario Outline: Employee and Employer contributions are greater than the minimum for 2018 but NOT for 2019
     Given I fill in my contributions:
       | your_contribution | employer_contribution |
-      | 4                 | 2.5                   |
+      | 3                 | 2.99                  |
     When I move on to the results page
     Then I should see a contribution explanation "<message>"
 
@@ -41,7 +41,7 @@ Feature: Display messaging based on results table shown in results
   Scenario Outline: Only Employee contribution is greater than the minimum for 2018 AND 2019
     Given I fill in my contributions:
       | your_contribution | employer_contribution |
-      | 6                 | 1                     |
+      | 5                 | 1                     |
     When I move on to the results page
     Then I should see a contribution explanation "<message>"
 
@@ -57,7 +57,7 @@ Feature: Display messaging based on results table shown in results
   Scenario Outline: Only Employer contribution is greater than the minimum for 2018 AND 2019
     Given I fill in my contributions:
       | your_contribution | employer_contribution |
-      | 1                 | 3.1                   |
+      | 1                 | 3                     |
     When I move on to the results page
     Then I should see a contribution explanation "<message>"
 


### PR DESCRIPTION
TP: https://moneyadviceservice.tpondemand.com/entity/8506

Context

The tables on step 3 appear based on the % contribution set by the user while completing the tool, depending on the % selected by the user and what is minimum % set by the govt. This feature is about displaying a message when the user contributes more, depending on the % the user added.

Fixes 

When this was developed the figures were followed on what it was written on the card. After it was realized that the figures were wrong because was not just greater than. The correct is greater than or equal in *some* comparisons, as you can see below (all this scenarios are on cucumber features too):

Scenario 1
When an Employee and an Employer, both contributing more than the minimum
increase for 2018 AND 2019
Employee contribution >= 5%
Employer contribution >= 3%

Scenario 2
When an Employee and an Employer, both contributing more than the minimum
increase for 2018 but NOT for 2019
Employee contribution >= 3% and <5%
Employer contribution >= 2% and <3%

Scenario 3
When only an Employee contributing more than the minimum increase for 2018 AND
2019
Employee contribution >= 5%
Employer contribution = minimum % as set by the Govt. over that period

Scenario 4
When only an Employer contributing more than the minimum increase for 2018 AND
2019
Employee contribution = minimum % as set by the Govt. over that period
Employer contribution >= 3%