### PR TITLE
[DEV APPROVED] 8572 - Updating links to open in new tabs

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,6 @@
+## 1.11.1:
+* TP-8572: Making reference links within WPCC to be opened in new tab
+
 ## 1.11.0:
 * TP-8565: Amend the employer percent for calculating contributions
 * TP-8564: Add server side validations for contribution percent

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -42,7 +42,7 @@ cy:
 
       salary:
         label: Eich cyflog
-        tooltip_html: Rhowch eich cyflog cyn i’r dreth nag unrhyw ddidyniadau eraill gael eu tynnu. Gelwir hyn yn gyflog gros. <a href="/cy/articles/cofrestriad-awtomatig-ar-bensiwn-man-gwaith#cofrestru-awtomatig-pam-fydd-gennych-fwy-nag-un-swydd" target="_blank">Os oes gennych fwy nag un swydd</a>, bydd raid i chi roi pob cyflog ar wahân.
+        tooltip_html: Rhowch eich cyflog cyn i’r dreth nag unrhyw ddidyniadau eraill gael eu tynnu. Gelwir hyn yn gyflog gros. <a href="/cy/articles/cofrestriad-awtomatig-ar-bensiwn-man-gwaith#cofrestru-awtomatig-pam-fydd-gennych-fwy-nag-un-swydd" target="_blank">Os oes gennych fwy nag un swydd <span class="visually-hidden">(Yn agor mewn ffenestr newydd)</span></a>, bydd raid i chi roi pob cyflog ar wahân.
         validation: Nodwch eich cyflog
         frequency:
           label: Frequency
@@ -144,9 +144,9 @@ cy:
           employers_fourweeks_html: Cyfraniad y cyflogwr <span data-wpcc-title-frequency>%{salary_frequency}</span>
           total_html: Cyfanswm y cyfraniad <span data-wpcc-title-frequency>%{salary_frequency}</span>
         tax_relief_html: (yn cynnwys gostyngiad treth o <span data-wpcc-tax-relief-value>%{formatted_tax_relief}</span>)
-      tax_relief_warning_html: Os nad ydych chi'n talu treth incwm ar eich enillion, fyddwch chi ddim ond yn cael gostyngiad treth ar eich cyfraniadau os bydd eich cynllun pensiwn yn casglu cyfraniadau yn defnyddio'r gostyngiad treth yn y ffynhonnell. Rydym wedi tybio bod eich cynllun yn gwneud hyn. Darllenwch ragor yn ein canllaw am <a href="https://www.moneyadviceservice.org.uk/cy/articles/gostyngiad-treth-ach-pensiwn-gweithle" target="_blank">ostyngiadau treth ar gyfraniadau pensiwn</a>.
+      tax_relief_warning_html: Os nad ydych chi'n talu treth incwm ar eich enillion, fyddwch chi ddim ond yn cael gostyngiad treth ar eich cyfraniadau os bydd eich cynllun pensiwn yn casglu cyfraniadau yn defnyddio'r gostyngiad treth yn y ffynhonnell. Rydym wedi tybio bod eich cynllun yn gwneud hyn. Darllenwch ragor yn ein canllaw am <a href="https://www.moneyadviceservice.org.uk/cy/articles/gostyngiad-treth-ach-pensiwn-gweithle" target="_blank">ostyngiadau treth ar gyfraniadau pensiwn <span class="visually-hidden">(Yn agor mewn ffenestr newydd)</span></a>.
       tax_relief_warning: Os nad ydych chi'n talu treth incwm ar eich enillion, fyddwch chi ddim ond yn cael gostyngiad treth ar eich cyfraniadau os bydd eich cynllun pensiwn yn casglu cyfraniadau yn defnyddio'r gostyngiad treth yn y ffynhonnell. Rydym wedi tybio bod eich cynllun yn gwneud hyn. Darllenwch ragor yn ein canllaw am ostyngiadau treth ar gyfraniadau pensiwn.
-      tax_relief_tooltip_html: Byddwch yn cael gostyngiad treth ar eich cyfraniadau pensiwn sy'n golygu y rhoddir peth o’r arian o'ch cyflog a fyddai wedi mynd i’r llywodraeth fel treth tuag at eich pensiwn yn hytrach. <a href="https://www.moneyadviceservice.org.uk/cy/articles/gostyngiad-treth-ach-pensiwn-gweithle" target="_blank">Darllenwch fwy am sut i gael gostyngiad treth</a>.
+      tax_relief_tooltip_html: Byddwch yn cael gostyngiad treth ar eich cyfraniadau pensiwn sy'n golygu y rhoddir peth o’r arian o'ch cyflog a fyddai wedi mynd i’r llywodraeth fel treth tuag at eich pensiwn yn hytrach. <a href="https://www.moneyadviceservice.org.uk/cy/articles/gostyngiad-treth-ach-pensiwn-gweithle" target="_blank">Darllenwch fwy am sut i gael gostyngiad treth <span class="visually-hidden">(Yn agor mewn ffenestr newydd)</span></a>.
       contribution_table_link: Darllen tabl sy’n dangos sut mae isafswm cyfraniadau cyfreithlon yn newid
       print_link: Argraffu eich canlyniadau
       email_link: E-bostio eich canlyniadau
