### PR TITLE
8564 percent validation server side

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,10 +1,14 @@
+## 1.11.0:
+* TP-8565: Amend the employer percent for calculating contributions
+* TP-8564: Add server side validations for contribution percent
+
 ## 1.10.0:
 * TP-8568: Adds meta title description and canonical
 
-## 1.9.2: 
+## 1.9.2:
 * Refactors data attributes for internal components
 
-## 1.9.1: 
+## 1.9.1:
 * TP-8556: Fixes Popuptips and div floating issue in step 1
 
 ## 1.9.0

--- a/app/assets/javascripts/wpcc/components/SalaryConditions.js
+++ b/app/assets/javascripts/wpcc/components/SalaryConditions.js
@@ -32,7 +32,6 @@ define(['jquery', 'DoughBaseComponent'], function($, DoughBaseComponent) {
   SalaryConditions.prototype.init = function(initialised) {
     this._initialisedSuccess(initialised);
     this._setUpEvents();
-    this._step2Conditions();
   };
 
   // Set up events to detect salary input changes
@@ -139,9 +138,6 @@ define(['jquery', 'DoughBaseComponent'], function($, DoughBaseComponent) {
     if (this.contribution !== 'full') {
       $this.$employerPartRadio.prop('checked', true);
     }
-
-    // Remove local storage if already saved
-    localStorage.removeItem('lt5876');
   }
 
   // Function for salary less than £5876
@@ -159,9 +155,6 @@ define(['jquery', 'DoughBaseComponent'], function($, DoughBaseComponent) {
     // Disable Employer contributions checkbox
     $this.$employerPartRadio.attr('disabled', true);
     $this.$employerFullRadio.prop('checked', true);
-
-    // Save state to local storage
-    localStorage.setItem('lt5876', true);
   };
 
   // Function for salary between £5876 and £10000
@@ -183,35 +176,6 @@ define(['jquery', 'DoughBaseComponent'], function($, DoughBaseComponent) {
     if (this.contribution !== 'full') {
       $this.$employerPartRadio.prop('checked', true);
     }
-
-    // Remove local storage if already saved
-    localStorage.removeItem('lt5876');
-  }
-
-  // Step 2 - Alters values of the contribution inputs
-  // Modifies the employee contributions tip
-  SalaryConditions.prototype._step2Conditions = function() {
-    var salaryCondition = localStorage.getItem('lt5876'),
-        $this           = this;
-
-    if (salaryCondition) {
-      this._updateEmployeeTip();
-      this.$employeeTip.addClass('is-hidden');
-      this.$employeeTip_lt5876.removeClass('is-hidden');
-    } else {
-      this.$employeeTip.removeClass('is-hidden');
-      this.$employeeTip_lt5876.addClass('is-hidden');
-    }
-
-  };
-
-  // Called from _step2Conditions
-  // Updates the values of the contributions inputs
-  // And removes the employer tip
-  SalaryConditions.prototype._updateEmployeeTip = function() {
-    this.$employeeContributions.val(1);
-    this.$employerContributions.val(0);
-    this.$employerTip.text('');
   }
 
   return SalaryConditions;

--- a/app/models/wpcc/salary_message.rb
+++ b/app/models/wpcc/salary_message.rb
@@ -14,11 +14,15 @@ module Wpcc
     }.freeze
 
     def manually_opt_in?
-      salary >= OPT_IN_SALARY_LOWER_LIMIT && salary <= OPT_IN_SALARY_UPPER_LIMIT
+      !salary_below_pension_limit? && salary <= OPT_IN_SALARY_UPPER_LIMIT
     end
 
     def salary_below_tax_relief_threshold?
       valid_salary_frequency? && salary_below_frequency_threshold?
+    end
+
+    def salary_below_pension_limit?
+      salary < OPT_IN_SALARY_LOWER_LIMIT
     end
 
     def above_max_contribution?

--- a/app/presenters/wpcc/message_presenter.rb
+++ b/app/presenters/wpcc/message_presenter.rb
@@ -40,5 +40,18 @@ module Wpcc
 
       t('wpcc.contributions.contribution_gt40000_warning', amount: amount)
     end
+
+    def employee_contribution_tip
+      if salary_below_pension_limit?
+        t('wpcc.contributions.your_contribution_tip_lt5876')
+      else
+        t('wpcc.contributions.your_contribution_tip')
+      end
+    end
+
+    def employer_contribution_tip
+      return if salary_below_pension_limit?
+      t('wpcc.contributions.employer_contribution_tip')
+    end
   end
 end

--- a/app/views/wpcc/your_contributions/new.html.erb
+++ b/app/views/wpcc/your_contributions/new.html.erb
@@ -25,6 +25,7 @@
             required: true,
             min: 0,
             max: 100,
+            step: 0.5,
             'data-wpcc-employee-contributions': true,
             'data-dough-validation-empty': t('wpcc.contributions.employee_validation.blank'),
             'data-dough-validation-invalid': t('wpcc.contributions.employee_validation.out_of_range')
@@ -42,6 +43,7 @@
             required: true,
             min: 0,
             max: 100,
+            step: 0.5,
             'data-wpcc-employer-contributions': true,
             'data-dough-validation-empty': t('wpcc.contributions.employer_validation.blank'),
             'data-dough-validation-invalid': t('wpcc.contributions.employee_validation.out_of_range')

--- a/app/views/wpcc/your_contributions/new.html.erb
+++ b/app/views/wpcc/your_contributions/new.html.erb
@@ -19,8 +19,7 @@
       <div class="contributions__row">
         <div class="contributions__source contributions__source--employee form__row">
           <h3 class="contributions__source-title"><%= t('wpcc.contributions.your_contribution_title') %></h3>
-          <p data-wpcc-employee-tip><%= t('wpcc.contributions.your_contribution_tip') %></p>
-          <p data-wpcc-employee-tip-lt5876 class="is-hidden"><%= t('wpcc.contributions.your_contribution_tip_lt5876') %></p>
+          <p><%= @message_presenter.employee_contribution_tip %></p>
           <%= f.number_field :employee_percent,
             class: "contributions__source-input",
             required: true,
@@ -37,7 +36,7 @@
         </div>
         <div class="contributions__source contributions__source--employer form__row">
           <h3 class="contributions__source-title"><%= t('wpcc.contributions.employer_contribution_title') %></h3>
-          <p data-wpcc-employer-tip><%= t('wpcc.contributions.employer_contribution_tip') %></p>
+          <p><%=  @message_presenter.employer_contribution_tip %></p>
           <%= f.number_field :employer_percent,
             class: "contributions__source-input",
             required: true,

--- a/features/_your_contributions/percent_validation.feature
+++ b/features/_your_contributions/percent_validation.feature
@@ -1,0 +1,39 @@
+Feature: Informing about contribution percentages
+  In order to gain a better understanding of how my workplace pension is being calculated,
+  As a user of the WPCC tool,
+  I want to see relevant information about the contributions my employer and I can make.
+
+Background:
+  Given I am on the Your Details step
+  When I fill in my details
+
+Scenario Outline: minimum contribution percentage on salary greater than £5,876
+  And I enter my salary as "6000"
+  And I proceed to the next step
+  And the "employee" contribution intro should display "<message>"
+  And the "employer" contribution intro should display "<message>"
+
+  Examples:
+    | message                 |
+    | The legal minimum is 1% |
+
+  @welsh
+  Examples:
+    | message                      |
+    | Yr isafswm cyfreithiol yw 1% |
+
+Scenario Outline: minimum contribution percentage on salary less than £5,876
+  And I enter a salary below the minimum threshold
+  And I choose to make full contributions
+  And I proceed to the next step
+  Then I should NOT see an intro for employer contributions
+  Then the "employee" contribution intro should display "<message>"
+
+  Examples:
+    | message                                                     |
+    | At your salary level there is no legal minimum contribution |
+
+  @welsh
+  Examples:
+    | message                                           |
+    | Ar eich lefel cyflog, nid oes isafswm cyfreithiol |

--- a/features/_your_contributions/your_contributions_calculating_qualifying_earnings.feature
+++ b/features/_your_contributions/your_contributions_calculating_qualifying_earnings.feature
@@ -13,8 +13,6 @@ Scenario: Calculate on minimum contribution for salary greater than the Upper Ea
   And I choose to make minimum contributions
   And I proceed to the next step
   Then I should see that my qualifying earnings is the limit of "£39,124"
-  And the employee_percent input intro paragraph should display the correct percentage
-  And the employer_percent input intro paragraph should display the correct percentage
 
 Scenario: Calculate minimum contribution for salary equal to or less than the Upper Earnings Threshold
   And my salary per year is equal to or less than the upper earnings threshold of £45,000
@@ -22,7 +20,7 @@ Scenario: Calculate minimum contribution for salary equal to or less than the Up
   And I proceed to the next step
   Then the Your Contributions step should tell me my qualifying earnings
 
-Scenario: Calculate on full pay
+Scenario: Calculate on full pay equal to or more than £5876
   And I choose to make full contributions
   And I proceed to the next step
   Then the Your Contributions step should tell me my qualifying earnings are my salary

--- a/features/step_definitions/your_contributions_steps.rb
+++ b/features/step_definitions/your_contributions_steps.rb
@@ -62,3 +62,9 @@ Then(/^I should see my current contributions in the form fields$/) do
   expect(your_contributions_page.employee_percent.value).to eq('14.0')
   expect(your_contributions_page.employer_percent.value).to eq('15.0')
 end
+
+Then(/^I should NOT see an intro for employer contributions$/) do
+  within(".contributions__source--employer") do
+    expect(your_contributions_page).to_not have_content('The legal minimum is')
+  end
+end

--- a/features/step_definitions/your_details_steps.rb
+++ b/features/step_definitions/your_details_steps.rb
@@ -173,15 +173,9 @@ Then(/^I should see my "([^"]*)", "([^"]*)", "([^"]*)", "([^"]*)" and "([^"]*)" 
   expect(your_details_page.send("#{contribution.downcase}_contribution_button")).to be_truthy
 end
 
-Then(/^the employee_percent input intro paragraph should display the correct percentage$/) do
-  within('.contributions__source--employee') do
-    expect(your_contributions_page).to have_content('The legal minimum is 1%')
-  end
-end
-
-Then(/^the employer_percent input intro paragraph should display the correct percentage$/) do
-  within('.contributions__source--employer') do
-    expect(your_contributions_page).to have_content('The legal minimum is 1%')
+Then(/^the "([^"]*)" contribution intro should display "([^"]*)"$/) do |contributor, message|
+  within(".contributions__source--#{contributor}") do
+    expect(your_contributions_page).to have_content(message)
   end
 end
 

--- a/lib/wpcc/version.rb
+++ b/lib/wpcc/version.rb
@@ -1,7 +1,7 @@
 module Wpcc
   module Version
     MAJOR = 1
-    MINOR = 10
+    MINOR = 11
     PATCH = 0
 
     STRING = [MAJOR, MINOR, PATCH].join('.')

--- a/spec/javascripts/tests/SalaryConditions_spec.js
+++ b/spec/javascripts/tests/SalaryConditions_spec.js
@@ -114,17 +114,6 @@ describe('Salary Conditions', function() {
         done();
       });
 
-      it('Saves this state to local storage and checks the correct radio control', function(done) {
-        this.salaryField.val('3000');
-        this.salaryField.trigger('keyup');
-        clock.tick(this.delay);
-        expect(localStorage.getItem('lt5876')).to.equal('true');
-        expect(
-          this.component.find('input[name="your_details_form[contribution_preference]"]:checked').val()
-        ).to.equal('full');
-        done();
-      });
-
       it('Clears state from localStorage if salary is changed to £5876 or above and checks the correct radio control',
         function(done) {
         this.salaryField.val('5876');
@@ -240,62 +229,6 @@ describe('Salary Conditions', function() {
       ).to.be.true;
     });
 
-  });
-
-  describe('When user proceeds to step 2 with salary below £5876', function() {
-    var clock;
-
-    beforeEach(function() {
-      this.salaryField = this.component.find('[data-wpcc-salary-input]');
-      this.employeeTip = this.component.find('[data-wpcc-employee-tip]');
-      this.employeeTip_lt5876 = this.component.find('[data-wpcc-employee-tip-lt5876]');
-      this.employerTip = this.component.find('[data-wpcc-employer-tip]');
-      this.employeeContributions = this.component.find('[data-wpcc-employee-contributions]');
-      this.employerContributions = this.component.find('[data-wpcc-employer-contributions]');
-      clock = sinon.useFakeTimers();
-      this.obj.init();
-    });
-
-    afterEach(function() {
-      clock.restore();
-    });
-
-    it('Has saved state to local storage', function(done) {
-      this.salaryField.val('3000');
-      this.salaryField.trigger('keyup');
-      clock.tick(this.delay);
-      expect(localStorage.getItem('lt5876')).to.equal('true');
-      done();
-    });
-
-    it('Adjusts the default contribution values', function(done) {
-      this.salaryField.val('3000');
-      this.salaryField.trigger('keyup');
-      clock.tick(this.delay);
-
-      if (localStorage.getItem('lt5876') == 'true') {
-        expect(this.employeeContributions.val()).to.equal('1');
-        expect(this.employerContributions.val()).to.equal('0');
-      }
-
-      done();
-    });
-
-    it('Updates the employee contribution tip', function(done) {
-      this.salaryField.val('3000');
-      this.salaryField.trigger('keyup');
-      clock.tick(this.delay);
-      expect(this.employeeTip_lt5876.hasClass('is-hidden')).to.be.false;
-      done();
-    });
-
-    it('Hides the employer contribution tip', function(done) {
-      this.salaryField.val('3000');
-      this.salaryField.trigger('keyup');
-      clock.tick(this.delay);
-      expect(this.employerTip.text()).to.equal('');
-      done();
-    });
   });
 
   describe('When user proceeds to step 2 with salary of £5876 or above', function() {

--- a/spec/models/salary_message_spec.rb
+++ b/spec/models/salary_message_spec.rb
@@ -156,4 +156,32 @@ RSpec.describe Wpcc::SalaryMessage do
       end
     end
   end
+
+  describe '#salary_below_pension_limit?' do
+    let(:salary_frequency) { 'whatever' }
+
+    context 'salary is within the range of an automatic workplace pension' do
+      let(:salary) { 5_876 }
+
+      it 'returns false' do
+        expect(subject).not_to be_salary_below_pension_limit
+      end
+    end
+
+    context 'salary is above the range of an automatic workplace pension' do
+      let(:salary) { 10_001 }
+
+      it 'returns false' do
+        expect(subject).not_to be_salary_below_pension_limit
+      end
+    end
+
+    context 'salary is below the range of an automatic workplace pension' do
+      let(:salary) { 5_875 }
+
+      it 'returns true' do
+        expect(subject).to be_salary_below_pension_limit
+      end
+    end
+  end
 end

--- a/spec/presenters/message_presenter_spec.rb
+++ b/spec/presenters/message_presenter_spec.rb
@@ -6,11 +6,13 @@ RSpec.describe Wpcc::MessagePresenter do
     double(
       :object,
       text: text,
-      salary_below_tax_relief_threshold?: salary_below_tax_relief_threshold?
+      salary_below_tax_relief_threshold?: salary_below_tax_relief_threshold?,
+      salary_below_pension_limit?: salary_below_pension_limit?
     )
   end
   let(:text) { nil }
   let(:salary_below_tax_relief_threshold?) { true }
+  let(:salary_below_pension_limit?) { true }
 
   describe '#manually_opt_in_message?' do
     context 'when the text is manually_opt_in' do
@@ -119,6 +121,43 @@ RSpec.describe Wpcc::MessagePresenter do
       it 'formats the session details to a string' do
         string = '43 years, female, £26,000 per week, full salary'
         expect(subject.your_details_summary(hash)).to eq(string)
+      end
+    end
+  end
+
+  describe '#employee_contribution_tip' do
+    context 'when the salary is below tax relief threshold' do
+      let(:salary_below_pension_limit?) { true }
+      it 'returns information message' do
+        string = 'At your salary level there is no legal minimum contribution' \
+          ' but your workplace pension scheme may have a set minimum.'\
+          ' Check with your employer.'
+        expect(subject.employee_contribution_tip).to eq string
+      end
+    end
+
+    context 'when the salary is above tax relief threshold' do
+      let(:salary_below_pension_limit?) { false }
+      it 'default legal message' do
+        string = 'The legal minimum is 1%'
+        expect(subject.employee_contribution_tip).to eq string
+      end
+    end
+  end
+
+  describe '#employer_contribution_tip' do
+    context 'when the salary is below tax relief threshold' do
+      let(:salary_below_pension_limit?) { true }
+      it 'returns no message' do
+        expect(subject.employer_contribution_tip).to be_nil
+      end
+    end
+
+    context 'when the salary is above tax relief threshold' do
+      let(:salary_below_pension_limit?) { false }
+      it 'default legal message' do
+        string = 'The legal minimum is 1%'
+        expect(subject.employer_contribution_tip).to eq string
       end
     end
   end


### PR DESCRIPTION
[TP - 8564](https://moneyadviceservice.tpondemand.com/entity/8564) Step 2 Validation based on Salary

This PR addresses a change of logic from Client side to Server side. The need for this comes from the fact that WPCC is not a one page app as originally planned. 
When a user has a salary less than £5,876 the messages displayed in the contribution boxes are different as there is no longer a legal minimum of 1%