### PR TITLE
[DEV APPROVED] 8580 - IE11 : Fixing the double dropdown issue

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,6 @@
+## 1.11.2:
+* TP-8580: Fixing the double dropdown issue
+
 ## 1.11.1:
 * TP-8572: Making reference links within WPCC to be opened in new tab
 

--- a/app/assets/stylesheets/wpcc/base/_forms.scss
+++ b/app/assets/stylesheets/wpcc/base/_forms.scss
@@ -7,4 +7,8 @@ select {
   -webkit-appearance:none;
   -moz-appearance:none;
   cursor: pointer;
+
+  &::-ms-expand {
+    display: none;
+  }
 }

--- a/lib/wpcc/version.rb
+++ b/lib/wpcc/version.rb
@@ -2,7 +2,7 @@ module Wpcc
   module Version
     MAJOR = 1
     MINOR = 11
-    PATCH = 1
+    PATCH = 2
 
     STRING = [MAJOR, MINOR, PATCH].join('.')
   end


### PR DESCRIPTION
# 8580 - IE11 : Fixing the double dropdown issue

There is currently a dropdown issue on IE11 in WPCC.  This PR solves it

| Before |
|-------|
|![image](https://user-images.githubusercontent.com/13165846/30813611-cea8efda-a205-11e7-8acb-479476023474.png)|

| After |
|------|
|![screen shot 2017-09-25 at 15 22 28 2](https://user-images.githubusercontent.com/13165846/30813657-ebdc5da8-a205-11e7-85bd-b48e0ac9e4c9.png)|