@@ -154,9 +154,9 @@ cy:
       next_steps:
         heading: Y Camau Nesaf
         list:
-          pension_calculator_html: Defnyddiwch ein <a href="https://www.moneyadviceservice.org.uk/cy/tools/cyfrifiannell-pensiwn" target="_blank">Cyfrifiannell Pensiwn</a> i weld faint o bensiwn y bydd eich cronfa yn ei chronni dros amser.
-          workplace_pensions_html: Dysgwch ragor am <a href="https://www.moneyadviceservice.org.uk/cy/categories/automatic-enrolment" target="_blank">bensiynau gweithle</a>.
-          budget_planner_html: Defnyddiwch ein <a href="https://www.moneyadviceservice.org.uk/cy/tools/cynllunydd-cyllideb/start" target="_blank">cynllunydd cyllideb</a> i weld pa effaith y bydd eich cyfraniadau yn eu cael ar eich incwm.
+          pension_calculator_html: Defnyddiwch ein <a href="https://www.moneyadviceservice.org.uk/cy/tools/cyfrifiannell-pensiwn" target="_blank">Cyfrifiannell Pensiwn <span class="visually-hidden">(Yn agor mewn ffenestr newydd)</span></a> i weld faint o bensiwn y bydd eich cronfa yn ei chronni dros amser.
+          workplace_pensions_html: Dysgwch ragor am <a href="https://www.moneyadviceservice.org.uk/cy/categories/automatic-enrolment" target="_blank">bensiynau gweithle <span class="visually-hidden">(Yn agor mewn ffenestr newydd)</span></a>.
+          budget_planner_html: Defnyddiwch ein <a href="https://www.moneyadviceservice.org.uk/cy/tools/cynllunydd-cyllideb/start" target="_blank">cynllunydd cyllideb <span class="visually-hidden">(Yn agor mewn ffenestr newydd)</span></a> i weld pa effaith y bydd eich cyfraniadau yn eu cael ar eich incwm.
       edit_frequency:
         label: Dangos fy nghyfraniadau
         button: Al-gyfrifo

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -42,7 +42,7 @@ cy:
 
       salary:
         label: Eich cyflog
-        tooltip_html: Rhowch eich cyflog cyn i’r dreth nag unrhyw ddidyniadau eraill gael eu tynnu. Gelwir hyn yn gyflog gros. <a href="/cy/articles/cofrestriad-awtomatig-ar-bensiwn-man-gwaith#cofrestru-awtomatig-pam-fydd-gennych-fwy-nag-un-swydd">Os oes gennych fwy nag un swydd</a>, bydd raid i chi roi pob cyflog ar wahân.
+        tooltip_html: Rhowch eich cyflog cyn i’r dreth nag unrhyw ddidyniadau eraill gael eu tynnu. Gelwir hyn yn gyflog gros. <a href="/cy/articles/cofrestriad-awtomatig-ar-bensiwn-man-gwaith#cofrestru-awtomatig-pam-fydd-gennych-fwy-nag-un-swydd" target="_blank">Os oes gennych fwy nag un swydd</a>, bydd raid i chi roi pob cyflog ar wahân.
         validation: Nodwch eich cyflog
         frequency:
           label: Frequency
@@ -144,9 +144,9 @@ cy:
           employers_fourweeks_html: Cyfraniad y cyflogwr <span data-wpcc-title-frequency>%{salary_frequency}</span>
           total_html: Cyfanswm y cyfraniad <span data-wpcc-title-frequency>%{salary_frequency}</span>
         tax_relief_html: (yn cynnwys gostyngiad treth o <span data-wpcc-tax-relief-value>%{formatted_tax_relief}</span>)
