### PR TITLE
[DEV APPROVED] TP8610, Adds tootips to Views 2 and 3

### DIFF
--- a/app/assets/stylesheets/wpcc/components/_popup-tip.scss
+++ b/app/assets/stylesheets/wpcc/components/_popup-tip.scss
@@ -1,6 +1,16 @@
 .popup-tip__content {
-  @include respond-to($mq-m) {
-    padding: $baseline-unit;
+  .js & {
+    @include respond-to($mq-m) {
+      padding: $baseline-unit;
+    }
+  }
+}
+
+.popup-tip__title--no-js {
+  display: inline;
+
+  .js & {
+    display: none;
   }
 }
 

--- a/app/assets/stylesheets/wpcc/section/_contributions.scss
+++ b/app/assets/stylesheets/wpcc/section/_contributions.scss
@@ -6,10 +6,15 @@
   @include column(12);
   @extend %clearfix;
   clear: both;
+  position: relative;
 
   @include respond-to($mq-l) {
     @include column(8);
   }
+}
+
+.contributions__helper {
+  top: 0;
 }
 
 .contributions__source {

--- a/app/assets/stylesheets/wpcc/section/_details.scss
+++ b/app/assets/stylesheets/wpcc/section/_details.scss
@@ -7,7 +7,7 @@
     @include column(8);
     margin: 0;
   }
-  
+
   .form__label-heading {
     display: inline;
   }
