### PR TITLE
[DEV APPROVED] 8565 Amend the employer percent for calculating contributions

### DIFF
--- a/app/models/wpcc/contributions_calendar.rb
+++ b/app/models/wpcc/contributions_calendar.rb
@@ -8,7 +8,7 @@ module Wpcc
         Wpcc::PeriodContributionCalculator.new(
           name: period.name,
           employee_percent: period.highest_employee_percent,
-          employer_percent: period.highest_employer_percent,
+          employer_percent: period.required_employer_percent(eligible_salary),
           eligible_salary: eligible_salary,
           salary_frequency: salary_frequency,
           tax_relief_percent: period.tax_relief_percent

--- a/app/models/wpcc/period.rb
+++ b/app/models/wpcc/period.rb
@@ -14,8 +14,12 @@ module Wpcc
       Percent.choose_highest(@employee_percent, @user_input_employee_percent)
     end
 
-    def highest_employer_percent
-      Percent.choose_highest(@employer_percent, @user_input_employer_percent)
+    def required_employer_percent(eligible_salary)
+      if salary_below_minimum?(eligible_salary)
+        @user_input_employer_percent
+      else
+        highest_employer_percent
+      end
     end
 
     def below_user_contributions?(period_filter)
@@ -31,6 +35,14 @@ module Wpcc
     def percents_below_user_input_percents?(period_filter)
       employee_percent <= period_filter.user_input_employee_percent &&
         employer_percent <= period_filter.user_input_employer_percent
+    end
+
+    def salary_below_minimum?(eligible_salary)
+      eligible_salary < Wpcc::ContributionCalculator::THRESHOLDS['lower']
+    end
+
+    def highest_employer_percent
+      Percent.choose_highest(@employer_percent, @user_input_employer_percent)
     end
   end
 end

--- a/features/_your_results/salary_below_minimum_threshold.feature
+++ b/features/_your_results/salary_below_minimum_threshold.feature
@@ -1,0 +1,34 @@
+Feature: Employer contributions do not increase when user's salary is less than the minimum threshold
+  In order to understand that there is no requirement for employer contributions to increase over time
+  As an employee earning under £5876 per year
+  I need to see employer contributions stay static
+
+  Scenario Outline: For monthly, 4-weekly and weekly salary frequencies
+    Given my "<salary>" "<salary_frequency>" is below the minimum threshold
+    And my employee contribution is "1"
+    And my employer contribution is "<employer_percent>"
+    When I move on to the results page
+    Then I should see that the "<employer_contribution>" is the same for each period
+
+    Examples:
+        | salary | salary_frequency  | employer_percent | employer_contribution |
+        | 416.67 | per Month         | 0                | £0.00                 |
+        | 416.67 | per Month         | 1                | £4.16                 |
+        | 384.62 | per 4 weeks       | 0                | £0.00                 |
+        | 384.62 | per 4 weeks       | 1                | £3.84                 |
+        | 96.15  | per Week          | 0                | £0.00                 |
+        | 96.15  | per Week          | 1                | £0.96                 |
+
+  Scenario Outline: For annual salary frequency
+    Given my "<salary>" "<salary_frequency>" is below the minimum threshold
+    And my employee contribution is "1"
+    And my employer contribution is "<employer_percent>"
+    When I move on to the results page
+    And I select "<salary_frequency>" to change the calculations
+    And I press recalculate
+    Then I should see that the "<employer_contribution>" is the same for each period
+
+    Examples:
+        | salary | salary_frequency | employer_percent | employer_contribution |
+        | 5000   | per Year         | 0                | £0.00                 |
+        | 5000   | per Year         | 1                | £50.00                |

--- a/features/step_definitions/your_details_steps.rb
+++ b/features/step_definitions/your_details_steps.rb
@@ -43,6 +43,13 @@ Given(/^I am a "([^"]*)" year old "([^"]*)"$/) do |age, gender|
   step %{I select my gender as "#{gender}"}
 end
 
+Given(/^my "([^"]*)" "([^"]*)" is below the minimum threshold$/) do |salary, salary_frequency|
+  step %{I am on the Your Details step}
+  step %{I enter my details}
+  step %{my salary is "#{salary}" "#{salary_frequency}" with "Full" contribution}
+  step %{I proceed to the next step}
+end
+
 When(/^I enter my details$/) do
   step %{I enter my age as "35"}
   step %{I select my gender as "#{I18n.translate('wpcc.details.options.gender.female')}"}

--- a/features/step_definitions/your_results_steps.rb
+++ b/features/step_definitions/your_results_steps.rb
@@ -133,6 +133,12 @@ Then(/^I should see the percents information:$/) do |table|
   expect(your_results_page.table_cells.map{|cell| cell.text}).to eq(data)
 end
 
+Then(/^I should see that the "([^"]*)" is the same for each period$/) do |employer_contribution|
+  step %{I should see my employer contributions for current period as "#{employer_contribution}"}
+  step %{I should see my employer contributions for second period as "#{employer_contribution}"}
+  step %{I should see my employer contributions for third period as "#{employer_contribution}"}  
+end
+
 Given(/^that I am on your details step I fill:$/) do |table|
   data = table.hashes.first
   step %{I enter my age as "#{data[:age]}"}