-      tax_relief_warning_html: Os nad ydych chi'n talu treth incwm ar eich enillion, fyddwch chi ddim ond yn cael gostyngiad treth ar eich cyfraniadau os bydd eich cynllun pensiwn yn casglu cyfraniadau yn defnyddio'r gostyngiad treth yn y ffynhonnell. Rydym wedi tybio bod eich cynllun yn gwneud hyn. Darllenwch ragor yn ein canllaw am <a href="https://www.moneyadviceservice.org.uk/cy/articles/gostyngiad-treth-ach-pensiwn-gweithle">ostyngiadau treth ar gyfraniadau pensiwn</a>.
+      tax_relief_warning_html: Os nad ydych chi'n talu treth incwm ar eich enillion, fyddwch chi ddim ond yn cael gostyngiad treth ar eich cyfraniadau os bydd eich cynllun pensiwn yn casglu cyfraniadau yn defnyddio'r gostyngiad treth yn y ffynhonnell. Rydym wedi tybio bod eich cynllun yn gwneud hyn. Darllenwch ragor yn ein canllaw am <a href="https://www.moneyadviceservice.org.uk/cy/articles/gostyngiad-treth-ach-pensiwn-gweithle" target="_blank">ostyngiadau treth ar gyfraniadau pensiwn</a>.
       tax_relief_warning: Os nad ydych chi'n talu treth incwm ar eich enillion, fyddwch chi ddim ond yn cael gostyngiad treth ar eich cyfraniadau os bydd eich cynllun pensiwn yn casglu cyfraniadau yn defnyddio'r gostyngiad treth yn y ffynhonnell. Rydym wedi tybio bod eich cynllun yn gwneud hyn. Darllenwch ragor yn ein canllaw am ostyngiadau treth ar gyfraniadau pensiwn.
-      tax_relief_tooltip_html: Byddwch yn cael gostyngiad treth ar eich cyfraniadau pensiwn sy'n golygu y rhoddir peth o’r arian o'ch cyflog a fyddai wedi mynd i’r llywodraeth fel treth tuag at eich pensiwn yn hytrach. <a href="https://www.moneyadviceservice.org.uk/cy/articles/gostyngiad-treth-ach-pensiwn-gweithle">Darllenwch fwy am sut i gael gostyngiad treth</a>.
+      tax_relief_tooltip_html: Byddwch yn cael gostyngiad treth ar eich cyfraniadau pensiwn sy'n golygu y rhoddir peth o’r arian o'ch cyflog a fyddai wedi mynd i’r llywodraeth fel treth tuag at eich pensiwn yn hytrach. <a href="https://www.moneyadviceservice.org.uk/cy/articles/gostyngiad-treth-ach-pensiwn-gweithle" target="_blank">Darllenwch fwy am sut i gael gostyngiad treth</a>.
       contribution_table_link: Darllen tabl sy’n dangos sut mae isafswm cyfraniadau cyfreithlon yn newid
       print_link: Argraffu eich canlyniadau
       email_link: E-bostio eich canlyniadau
@@ -154,9 +154,9 @@ cy:
       next_steps:
         heading: Y Camau Nesaf
         list:
-          pension_calculator_html: Defnyddiwch ein <a href="https://www.moneyadviceservice.org.uk/cy/tools/cyfrifiannell-pensiwn">Cyfrifiannell Pensiwn</a> i weld faint o bensiwn y bydd eich cronfa yn ei chronni dros amser.
-          workplace_pensions_html: Dysgwch ragor am <a href="https://www.moneyadviceservice.org.uk/cy/categories/automatic-enrolment">bensiynau gweithle</a>.
-          budget_planner_html: Defnyddiwch ein <a href="https://www.moneyadviceservice.org.uk/cy/tools/cynllunydd-cyllideb/start">cynllunydd cyllideb</a> i weld pa effaith y bydd eich cyfraniadau yn eu cael ar eich incwm.
+          pension_calculator_html: Defnyddiwch ein <a href="https://www.moneyadviceservice.org.uk/cy/tools/cyfrifiannell-pensiwn" target="_blank">Cyfrifiannell Pensiwn</a> i weld faint o bensiwn y bydd eich cronfa yn ei chronni dros amser.
+          workplace_pensions_html: Dysgwch ragor am <a href="https://www.moneyadviceservice.org.uk/cy/categories/automatic-enrolment" target="_blank">bensiynau gweithle</a>.
+          budget_planner_html: Defnyddiwch ein <a href="https://www.moneyadviceservice.org.uk/cy/tools/cynllunydd-cyllideb/start" target="_blank">cynllunydd cyllideb</a> i weld pa effaith y bydd eich cyfraniadau yn eu cael ar eich incwm.
       edit_frequency:
         label: Dangos fy nghyfraniadau
         button: Al-gyfrifo

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -42,7 +42,7 @@ en:
 
       salary:
         label: Your salary
