### PR TITLE
[DEV APPROVED] - Ally fixes

### DIFF
--- a/app/assets/stylesheets/wpcc/section/_details.scss
+++ b/app/assets/stylesheets/wpcc/section/_details.scss
@@ -75,12 +75,6 @@
   }
 }
 
-.details__salary-frequency {
-  .form__label-heading {
-    visibility: hidden;
-  }
-}
-
 .details__calculate-heading,
 .details__calculate-intro {
   @include column(12);

--- a/app/views/layouts/wpcc/engine.html.erb
+++ b/app/views/layouts/wpcc/engine.html.erb
@@ -1,5 +1,4 @@
-<% set_meta_tags title:       t("wpcc.meta.title"),
-                 description: t("wpcc.meta.description"),
+<% set_meta_tags description: t("wpcc.meta.description"),
                  canonical:   t("wpcc.meta.canonical_url") %>
 
 <% content_for(:head) do %>

--- a/app/views/wpcc/shared/_your_contributions.html.erb
+++ b/app/views/wpcc/shared/_your_contributions.html.erb
@@ -4,7 +4,12 @@
       <%= t('wpcc.results.contribution_changes.you') %>: <%= session[:employee_percent] %>%, <%= t('wpcc.results.contribution_changes.employer') %>: <%= session[:employer_percent] %>%
     </span>
     <span>
-      <%= link_to(t('wpcc.edit'), new_your_contribution_path, class: 'section__heading-edit') %>
+      <%= link_to(new_your_contribution_path, class: 'section__heading-edit') do %>
+        <%= t('wpcc.edit') %>
+        <span class="visually-hidden">
+          <%= t('wpcc.contributions.title') %>
+        </span>
+      <% end %>
     </span>
   </h2>
   <% if message_presenter.show_above_max_contribution? %>

--- a/app/views/wpcc/shared/_your_details.html.erb
+++ b/app/views/wpcc/shared/_your_details.html.erb
@@ -2,7 +2,12 @@
   <h2 class="section__heading details__heading">1. <%= t('wpcc.details.title') %>
     <span class="section__heading-summary" data-wpcc-details-heading-summary><%= message_presenter.your_details_summary(session) %></span>
     <span>
-      <%= link_to(t('wpcc.edit'), new_your_detail_path, class: 'section__heading-edit') %>
+      <%= link_to(new_your_detail_path, class: 'section__heading-edit') do %>
+        <%= t('wpcc.edit') %>
+        <span class="visually-hidden">
+          <%= t('wpcc.details.title') %>
+        </span>
+      <% end %>
     </span>
   </h2>
   <% if message_presenter.manually_opt_in_message? %>

--- a/app/views/wpcc/your_contributions/new.html.erb
+++ b/app/views/wpcc/your_contributions/new.html.erb
@@ -1,4 +1,5 @@
-<% set_meta_tags title: t("wpcc.contributions.title") + ' | ' + t("wpcc.meta.title") %>
+<% set_meta_tags title: [t("wpcc.meta.title"), t("wpcc.contributions.title")], 
+                 reverse: true %>
 
 <%= render 'wpcc/shared/your_details', message_presenter: @message_presenter %>
 

--- a/app/views/wpcc/your_contributions/new.html.erb
+++ b/app/views/wpcc/your_contributions/new.html.erb
@@ -29,7 +29,11 @@
     <div data-dough-component="SalaryConditions ContributionConditions">
       <div class="contributions__row">
         <div class="contributions__source contributions__source--employee form__row">
-          <h3 class="contributions__source-title"><%= t('wpcc.contributions.your_contribution_title') %></h3>
+          <h3 class="contributions__source-title">
+            <label for="your_contributions_form_employee_percent">
+              <%= t('wpcc.contributions.your_contribution_title') %>
+            </label>
+          </h3>
           <p><%= @message_presenter.employee_contribution_tip %></p>
           <%= f.number_field :employee_percent,
             class: "contributions__source-input",
@@ -47,7 +51,11 @@
           </span>
         </div>
         <div class="contributions__source contributions__source--employer form__row">
-          <h3 class="contributions__source-title"><%= t('wpcc.contributions.employer_contribution_title') %></h3>
+          <h3 class="contributions__source-title">
+            <label for="your_contributions_form_employer_percent">
+              <%= t('wpcc.contributions.employer_contribution_title') %>
+            </label>
+          </h3>
           <p><%=  @message_presenter.employer_contribution_tip %></p>
           <%= f.number_field :employer_percent,
             class: "contributions__source-input",

--- a/app/views/wpcc/your_contributions/new.html.erb
+++ b/app/views/wpcc/your_contributions/new.html.erb
@@ -1,3 +1,5 @@
+<% set_meta_tags title: t("wpcc.contributions.title") + ' | ' + t("wpcc.meta.title") %>
+
 <%= render 'wpcc/shared/your_details', message_presenter: @message_presenter %>
 
 <section class="contributions">

--- a/app/views/wpcc/your_details/new.html.erb
+++ b/app/views/wpcc/your_details/new.html.erb
@@ -1,3 +1,5 @@
+<% set_meta_tags title: t("wpcc.details.title") + ' | ' + t("wpcc.meta.title") %>
+
 <section class="section section--details details" data-dough-component="ConditionalMessaging">
   <%= form_for(
     @your_details_form,

--- a/app/views/wpcc/your_details/new.html.erb
+++ b/app/views/wpcc/your_details/new.html.erb
@@ -1,4 +1,5 @@
-<% set_meta_tags title: t("wpcc.details.title") + ' | ' + t("wpcc.meta.title") %>
+<% set_meta_tags title: [t("wpcc.meta.title"), t("wpcc.details.title")], 
+                 reverse: true %>
 
 <section class="section section--details details" data-dough-component="ConditionalMessaging">
   <%= form_for(

--- a/app/views/wpcc/your_details/new.html.erb
+++ b/app/views/wpcc/your_details/new.html.erb
@@ -98,7 +98,7 @@
                 </div>
                 <div class="details__salary-frequency">
                   <%= f.label :salary_frequency, t('wpcc.details.salary.frequency.label'), class: 'form__label-heading details__field-label visually-hidden' %>
-                <%= f.select(:salary_frequency, options_for_select(@your_details_form.salary_frequency_options, @your_details_form.salary_frequency), {}, {'data-wpcc-frequency-select': true}) %>
+                  <%= f.select(:salary_frequency, options_for_select(@your_details_form.salary_frequency_options, @your_details_form.salary_frequency), {}, {'data-wpcc-frequency-select': true}) %>
                 </div>
               </div>
             <% end %>

--- a/app/views/wpcc/your_results/_frequency_selector_form.html.erb
+++ b/app/views/wpcc/your_results/_frequency_selector_form.html.erb
@@ -1,6 +1,6 @@
 <div class="results__salary-frequency">
   <%= form_tag(your_results_path, method: :get) do %>
-    <%= label :salary_frequency, t('wpcc.results.edit_frequency.label'), class: 'form__label-heading results__salary-label' %>
+    <%= label :salary_frequency, t('wpcc.results.edit_frequency.label'), for: 'salary_frequency',class: 'form__label-heading results__salary-label' %>
     <%= select_tag(
       :salary_frequency,
       options_for_select(

--- a/app/views/wpcc/your_results/index.html.erb
+++ b/app/views/wpcc/your_results/index.html.erb
@@ -1,3 +1,5 @@
+<% set_meta_tags title: t("wpcc.results.title") + ' | ' + t("wpcc.meta.title") %>
+
 <%= render 'wpcc/shared/your_details' %>
 <%= render 'wpcc/shared/your_contributions', message_presenter: message_presenter %>
 <section class="section section--results">

--- a/app/views/wpcc/your_results/index.html.erb
+++ b/app/views/wpcc/your_results/index.html.erb
@@ -1,4 +1,5 @@
-<% set_meta_tags title: t("wpcc.results.title") + ' | ' + t("wpcc.meta.title") %>
+<% set_meta_tags title: [t("wpcc.meta.title"), t("wpcc.results.title")], 
+                 reverse: true %>
 
 <%= render 'wpcc/shared/your_details' %>
 <%= render 'wpcc/shared/your_contributions', message_presenter: message_presenter %>

--- a/lib/wpcc/version.rb
+++ b/lib/wpcc/version.rb
@@ -2,7 +2,7 @@ module Wpcc
   module Version
     MAJOR = 1
     MINOR = 11
-    PATCH = 12
+    PATCH = 13
 
     STRING = [MAJOR, MINOR, PATCH].join('.')
   end


### PR DESCRIPTION
# WPCC Accessibility Fixes

This PR addresses a number of accessibility fixed for WPCC as a result of the testing performed by DAC.

[8686](https://moneyadviceservice.tpondemand.com/entity/8686) 
```
On step 1 of the WPCC tool, the label for salary frequency has the 'visually-hidden' class (which is correct), but also has the class 'details__field-label'.

In the CSS, the .details__field-label {} contains visibility: hidden, making it invisible to screen readers.

Task: Remove 'visibility: hidden;' from the .details__field-label attributes in the CSS.
```

[8687](https://moneyadviceservice.tpondemand.com/entity/8687)
```
Missing contributions labels

There is currently no label for attribute present for the contributions step of the WPCC tool

Suggestion: To avoid adding repeated content, use the header of each section as the label for the input, this will read correctly to screen reader users.
```

[8689](https://moneyadviceservice.tpondemand.com/entity/8689)
```
On step 3 (Results) of the WPCC tool, when a user has completed all other steps, a label-for attribute is incorrect from the contributions frequency select
```
![image](https://user-images.githubusercontent.com/13165846/33023543-6cb52380-ce00-11e7-8ed9-64295f00d029.png)

[8693](https://moneyadviceservice.tpondemand.com/entity/8693)
```
Currently the header for each step contains just the word "Edit".

These links need to be more descriptive for screen reader users, and can remain as they are for users who do not rely on assistive tech, this can be achieved by altering the way that the links are created and include a visually hidden span.
```
![image](https://user-images.githubusercontent.com/13165846/33023596-953f3908-ce00-11e7-9801-542a2d92ee41.png)

[8692](https://moneyadviceservice.tpondemand.com/entity/8692)
```
The page titles throughout the calculator process are non-descriptive and duplicated.

They should reflect the step that the user is on:
- Your details
- Your Contributions
- Your Results
```