--- a/spec/models/contributions_calendar_spec.rb
+++ b/spec/models/contributions_calendar_spec.rb
@@ -47,7 +47,7 @@ describe Wpcc::ContributionsCalendar, type: :model do
       it 'calls the PeriodContributionCalculator passing the percentages' do
         expect(next_period).to receive(:highest_employee_percent).and_return(3)
 
-        expect(next_period).to receive(:highest_employer_percent).and_return(4)
+        expect(next_period).to receive(:required_employer_percent).and_return(4)
 
         expect(Wpcc::PeriodContributionCalculator)
           .to receive(:new)

--- a/spec/models/period_spec.rb
+++ b/spec/models/period_spec.rb
@@ -25,13 +25,29 @@ RSpec.describe Wpcc::Period do
     end
   end
 
-  describe '#highest_employer_percent' do
+  describe '#required_employer_percent' do
     let(:employer_percent) { 5 }
     let(:user_input_employer_percent) { 6 }
 
-    it 'returns highest percent between period percent and user percent' do
-      expect(Wpcc::Percent).to receive(:choose_highest).with(5, 6).and_return(6)
-      period.highest_employer_percent
+    context 'when user\'s salary is below the minimum threshold' do
+      let(:salary) { 5_000 }
+
+      it 'returns the user percent' do
+        expect(period.required_employer_percent(salary)).to eq(6)
+      end
+    end
+
+    context 'when user\'s salary is gte the minimum threshold' do
+      let(:salary) { 5_876 }
+
+      it 'returns highest percent between period percent and user percent' do
+        expect(Wpcc::Percent)
+          .to receive(:choose_highest)
+          .with(5, 6)
+          .and_return(6)
+
+        period.required_employer_percent(salary)
+      end
     end
   end
 


### PR DESCRIPTION
This pr addresses [TP User Story 8565](https://moneyadviceservice.tpondemand.com/RestUI/Board.aspx?acid=DDD7F3A626844AB8D1BEE3F06EC28EFA#page=board/5624876525867731357&appConfig=eyJhY2lkIjoiREI4ODcwRjkxMDNDRTM2NTlBMzhDNTRBRTVBNUU1N0UifQ==&searchPopup=UserStory/8565).
### Objective
If the user's salary is below the minimum, use the user input; otherwise use the higher of the user's input and the legal requirement.

### Technical
* The Period class sets the employer percent. I amended this class to first check the salary and then set the employer percent accordingly
* The ContributionsCalculator needs to call the new Period class method and pass the salary.