-        tooltip_html: Enter your salary before tax or other deductions are taken off.  This is known as your gross salary.  <a href="/en/articles/automatic-enrolment-into-a-workplace-pension#automatic-enrolment-when-you-have-more-than-one-job" target="_blank">If you have more than one job</a>, you will have to enter each salary separately.
+        tooltip_html: Enter your salary before tax or other deductions are taken off.  This is known as your gross salary.  <a href="/en/articles/automatic-enrolment-into-a-workplace-pension#automatic-enrolment-when-you-have-more-than-one-job" target="_blank">If you have more than one job <span class="visually-hidden">(opens in a new window)</span></a>, you will have to enter each salary separately.
         validation: Please enter your salary
         frequency:
           label: Frequency
@@ -143,9 +143,9 @@ en:
           employers_html: Employer's <span data-wpcc-title-frequency>%{salary_frequency}</span> contribution
           total_html: Total <span data-wpcc-title-frequency>%{salary_frequency}</span> contributions
         tax_relief_html: (includes tax relief of <span data-wpcc-tax-relief-value>%{formatted_tax_relief}</span>)
-      tax_relief_warning_html: If you don’t pay income tax on your earnings, you will only receive tax relief on your pension contributions if your pension scheme collects contributions using the tax relief at source method. We have assumed your scheme does. Read more in our guide about <a href="https://www.moneyadviceservice.org.uk/en/articles/tax-relief-and-your-workplace-pension" target="_blank">tax relief on pension contributions</a>.
+      tax_relief_warning_html: If you don’t pay income tax on your earnings, you will only receive tax relief on your pension contributions if your pension scheme collects contributions using the tax relief at source method. We have assumed your scheme does. Read more in our guide about <a href="https://www.moneyadviceservice.org.uk/en/articles/tax-relief-and-your-workplace-pension" target="_blank">tax relief on pension contributions <span class="visually-hidden">(opens in a new window)</span></a>.
       tax_relief_warning: If you don’t pay income tax on your earnings, you will only receive tax relief on your pension contributions if your pension scheme collects contributions using the tax relief at source method.  We have assumed your scheme does. Read more in our guide about tax relief on pension contributions.
-      tax_relief_tooltip_html: You get tax relief on pension contributions which means some of the money from your pay that would have gone to the government as tax goes towards your pension instead. <a href="https://www.moneyadviceservice.org.uk/en/articles/tax-relief-and-your-workplace-pension" target="_blank">Read more about how you get tax relief</a>.
+      tax_relief_tooltip_html: You get tax relief on pension contributions which means some of the money from your pay that would have gone to the government as tax goes towards your pension instead. <a href="https://www.moneyadviceservice.org.uk/en/articles/tax-relief-and-your-workplace-pension" target="_blank">Read more about how you get tax relief <span class="visually-hidden">(opens in a new window)</span></a>.
       contribution_table_link: View a table of how legal minimum contributions change
       print_link: Print your results
       email_link: Email your results
@@ -153,9 +153,9 @@ en:
       next_steps:
         heading: Next steps
         list:
-          pension_calculator_html: Use our <a href="https://www.moneyadviceservice.org.uk/en/tools/pension-calculator" target="_blank">Pension Calculator</a> to see how much pension pot you will build over time.
-          workplace_pensions_html: Find out more about <a href="https://www.moneyadviceservice.org.uk/en/categories/automatic-enrolment" target="_blank">workplace pensions</a>.
-          budget_planner_html: Use our <a href="https://www.moneyadviceservice.org.uk/en/tools/budget-planner" target="_blank">budget planner</a> to see what effect your contributions will have on your income.
+          pension_calculator_html: Use our <a href="https://www.moneyadviceservice.org.uk/en/tools/pension-calculator" target="_blank">Pension Calculator <span class="visually-hidden">(opens in a new window)</span></a> to see how much pension pot you will build over time.
+          workplace_pensions_html: Find out more about <a href="https://www.moneyadviceservice.org.uk/en/categories/automatic-enrolment" target="_blank">workplace pensions <span class="visually-hidden">(opens in a new window)</span></a>.
+          budget_planner_html: Use our <a href="https://www.moneyadviceservice.org.uk/en/tools/budget-planner" target="_blank">budget planner <span class="visually-hidden">(opens in a new window)</span></a> to see what effect your contributions will have on your income.
       edit_frequency:
         label: Show my contributions
         button: Recalculate

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -42,7 +42,7 @@ en:
 
       salary:
         label: Your salary
