### PR TITLE
[DEV APPROVED] Removes Karma tests checking for local storage

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,6 @@
+## 1.11.3:
+* Fixing Karma tests
+
 ## 1.11.2:
 * TP-8580: Fixing the double dropdown issue
 

--- a/lib/wpcc/version.rb
+++ b/lib/wpcc/version.rb
@@ -2,7 +2,7 @@ module Wpcc
   module Version
     MAJOR = 1
     MINOR = 11
-    PATCH = 2
+    PATCH = 3
 
     STRING = [MAJOR, MINOR, PATCH].join('.')
   end

--- a/spec/javascripts/tests/SalaryConditions_spec.js
+++ b/spec/javascripts/tests/SalaryConditions_spec.js
@@ -113,18 +113,6 @@ describe('Salary Conditions', function() {
         ).to.equal('full');
         done();
       });
-
-      it('Clears state from localStorage if salary is changed to £5876 or above and checks the correct radio control',
-        function(done) {
-        this.salaryField.val('5876');
-        this.salaryField.trigger('keyup');
-        clock.tick(this.delay);
-        expect(localStorage.getItem('lt5876')).to.be.equal(null);
-        expect(
-          this.component.find('input[name="your_details_form[contribution_preference]"]:checked').val()
-        ).to.equal('full');
-        done();
-      });
     });
 
     describe('When salary is between £5876 and £10000', function() {
@@ -243,14 +231,6 @@ describe('Salary Conditions', function() {
       this.employerTip = this.component.find('[data-wpcc-employer-tip]');
       clock = sinon.useFakeTimers();
       this.obj.init();
-    });
-
-    it('Has not saved state to local storage', function(done) {
-      this.salaryField.val('6000');
-      this.salaryField.trigger('keyup');
-      clock.tick(this.delay);
-      expect(localStorage.getItem('lt5876')).to.equal(null);
-      done();
     });
 
     it('Shows the original contribution values', function(done) {


### PR DESCRIPTION
# Removes Karma tests checking for local storage

This is now handled in the back end.  Currently 2 tests are failing on WPCC.  One checks that a local storage item is saved when a user enters a salary under £5876 and the other checks that this entry exists on step 2.

This functionality was moved into the backend in [this PR](https://github.com/moneyadviceservice/wpcc/pull/146) and is therefore no longer needs to be tested.