### PR TITLE
[DEV APPROVED] TP: 8588, Comment: Updates component and tests to exclude tooltip

### DIFF
--- a/app/assets/javascripts/wpcc/components/Email.js
+++ b/app/assets/javascripts/wpcc/components/Email.js
@@ -68,7 +68,7 @@ define(['jquery', 'DoughBaseComponent'], function($, DoughBaseComponent) {
       message +=
         $(resultTable).find('[data-wpcc-period-heading-yours]').text().trim() + ': ' +
         $(resultTable).find('[data-wpcc-employee-contribution]').text().trim() + ' ' +
-        $(resultTable).find('[data-wpcc-tax-relief]').text().trim() + '\n';
+        $(resultTable).find('[data-wpcc-tax-relief-text]').text().trim() + '\n';
       message +=
         $(resultTable).find('[data-wpcc-period-heading-employers]').text().trim() + ': ' +
         $(resultTable).find('[data-wpcc-employer-contribution]').text().trim() + '\n';

--- a/app/views/wpcc/your_results/_contributions_table.html.erb
+++ b/app/views/wpcc/your_results/_contributions_table.html.erb
@@ -11,7 +11,7 @@
         <%= period.formatted_employee_contribution %>
       </p>
       <p class="results__period-parenthesis" data-wpcc-tax-relief data-value="<%= period.tax_relief %>">
-        <span class="results__period-tax-relief">
+        <span data-wpcc-tax-relief-text class="results__period-tax-relief">
           <%= period.formatted_tax_relief %>
         </span>
         <%= render 'wpcc/tooltips/trigger' %>

--- a/spec/javascripts/fixtures/Email.html
+++ b/spec/javascripts/fixtures/Email.html
@@ -21,34 +21,43 @@
           <div>
             <div data-wpcc-results-table>
               <h3 data-wpcc-results-period-title>Now</h3>
-              <p data-wpcc-period-heading-yours>Your contribution</p>
-              <p data-wpcc-employee-contribution data-employee-contribution="">£32.60</p>
-              <p data-wpcc-tax-relief data-tax-relief="">(includes tax relief of £6.52)</p>
-              <p data-wpcc-period-heading-employers>Employer's contribution</p>
-              <p data-wpcc-employer-contribution data-employer-contribution="">£32.60</p>
-              <p data-wpcc-period-heading-total>Total contributions</p>
+              <p data-wpcc-period-heading-yours>Your <span data-wpcc-title-frequency>monthly</span> contribution</p>
+              <p data-wpcc-employee-contribution>£32.60</p>
+              <p data-wpcc-tax-relief>
+                <span data-wpcc-tax-relief-text>(includes tax relief of <span data-wpcc-tax-relief-value>£6.52</span>)</span>
+                <button><span>i</span><span>show help</span></button>
+              </p>
+              <p data-wpcc-period-heading-employers>Employer's <span data-wpcc-title-frequency>monthly</span> contribution</p>
+              <p data-wpcc-employer-contribution>£32.60</p>
+              <p data-wpcc-period-heading-total>Total <span data-wpcc-title-frequency>monthly</span> contributions</p>
               <p data-wpcc-total>£65.20</p>
             </div>
 
             <div data-wpcc-results-table>
               <h3 data-wpcc-results-period-title>April 2018 - March 2019</h3>
-              <p data-wpcc-period-heading-yours>Your contribution</p>
-              <p data-wpcc-employee-contribution data-employee-contribution="">£97.81</p>
-              <p data-wpcc-tax-relief data-tax-relief="">(includes tax relief of £19.56)</p>
-              <p data-wpcc-period-heading-employers>Employer's contribution</p>
-              <p data-wpcc-employer-contribution data-employer-contribution="">£65.21</p>
-              <p data-wpcc-period-heading-total>Total contributions</p>
+              <p data-wpcc-period-heading-yours>Your <span data-wpcc-title-frequency>monthly</span> contribution</p>
+              <p data-wpcc-employee-contribution>£97.81</p>
+              <p data-wpcc-tax-relief>
+                <span data-wpcc-tax-relief-text>(includes tax relief of <span data-wpcc-tax-relief-value>£19.56</span>)</span>
+                <button><span>i</span><span>show help</span></button>
+              </p>
+              <p data-wpcc-period-heading-employers>Employer's <span data-wpcc-title-frequency>monthly</span> contribution</p>
+              <p data-wpcc-employer-contribution>£65.21</p>
+              <p data-wpcc-period-heading-total>Total <span data-wpcc-title-frequency>monthly</span> contributions</p>
               <p data-wpcc-total>£163.02</p>
             </div>
 
             <div data-wpcc-results-table>
               <h3 data-wpcc-results-period-title>April 2019 onwards</h3>
-              <p data-wpcc-period-heading-yours>Your contribution</p>
-              <p data-wpcc-employee-contribution data-employee-contribution="">£163.02</p>
-              <p data-wpcc-tax-relief data-tax-relief="">(includes tax relief of £32.60)</p>
-              <p data-wpcc-period-heading-employers>Employer's contribution</p>
-              <p data-wpcc-employer-contribution data-employer-contribution="">£97.81</p>
-              <p data-wpcc-period-heading-total>Total contributions</p>
+              <p data-wpcc-period-heading-yours>Your <span data-wpcc-title-frequency>monthly</span> contribution</p>
+              <p data-wpcc-employee-contribution>£163.02</p>
+              <p data-wpcc-tax-relief>
+                <span data-wpcc-tax-relief-text>(includes tax relief of <span data-wpcc-tax-relief-value>£32.60</span>)</span>
+                <button><span>i</span><span>show help</span></button>
+              </p>
+              <p data-wpcc-period-heading-employers>Employer's <span data-wpcc-title-frequency>monthly</span> contribution</p>
+              <p data-wpcc-employer-contribution>£97.81</p>
+              <p data-wpcc-period-heading-total>Total <span data-wpcc-title-frequency>monthly</span> contributions</p>
               <p data-wpcc-total>£260.83</p>
             </div>
           </div>

--- a/spec/javascripts/tests/Email_spec.js
+++ b/spec/javascripts/tests/Email_spec.js
@@ -35,17 +35,17 @@ describe('Email', function() {
       message += '3. Your Results\n';
       message += 'Qualifying earnings: £39,124\n\n';
       message += 'Now\n';
-      message += 'Your contribution: £32.60 (includes tax relief of £6.52)\n';
-      message += 'Employer\'s contribution: £32.60\n';
-      message += 'Total contributions: £65.20\n\n';
+      message += 'Your monthly contribution: £32.60 (includes tax relief of £6.52)\n';
+      message += 'Employer\'s monthly contribution: £32.60\n';
+      message += 'Total monthly contributions: £65.20\n\n';
       message += 'April 2018 - March 2019\n';
-      message += 'Your contribution: £97.81 (includes tax relief of £19.56)\n';
-      message += 'Employer\'s contribution: £65.21\n';
-      message += 'Total contributions: £163.02\n\n';
+      message += 'Your monthly contribution: £97.81 (includes tax relief of £19.56)\n';
+      message += 'Employer\'s monthly contribution: £65.21\n';
+      message += 'Total monthly contributions: £163.02\n\n';
       message += 'April 2019 onwards\n';
-      message += 'Your contribution: £163.02 (includes tax relief of £32.60)\n';
-      message += 'Employer\'s contribution: £97.81\n';
-      message += 'Total contributions: £260.83';
+      message += 'Your monthly contribution: £163.02 (includes tax relief of £32.60)\n';
+      message += 'Employer\'s monthly contribution: £97.81\n';
+      message += 'Total monthly contributions: £260.83';
 
       var href = 'mailto:?body=' + encodeURIComponent(message);
 


### PR DESCRIPTION
TP ticket: [TP8588](https://moneyadviceservice.tpondemand.com/RestUI/Board.aspx#page=userstory/8611&appConfig=eyJhY2lkIjoiREI4ODcwRjkxMDNDRTM2NTlBMzhDNTRBRTVBNUU1N0UifQ==&searchPopup=bug/8588)

Adding the tooltip to the tax relief line in the results table has caused an error, meaning the tooltip trigger is included in the text that the user might send by email. 

This PR excludes that text when the email text is constructed, and updates the Karma tests to reflect this change.

**Before:**

![screen shot 2017-10-16 at 12 13 34](https://user-images.githubusercontent.com/6080548/31609321-8fa2f0f8-b26b-11e7-8337-c2710b819ffc.png)

**After:**

![screen shot 2017-10-16 at 12 13 57](https://user-images.githubusercontent.com/6080548/31609327-957566fa-b26b-11e7-9c2f-e8d868dca16f.png)
