### PR TITLE
[DEV APPROVED] 8605 - Incorrect employer percent

### DIFF
--- a/app/controllers/wpcc/your_results_controller.rb
+++ b/app/controllers/wpcc/your_results_controller.rb
@@ -70,7 +70,7 @@ module Wpcc
         eligible_salary: session[:eligible_salary].to_i,
         salary_frequency: salary_frequency.to_i,
         periods: period_filter.filtered_periods,
-        salary: session[:salary].to_i
+        annual_salary: annual_salary
       }
     end
 
@@ -80,6 +80,13 @@ module Wpcc
         salary_frequency: session[:salary_frequency],
         employee_percent: session[:employee_percent]
       )
+    end
+
+    def annual_salary
+      Wpcc::SalaryPerYear.new(
+        salary: session[:salary],
+        salary_frequency: session[:salary_frequency]
+      ).convert
     end
   end
 end

--- a/app/models/wpcc/contributions_calendar.rb
+++ b/app/models/wpcc/contributions_calendar.rb
@@ -1,7 +1,7 @@
 module Wpcc
   class ContributionsCalendar
     include ActiveModel::Model
-    attr_accessor :eligible_salary, :salary_frequency, :periods, :salary
+    attr_accessor :eligible_salary, :salary_frequency, :periods, :annual_salary
 
     def schedule
       periods.map do |period|
@@ -14,12 +14,6 @@ module Wpcc
           tax_relief_percent: period.tax_relief_percent
         ).contribution
       end
-    end
-
-    private
-
-    def annual_salary
-      salary * salary_frequency.to_i
     end
   end
 end

--- a/features/_your_results/salary_below_minimum_threshold.feature
+++ b/features/_your_results/salary_below_minimum_threshold.feature
@@ -24,14 +24,15 @@ Feature: Employer contributions do not increase when user's salary is less than 
     And my employee contribution is "1"
     And my employer contribution is "<employer_percent>"
     When I move on to the results page
+    Then I should see that the employer_contributions is the same for each period at the "<monthly_value>"
     And I select "<salary_frequency>" to change the calculations
     And I press recalculate
-    Then I should see that the "<employer_contribution>" is the same for each period
+    Then I should see that the employer_contributions is the same for each period at the "<yearly_value>"
 
     Examples:
-        | salary | salary_frequency | part_or_full | employer_percent | employer_contribution |
-        | 5000   | per Year         | Full         | 0                | £0.00                 |
-        | 5000   | per Year         | Full         | 1                | £50.00                |
+        | salary | salary_frequency | part_or_full | employer_percent | monthly_value | yearly_value |
+        | 5000   | per Year         | Full         | 0                | £0.00         | £0.00        |
+        | 5000   | per Year         | Full         | 1                | £4.17         | £50.00       |
 
   Scenario Outline: For monthly, 4-weekly and weekly salary frequencies above the minimum threshold
     Given my "<salary>" "<salary_frequency>", regardless of "<part_or_full>" contribution, is above the minimum threshold

--- a/features/step_definitions/your_results_steps.rb
+++ b/features/step_definitions/your_results_steps.rb
@@ -145,6 +145,10 @@ Then(/^I should see employer_contributions for "([^"]*)", "([^"]*)" and "([^"]*)
   step %{I should see my employer contributions for third period as "#{period_3}"}
 end
 
+Then(/^I should see that the employer_contributions is the same for each period at the "([^"]*)"$/) do |employer_contribution|
+  step %{I should see that the "#{employer_contribution}" is the same for each period}
+end
+
 Given(/^that I am on your details step I fill:$/) do |table|
   data = table.hashes.first
   step %{I enter my age as "#{data[:age]}"}

--- a/lib/wpcc/version.rb
+++ b/lib/wpcc/version.rb
@@ -2,7 +2,7 @@ module Wpcc
   module Version
     MAJOR = 1
     MINOR = 11
-    PATCH = 6
+    PATCH = 7
 
     STRING = [MAJOR, MINOR, PATCH].join('.')
   end

--- a/spec/controllers/your_results_controller_spec.rb
+++ b/spec/controllers/your_results_controller_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe Wpcc::YourResultsController do
   let(:period) { double(Wpcc::Period) }
   let(:period_presenters) { [period_presenter, period_presenter] }
   let(:period_presenter) { double(Wpcc::PeriodPresenter) }
+  let(:salary_per_year) { double(Wpcc::SalaryPerYear) }
 
   describe 'GET /your_results' do
     context 'when session has no keys' do
@@ -28,6 +29,19 @@ RSpec.describe Wpcc::YourResultsController do
 
   describe '#schedule' do
     it 'returns an array of formatted PeriodContributions' do
+      request.session[:salary] = 75
+      request.session[:salary_frequency] = 'week'
+
+      expect(Wpcc::SalaryPerYear)
+        .to receive(:new)
+        .with(
+          salary: 75,
+          salary_frequency: 'week'
+        )
+        .and_return(salary_per_year)
+
+      expect(salary_per_year).to receive(:convert)
+
       expect(Wpcc::ContributionsCalendar)
         .to receive(:new)
         .and_return(contributions_calendar)

--- a/spec/models/contributions_calendar_spec.rb
+++ b/spec/models/contributions_calendar_spec.rb
@@ -6,7 +6,7 @@ describe Wpcc::ContributionsCalendar, type: :model do
       eligible_salary: eligible_salary,
       salary_frequency: salary_frequency,
       periods: periods,
-      salary: salary
+      annual_salary: salary
     )
   end
 


### PR DESCRIPTION
This pr addresses [TP 8605](https://moneyadviceservice.tpondemand.com/restui/board.aspx?acid=ddd7f3a626844ab8d1bee3f06ec28efa#page=board/5624876525867731357&appConfig=eyJhY2lkIjoiREI4ODcwRjkxMDNDRTM2NTlBMzhDNTRBRTVBNUU1N0UifQ==&searchPopup=bug/8605). It addresses a bug whereby an incorrect employer_percent is being used for the calculations of the second and third periods. This bug was only appearing for salaries initially entered as annual; it was not appearing for the other salary_frequencies e.g. monthly, weekly and 4-weekly.

### Tech
__The tool is set up to show the monthly figures by default if the user enters an annual salary.__

The annual salary was being calculated in the Contributions Calendar, using  the __default salary frequency__ rather than the one stored in the session. Hence, why the bug was only occurring for annual salaries. 

The fix is to convert the salary to its annual equivalent using the salary_frequency stored in the session.