@@ -46,10 +46,10 @@
 
 .details__helper {
   @include column(12);
-  
+
   @include respond-to($mq-m) {
     @include column(8);
-    
+
     .js & {
       margin-top: $baseline-unit*6;
     }
@@ -58,14 +58,6 @@
 
 .details__helper--block {
   @include column(12);
-}
-
-.details__helper-title--no-js {
-  display: inline;
-
-  .js & {
-    display: none;
-  }
 }
 
 .details__salary {
@@ -98,7 +90,7 @@
 .details__calculate-item {
   @include column(12);
   position: relative;
-  
+
   @include respond-to($mq-m) {
     @include column(6);
   }
@@ -125,5 +117,5 @@
   background-color: $color-white;
   padding: $baseline-unit*6 $baseline-unit*2 $baseline-unit*2;
   display: block;
-  text-align: center;  
+  text-align: center;
 }

--- a/app/assets/stylesheets/wpcc/section/_results.scss
+++ b/app/assets/stylesheets/wpcc/section/_results.scss
@@ -1,3 +1,7 @@
+.results__content {
+  position: relative;
+}
+
 .results__row {
   @include row(12);
 }
@@ -38,6 +42,8 @@
 }
 
 .results__helper {
+  top: 0;
+
   .no-js & {
     font-size: 0.875rem;
     padding: 0;

--- a/app/presenters/wpcc/earnings_description.rb
+++ b/app/presenters/wpcc/earnings_description.rb
@@ -4,13 +4,14 @@ module Wpcc
       formatted_currency(object.eligible_salary, precision: 0)
     end
 
-    def earnings_description
+    def earnings_description(opts = {})
       contribution_preference = session[:contribution_preference]
       description_key = earnings_description_key
 
       t(
-        "wpcc.#{description_key}.description_#{contribution_preference}",
-        eligible_salary: formatted_eligible_salary
+        "wpcc.#{description_key}.description_#{contribution_preference}_html",
+        eligible_salary: formatted_eligible_salary,
+        tooltip_html: opts[:tooltip_html]
       )
     end
 

--- a/app/presenters/wpcc/message_presenter.rb
+++ b/app/presenters/wpcc/message_presenter.rb
@@ -28,6 +28,10 @@ module Wpcc
       ].join(', ')
     end
 
+    def minimum_contribution?
+      session[:contribution_preference] == 'minimum'
+    end
+
     def show_above_max_contribution?
       above_max_contribution?
     end

--- a/app/views/layouts/wpcc/engine.html.erb
+++ b/app/views/layouts/wpcc/engine.html.erb
@@ -24,7 +24,7 @@
               "detailsHeading": "<%= t('wpcc.details.title') %>",
               "contributionsHeading": "<%= t('wpcc.contributions.title') %>",
               "resultsHeading": "<%= t('wpcc.results.title') %>",
-              "qualifyingEarningsHeading": "<%= t('wpcc.details.calculate.qualifying_earnings_title') %>"
+              "qualifyingEarningsHeading": "<%= t('wpcc.tooltip_qualifying_earnings.title') %>"
             }
           }'
         >

--- a/app/views/wpcc/tooltips/_content_qualifying_earnings.html.erb
+++ b/app/views/wpcc/tooltips/_content_qualifying_earnings.html.erb
@@ -1,0 +1,13 @@
+<div data-dough-popup-container class="popup-tip__container <%= classname %>">
+  <p data-dough-popup-content class="popup-tip__content">
+    <span class="popup-tip__title--no-js">
+      <%= t('wpcc.tooltip_qualifying_earnings.title') %>:
+    </span>
+    <%= t(
+      'wpcc.tooltip_qualifying_earnings.text',
+      formatted_upper_earnings: formatted_upper_earnings,
+      formatted_lower_earnings: formatted_lower_earnings
+      ) %>
+  </p>
+  <%= render 'wpcc/tooltips/close' %>
+</div>

--- a/app/views/wpcc/tooltips/_trigger.html.erb
+++ b/app/views/wpcc/tooltips/_trigger.html.erb
@@ -1,4 +1,10 @@
-<button type="button" class="popup-tip__button" data-dough-popup-trigger>
+<% if local_assigns[:locals] %>
+  <% popup_type = locals.fetch(:popup_type, '') %>
+<% end %>
+
+<button type="button"
+        class= "popup-tip__button <%= popup_type %>"
+        data-dough-popup-trigger>
   <span aria-hidden="true">i</span>
   <span class="visually-hidden"><%= t('wpcc.tooltip_show') %></span>
 </button>

--- a/app/views/wpcc/your_contributions/new.html.erb
+++ b/app/views/wpcc/your_contributions/new.html.erb
@@ -2,11 +2,22 @@
 
 <section class="contributions">
   <h2 class="wpcc__heading">2. <%= t('wpcc.contributions.title') %></h2>
-  <div class="contributions__row">
+  <div class="contributions__row" data-dough-component="PopupTip">
     <p class="t-contributions_description">
-      <%= @your_contribution.earnings_description %>
+      <% if @message_presenter.minimum_contribution? %>
+        <% tooltip_html = render('wpcc/tooltips/trigger', locals: { popup_type: 't-qualifying-earnings' }) %>
+        <%= @your_contribution.earnings_description({ tooltip_html: raw(tooltip_html) }) %>
+      <% else %>
+        <%= @your_contribution.earnings_description %>
+      <% end %>
     </p>
+    <%= render 'wpcc/tooltips/content_qualifying_earnings',
+      formatted_upper_earnings: @message_presenter.formatted_upper_earnings,
+      formatted_lower_earnings: @message_presenter.formatted_lower_earnings,
+      classname: 'contributions__helper'
+    %>
   </div>
+
   <%= form_for(
     @your_contributions_form,
     url: your_contributions_path,

--- a/app/views/wpcc/your_details/new.html.erb
+++ b/app/views/wpcc/your_details/new.html.erb
@@ -128,19 +128,11 @@
               <%= render 'wpcc/tooltips/trigger' %>
               <%= t('wpcc.details.calculate.details_html_2') %>
             </p>
-            <div data-dough-popup-container class="popup-tip__container details__helper details__helper--block">
-              <p data-dough-popup-content class="popup-tip__content">
-                <span class="details__helper-title--no-js">
-                  <%= t('wpcc.details.calculate.qualifying_earnings_title') %>:
-                </span>
-                <%= t(
-                  'wpcc.details.calculate.qualifying_earnings',
-                  formatted_upper_earnings: @your_details_form.formatted_upper_earnings,
-                  formatted_lower_earnings: @your_details_form.formatted_lower_earnings
-                  ) %>
-              </p>
-              <%= render 'wpcc/tooltips/close' %>
-            </div>
+            <%= render 'wpcc/tooltips/content_qualifying_earnings',
+              formatted_upper_earnings: @your_details_form.formatted_upper_earnings,
+              formatted_lower_earnings: @your_details_form.formatted_lower_earnings,
+              classname: 'details__helper details__helper--block'
+            %>
             <div class="details__callouts">
               <div class="form__row details__callout <%= @your_details_form.activate_disabled_callout %>" data-wpcc-callout-lt5876-min-contribution>
                 <div class="callout">

--- a/app/views/wpcc/your_results/index.html.erb
+++ b/app/views/wpcc/your_results/index.html.erb
@@ -1,15 +1,26 @@
 <%= render 'wpcc/shared/your_details' %>
 <%= render 'wpcc/shared/your_contributions', message_presenter: message_presenter %>
-
 <section class="section section--results">
   <h2 class="section__heading results__heading">3. <%= t('wpcc.results.title') %></h2>
 
   <div class="results__content" data-dough-component="UpdateResults">
-    <p>
-      <%= t('wpcc.results.description_html') %>
-      <%= your_results_presenter.earnings_description.html_safe %>
-      <%= period_filter_presenter.contribution_percents_explanation %>
-    </p>
+    <div data-dough-component="PopupTip">
+      <p>
+        <%= t('wpcc.results.description_html') %>
+        <% if message_presenter.minimum_contribution? %>
+          <% tooltip_html = render('wpcc/tooltips/trigger', locals: { popup_type: 't-qualifying-earnings' }) %>
+          <%= your_results_presenter.earnings_description({ tooltip_html: raw(tooltip_html) }) %>
+        <% else %>
+          <%= your_results_presenter.earnings_description.html_safe %>
+        <% end %>
+        <%= period_filter_presenter.contribution_percents_explanation %>
+      </p>
+      <%= render 'wpcc/tooltips/content_qualifying_earnings',
+        formatted_upper_earnings: message_presenter.formatted_upper_earnings,
+        formatted_lower_earnings: message_presenter.formatted_lower_earnings,
+        classname: 'results__helper'
+      %>
+    </div>
 
     <% if message_presenter.tax_relief_warning? %>
       <div class="callout">

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -19,6 +19,9 @@ cy:
       canonical_url: https://www.moneyadviceservice.org.uk/cy/tools/cyfrifiannell-cyfraniadau-pensiwn-gweithle
     tooltip_show: sioe help
     tooltip_hide: cuddio cymorth
+    tooltip_qualifying_earnings:
+      title: Enillion cymhwyso
+      text: Dyma’r rhan o’ch cyflog blynyddol fydd yn cael ei defnyddio i gyfrifo eich cyfraniad pensiwn dan gofrestru awtomatig. Sef eich enillion cyn treth (hyd at derfyn uchafswm o %{formatted_upper_earnings} y flwyddyn) - tynnu’r trothwy enillion isaf o %{formatted_lower_earnings}.
 
     launch_warning_title: Mae’r offeryn hwn yn un Beta
     launch_warning_content: sy’n golygu ein bod yn profi a gwella’r gyfrifiannell. Os oes gennych chi unrhyw adborth
@@ -63,10 +66,8 @@ cy:
 
       calculate:
         legend: Dewiswch sut mae eich cyflogwr yn cyfrannu
-        qualifying_earnings_title: Enillion cymhwyso
         details_html_1: Gall eich cyflogwr ddewis os yw am wneud cyfraniadau ar ran o'ch cyflog (a elwir yn enillion cymhwyso
         details_html_2: ) neu ar eich cyflog llawn. I gael gwybod pa un, bydd angen i chi wirio gyda’ch cyflogwr.
-        qualifying_earnings: Dyma’r rhan o’ch cyflog blynyddol fydd yn cael ei defnyddio i gyfrifo eich cyfraniad pensiwn dan gofrestru awtomatig. Sef eich enillion cyn treth (hyd at derfyn uchafswm o %{formatted_upper_earnings} y flwyddyn) - tynnu’r trothwy enillion isaf o %{formatted_lower_earnings}.
 
       next: Nesaf
       prompt: os gwelwch yn dda dewiswch
@@ -91,8 +92,8 @@ cy:
 
     contributions:
       title: Eich cyfraniadaulower
-      description_minimum: Gwneir cyfraniadau ar eich enillion cymwys o %{eligible_salary} y flwyddyn.
-      description_full: Gwneir cyfraniadau ar eich cyflog o %{eligible_salary} y flwyddyn.
+      description_minimum_html: Gwneir cyfraniadau ar eich enillion cymwys o %{eligible_salary} y flwyddyn.
+      description_full_html: Gwneir cyfraniadau ar eich cyflog o %{eligible_salary} y flwyddyn.
       your_contribution_title: Nodwch eich cyfraniad
       your_contribution_tip: Yr isafswm cyfreithiol yw 1%
       your_contribution_tip_lt5876: Ar eich lefel cyflog, nid oes isafswm cyfreithiol o gyfraniad ond efallai y bydd eich cynllun pensiwn gweithlu wedi gosod isafswm. Holwch eich cyflogwr.
@@ -117,10 +118,10 @@ cy:
       description_html: |
         Bydd cyfraddau cyfraniadau pensiwn isaf yn cynyddu yn Ebrill 2018 ac eto yn Ebrill 2019.
         Bydd y ffigyrau hyn yn dangos sut y bydd hyn yn effeithio ar eich cyfraniadau.
-      description_full:
+      description_full_html:
         Bydd cyfraniadau yn seiliedig ar eich cyflog o <span data-wpcc-eligible-salary>%{eligible_salary}</span> y flwyddyn.
-      description_minimum:
-        Bydd cyfraniadau yn seiliedig ar eich enillion cymwys o <span data-wpcc-eligible-salary>%{eligible_salary}</span> y flwyddyn.
+      description_minimum_html:
+        Bydd cyfraniadau yn seiliedig ar eich enillion cymwys%{tooltip_html} o <span data-wpcc-eligible-salary>%{eligible_salary}</span> y flwyddyn.
       large_contribution_percent_for_two_periods:
         Rydych chi a'ch cyflogwr eisoes yn talu mwy na'r isafswm newydd, felly rydym wedi dangos y cyfraniadau cyfredol yn unig. Ni fydd y rhain yn newid oni bai bod eich cyflog yn cynyddu neu rydych chi ac/neu eich cyflogwr yn dewis talu mwy.
       large_contribution_percent_for_middle_period:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -19,6 +19,9 @@ en:
       canonical_url: https://www.moneyadviceservice.org.uk/en/tools/workplace-pension-contribution-calculator
     tooltip_show: show help
     tooltip_hide: hide help
+    tooltip_qualifying_earnings:
+      title: Qualifying earnings
+      text: This is the part of your annual pay that will be used to calculate your pension contribution under automatic enrolment. It is your earnings before tax (up to a maximum limit of %{formatted_upper_earnings} per year) – less the lower earnings threshold of %{formatted_lower_earnings}.
 
     launch_warning_title: This tool is in Beta
     launch_warning_content: That means we are testing and improving the calculator. If you have any feedback
@@ -63,10 +66,8 @@ en:
 
       calculate:
         legend: Choose how your employer makes contributions
-        qualifying_earnings_title: Qualifying earnings
         details_html_1: Your employer can choose whether to make contributions on part of your salary (known as your qualifying earnings
         details_html_2: ) or on your full salary. To find this out, you will need to check with your employer.
-        qualifying_earnings: This is the part of your annual pay that will be used to calculate your pension contribution under automatic enrolment. It is your earnings before tax (up to a maximum limit of %{formatted_upper_earnings} per year) – less the lower earnings threshold of %{formatted_lower_earnings}.
 
       next: Next
       prompt: Please choose
@@ -91,8 +92,8 @@ en:
 
     contributions:
       title: Your contributions
-      description_minimum:  Contributions will be made on your qualifying earnings of %{eligible_salary} per year.
-      description_full:  Contributions will be made on your salary of %{eligible_salary} per year.
+      description_minimum_html:  Contributions will be made on your qualifying earnings%{tooltip_html} of %{eligible_salary} per year.
+      description_full_html:  Contributions will be made on your salary of %{eligible_salary} per year.
       your_contribution_title: Enter your contribution
       your_contribution_tip: The legal minimum is 1%
       your_contribution_tip_lt5876: At your salary level there is no legal minimum contribution but your workplace pension scheme may have a set minimum. Check with your employer.
@@ -117,10 +118,10 @@ en:
       description_html: |
         Minimum pension contribution rates will increase in April 2018 and again in April 2019.
         These figures show how this will affect your contributions.
-      description_full:
+      description_full_html:
         Contributions will be based on your salary of <span data-wpcc-eligible-salary>%{eligible_salary}</span> per year.
-      description_minimum:
-        Contributions will be based on your qualifying earnings of <span data-wpcc-eligible-salary>%{eligible_salary}</span> per year.
+      description_minimum_html:
+        Contributions will be based on your qualifying earnings%{tooltip_html} of <span data-wpcc-eligible-salary>%{eligible_salary}</span> per year.
       large_contribution_percent_for_two_periods:
         "Both you and your employer are already paying above the new minimums so we have just shown the current contributions. These won't change unless your salary increases or you and/or your employer choose to pay more."
       large_contribution_percent_for_middle_period:

--- a/features/_your_results/conditional_qualifying_earnings_message.feature
+++ b/features/_your_results/conditional_qualifying_earnings_message.feature
@@ -15,12 +15,12 @@ Feature: Additional message depending on your contribution preference
 
       Examples:
         | message |
-        | Contributions will be based on your qualifying earnings of £29,124 per year |
+        | Contributions will be based on your qualifying earnings i show help of £29,124 per year |
 
       @welsh
       Examples:
         | message |
-        | Bydd cyfraniadau yn seiliedig ar eich enillion cymwys o £29,124 y flwyddyn. |
+        | Bydd cyfraniadau yn seiliedig ar eich enillion cymwys i sioe help o £29,124 y flwyddyn. |
 
     Scenario Outline: When is Full Contribution
       Given I choose my contribution preference as "Full"

--- a/features/qualifying_earnings_tooltip.feature
+++ b/features/qualifying_earnings_tooltip.feature
@@ -1,0 +1,30 @@
+Feature: Qualifying earnings tooltip
+  As a user of the WPCC Tool
+  In order to gain a clear understanding of financial jargons
+  I want to be able to read further information through tooltips
+
+  Background:
+    Given I am on the Your Details step
+    When I fill in my details
+
+  Scenario: Show qualifying earnings tooltip on your contribution page
+    And I choose to make minimum contributions
+    And I click the Next button
+    Then I should see a tooltip next to the qualifying earnings text
+
+  Scenario: Hide qualifying earnings tooltip on your contribution page
+    And I choose to make full contributions
+    And I click the Next button
+    Then I should not see a tooltip next to the qualifying earnings text
+
+  Scenario: Show qualifying earnings tooltip on your results page
+    And I choose to make minimum contributions
+    And I move to your contribution step
+    And I press next and move to your result step
+    Then I should see a tooltip next to the qualifying earnings text
+
+  Scenario: Hide qualifying earnings tooltip on your results page
+    And I choose to make full contributions
+    And I move to your contribution step
+    And I press next and move to your result step
+    Then I should not see a tooltip next to the qualifying earnings text

--- a/features/step_definitions/qualifying_earnings_tooltip_steps.rb
+++ b/features/step_definitions/qualifying_earnings_tooltip_steps.rb
@@ -1,0 +1,7 @@
+Then(/^I should( not| NOT)? see a tooltip next to the qualifying earnings text$/) do |should_not|
+  if should_not
+    expect(page).not_to have_css('button.t-qualifying-earnings')
+  else
+    expect(page).to have_css('button.t-qualifying-earnings')
+  end
+end

--- a/features/step_definitions/your_details_steps.rb
+++ b/features/step_definitions/your_details_steps.rb
@@ -130,6 +130,10 @@ When(/^I proceed to the next step$/) do
   step 'I submit my details'
 end
 
+When(/^I move to your contribution step$/) do
+  step 'I submit my details'
+end
+
 When(/^I press next and move to your contributions step$/) do
   step 'I submit my details'
 end

--- a/lib/wpcc/version.rb
+++ b/lib/wpcc/version.rb
@@ -2,7 +2,7 @@ module Wpcc
   module Version
     MAJOR = 1
     MINOR = 11
-    PATCH = 8
+    PATCH = 9
 
     STRING = [MAJOR, MINOR, PATCH].join('.')
   end

--- a/spec/presenters/message_presenter_spec.rb
+++ b/spec/presenters/message_presenter_spec.rb
@@ -14,6 +14,28 @@ RSpec.describe Wpcc::MessagePresenter do
   let(:salary_below_tax_relief_threshold?) { true }
   let(:salary_below_pension_limit?) { true }
 
+  describe '#minimum_contribution?' do
+    before do
+      allow(context).to receive(:session).and_return(session)
+    end
+
+    context 'select part salary' do
+      let(:session) { { contribution_preference: 'minimum' } }
+
+      it 'returns true' do
+        expect(subject.minimum_contribution?).to be_truthy
+      end
+    end
+
+    context 'select full salary' do
+      let(:session) { { contribution_preference: 'full' } }
+
+      it 'returns false' do
+        expect(subject.minimum_contribution?).to be_falsey
+      end
+    end
+  end
+
   describe '#manually_opt_in_message?' do
     context 'when the text is manually_opt_in' do
       let(:text) { :manually_opt_in }


### PR DESCRIPTION
TP ticket: [TP8610](https://moneyadviceservice.tpondemand.com/RestUI/Board.aspx#page=userstory/8609&appConfig=eyJhY2lkIjoiREI4ODcwRjkxMDNDRTM2NTlBMzhDNTRBRTVBNUU1N0UifQ==&searchPopup=userstory/8610)

This work is to add a tooltip describing the concept of qualifying earnings to the relevant message in Steps 2 and 3 of the tool, as already exists in Step 1.

**Step 1:**
![image](https://user-images.githubusercontent.com/6080548/31759149-596e6d98-b4a8-11e7-9d37-54676d15ac76.png)

**Step 2 current: **
![image](https://user-images.githubusercontent.com/6080548/31759281-d18b6f38-b4a8-11e7-98e6-562a423d4eb4.png)

**Step 2 update: **
![image](https://user-images.githubusercontent.com/6080548/31759266-c06257b2-b4a8-11e7-8b21-eb4b69d26e8b.png)

**Step 3 current: **
![image](https://user-images.githubusercontent.com/6080548/31759448-5c3f9cc6-b4a9-11e7-84d9-77719a5836da.png)

**Step 3 update: **
![image](https://user-images.githubusercontent.com/6080548/31759486-76531340-b4a9-11e7-9ced-bdff9eea2ab9.png)

This involved a combination of back and front end work to implement an elegant solution because the tooltip trigger is rendered via a partial and the text message is rendered via a presenter which complicated an otherwise seemingly straightforward task. 