### PR TITLE
[DEV APPROVED] TP: 8609, Comment: Corrects typo on salary tooltip

### DIFF
--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -42,7 +42,7 @@ cy:
 
       salary:
         label: Eich cyflog
-        tooltip_html: Rhowch eich cyflog cyn i’r dreth nag unrhyw ddidyniadau eraill gael eu tynnu. Gelwir hyn yn gyflog gros. <a href="/cy/articles/cofrestriad-awtomatig-ar-bensiwn-man-gwaith#cofrestru-awtomatig-pam-fydd-gennych-fwy-nag-un-swydd" target="_blank">Os oes gennych fwy nag un swydd <span class="visually-hidden">(Yn agor mewn ffenestr newydd)</span></a>, bydd raid i chi roi pob cyflog ar wahân.
+        tooltip_html: Rhowch eich cyflog cyn i’r dreth nag unrhyw ddidyniadau eraill gael eu tynnu. Gelwir hyn yn gyflog gros. <a href="/cy/articles/cofrestriad-awtomatig-ar-bensiwn-man-gwaith#cofrestru-awtomatig-pam-fydd-gennych-fwy-nag-un-swydd" target="_blank">Os oes gennych fwy nag un swydd<span class="visually-hidden"> (Yn agor mewn ffenestr newydd)</span></a>, bydd raid i chi roi pob cyflog ar wahân.
         validation: Nodwch eich cyflog
         frequency:
           label: Frequency

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -42,7 +42,7 @@ en:
 
       salary:
         label: Your salary
-        tooltip_html: Enter your salary before tax or other deductions are taken off.  This is known as your gross salary.  <a href="/en/articles/automatic-enrolment-into-a-workplace-pension#automatic-enrolment-when-you-have-more-than-one-job" target="_blank">If you have more than one job <span class="visually-hidden">(opens in a new window)</span></a>, you will have to enter each salary separately.
+        tooltip_html: Enter your salary before tax or other deductions are taken off. This is known as your gross salary. <a href="/en/articles/automatic-enrolment-into-a-workplace-pension#automatic-enrolment-when-you-have-more-than-one-job" target="_blank">If you have more than one job<span class="visually-hidden"> (opens in a new window)</span></a>, you will have to enter each salary separately.
         validation: Please enter your salary
         frequency:
           label: Frequency


### PR DESCRIPTION
TP Ticket: [8609](https://moneyadviceservice.tpondemand.com/RestUI/Board.aspx?acid=6C17D8319C81AC3D36AFAD64CAE08A28#page=userstory/8608&appConfig=eyJhY2lkIjoiREI4ODcwRjkxMDNDRTM2NTlBMzhDNTRBRTVBNUU1N0UifQ==&searchPopup=userstory/8609)

This PR is to correct a typo on the salary tooltip on the first view, specifically a space appearing before the comma after the link: 

![image](https://user-images.githubusercontent.com/6080548/31330335-e09e2dc4-acd5-11e7-9c5c-a5a477ec9784.png)

This has been corrected in the English and Welsh versions:

![image](https://user-images.githubusercontent.com/6080548/31330391-246a0a46-acd6-11e7-9cff-cbf1c0d44d2e.png)

![image](https://user-images.githubusercontent.com/6080548/31330423-498ed482-acd6-11e7-9bf9-7c71ce6337cf.png)