-        tooltip_html: Enter your salary before tax or other deductions are taken off.  This is known as your gross salary.  <a href="/en/articles/automatic-enrolment-into-a-workplace-pension#automatic-enrolment-when-you-have-more-than-one-job">If you have more than one job</a>, you will have to enter each salary separately.
+        tooltip_html: Enter your salary before tax or other deductions are taken off.  This is known as your gross salary.  <a href="/en/articles/automatic-enrolment-into-a-workplace-pension#automatic-enrolment-when-you-have-more-than-one-job" target="_blank">If you have more than one job</a>, you will have to enter each salary separately.
         validation: Please enter your salary
         frequency:
           label: Frequency
@@ -143,9 +143,9 @@ en:
           employers_html: Employer's <span data-wpcc-title-frequency>%{salary_frequency}</span> contribution
           total_html: Total <span data-wpcc-title-frequency>%{salary_frequency}</span> contributions
         tax_relief_html: (includes tax relief of <span data-wpcc-tax-relief-value>%{formatted_tax_relief}</span>)
-      tax_relief_warning_html: If you don’t pay income tax on your earnings, you will only receive tax relief on your pension contributions if your pension scheme collects contributions using the tax relief at source method. We have assumed your scheme does. Read more in our guide about <a href="https://www.moneyadviceservice.org.uk/en/articles/tax-relief-and-your-workplace-pension">tax relief on pension contributions</a>.
+      tax_relief_warning_html: If you don’t pay income tax on your earnings, you will only receive tax relief on your pension contributions if your pension scheme collects contributions using the tax relief at source method. We have assumed your scheme does. Read more in our guide about <a href="https://www.moneyadviceservice.org.uk/en/articles/tax-relief-and-your-workplace-pension" target="_blank">tax relief on pension contributions</a>.
       tax_relief_warning: If you don’t pay income tax on your earnings, you will only receive tax relief on your pension contributions if your pension scheme collects contributions using the tax relief at source method.  We have assumed your scheme does. Read more in our guide about tax relief on pension contributions.
-      tax_relief_tooltip_html: You get tax relief on pension contributions which means some of the money from your pay that would have gone to the government as tax goes towards your pension instead. <a href="https://www.moneyadviceservice.org.uk/en/articles/tax-relief-and-your-workplace-pension">Read more about how you get tax relief</a>.
+      tax_relief_tooltip_html: You get tax relief on pension contributions which means some of the money from your pay that would have gone to the government as tax goes towards your pension instead. <a href="https://www.moneyadviceservice.org.uk/en/articles/tax-relief-and-your-workplace-pension" target="_blank">Read more about how you get tax relief</a>.
       contribution_table_link: View a table of how legal minimum contributions change
       print_link: Print your results
       email_link: Email your results
@@ -153,9 +153,9 @@ en:
       next_steps:
         heading: Next steps
         list:
-          pension_calculator_html: Use our <a href="https://www.moneyadviceservice.org.uk/en/tools/pension-calculator">Pension Calculator</a> to see how much pension pot you will build over time.
-          workplace_pensions_html: Find out more about <a href="https://www.moneyadviceservice.org.uk/en/categories/automatic-enrolment">workplace pensions</a>.
-          budget_planner_html: Use our <a href="https://www.moneyadviceservice.org.uk/en/tools/budget-planner">budget planner</a> to see what effect your contributions will have on your income.
+          pension_calculator_html: Use our <a href="https://www.moneyadviceservice.org.uk/en/tools/pension-calculator" target="_blank">Pension Calculator</a> to see how much pension pot you will build over time.
+          workplace_pensions_html: Find out more about <a href="https://www.moneyadviceservice.org.uk/en/categories/automatic-enrolment" target="_blank">workplace pensions</a>.
+          budget_planner_html: Use our <a href="https://www.moneyadviceservice.org.uk/en/tools/budget-planner" target="_blank">budget planner</a> to see what effect your contributions will have on your income.
       edit_frequency:
         label: Show my contributions
         button: Recalculate

--- a/lib/wpcc/version.rb
+++ b/lib/wpcc/version.rb
@@ -2,7 +2,7 @@ module Wpcc
   module Version
     MAJOR = 1
     MINOR = 11
-    PATCH = 0
+    PATCH = 1
 
     STRING = [MAJOR, MINOR, PATCH].join('.')
   end


### PR DESCRIPTION
# 8572 - Updating links to open in new tabs

[TP Ticket 8572](https://moneyadviceservice.tpondemand.com/entity/8572)

There are three links (listed below) in the WPCC tool, mostly referenced to articles, that open in the same tab; this kind of kills the user journey as the user is sent to those links from the tool.

This PR:

- Adds the target="_blank" attribute to these links
- Also adds visually hidden text for accessibility
