### PR TITLE
Bumps minor version for accessibility updates

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,6 @@
+## 1.11.14:
+* Bumps version for accessibility updates
+
 ## 1.11.13:
 * TP-8686: Adds field label for salary frequency
 * TP-8687: Adds labels to contribution inputs

--- a/lib/wpcc/version.rb
+++ b/lib/wpcc/version.rb
@@ -2,7 +2,7 @@ module Wpcc
   module Version
     MAJOR = 1
     MINOR = 11
-    PATCH = 13
+    PATCH = 14
 
     STRING = [MAJOR, MINOR, PATCH].join('.')
   end


### PR DESCRIPTION
## Bumps minor version of the WPCC tool for accessibility tickets

I missed something in the last deploy and my changes aren't present on the test environment, Im putting this down to versions and tags not being aligned.

This aims to fix this inconsistency