### PR TITLE
[DEV APPROVED] -  Fix bad tests + ensure below limit message shows for non-JS

### DIFF
--- a/app/presenters/wpcc/message_presenter.rb
+++ b/app/presenters/wpcc/message_presenter.rb
@@ -8,6 +8,14 @@ module Wpcc
       t('wpcc.contributions.manually_opt_in')
     end
 
+    def salary_below_pension_limit_message?
+      salary_below_pension_limit?
+    end
+
+    def salary_below_pension_limit_message
+      t('wpcc.details.callout__lt5876')
+    end
+
     def tax_relief_warning?
       salary_below_tax_relief_threshold?
     end

--- a/app/views/wpcc/shared/_your_details.html.erb
+++ b/app/views/wpcc/shared/_your_details.html.erb
@@ -12,4 +12,11 @@
       </div>
     </div>
   <% end %>
+  <% if message_presenter.salary_below_pension_limit_message? %>
+    <div class="contributions__row">
+      <div class="callout">
+        <p><%= message_presenter.salary_below_pension_limit_message %></p>
+      </div>
+    </div>
+  <% end %>
 </section>

--- a/features/manually_opt_in_message.feature
+++ b/features/manually_opt_in_message.feature
@@ -11,6 +11,7 @@ Feature: Conditional messaging for users earning £5876 - £10,000 (inclusive)
   @no-javascript
   Scenario Outline: Viewing my details on step 2 and my salary is below the Manual Opt In limits
     And my salary is "<salary>" "<salary_frequency>" with "Full" contribution
+    And I submit my details
     Then I should see the salary less than the threshold "<message>"
 
     Examples:
@@ -23,14 +24,15 @@ Feature: Conditional messaging for users earning £5876 - £10,000 (inclusive)
     @welsh
     Examples:
       | salary   | salary_frequency | message                                                                                                                                                         |
-      | 5875.99  | y flwyddyn       | Ni fydd eich cyflogwr yn eich cofrestru yn awtomatig am gynllun pensiwn gweithle, ond gallwch ddewis ymuno. Os felly, bydd eich cyflogwr yn gwneud cyfraniadau. |
-      | 489.99   | y mis            | Ni fydd eich cyflogwr yn eich cofrestru yn awtomatig am gynllun pensiwn gweithle, ond gallwch ddewis ymuno. Os felly, bydd eich cyflogwr yn gwneud cyfraniadau. |
-      | 451.99   | fesul 4 wythnos  | Ni fydd eich cyflogwr yn eich cofrestru yn awtomatig am gynllun pensiwn gweithle, ond gallwch ddewis ymuno. Os felly, bydd eich cyflogwr yn gwneud cyfraniadau. |
-      | 121.99   | y wythnos        | Ni fydd eich cyflogwr yn eich cofrestru yn awtomatig am gynllun pensiwn gweithle, ond gallwch ddewis ymuno. Os felly, bydd eich cyflogwr yn gwneud cyfraniadau. |
+      | 5875.99  | y flwyddyn       | Ni fydd eich cyflogwr yn eich cofrestru yn awtomatig am gynllun pensiwn gweithle, ond gallwch ddewis ymuno. Os felly, ni fydd yn ofynnol i'ch cyflogwr wneud cyfraniadau. |
+      | 489.99   | y mis            | Ni fydd eich cyflogwr yn eich cofrestru yn awtomatig am gynllun pensiwn gweithle, ond gallwch ddewis ymuno. Os felly, ni fydd yn ofynnol i'ch cyflogwr wneud cyfraniadau. |
+      | 451.99   | fesul 4 wythnos  | Ni fydd eich cyflogwr yn eich cofrestru yn awtomatig am gynllun pensiwn gweithle, ond gallwch ddewis ymuno. Os felly, ni fydd yn ofynnol i'ch cyflogwr wneud cyfraniadau. |
+      | 112.99   | y wythnos        | Ni fydd eich cyflogwr yn eich cofrestru yn awtomatig am gynllun pensiwn gweithle, ond gallwch ddewis ymuno. Os felly, ni fydd yn ofynnol i'ch cyflogwr wneud cyfraniadau. |
 
   @no-javascript
   Scenario Outline: Viewing my details on step 2 and my salary is between the Manual Opt In limits
     And my salary is "<salary>" "<salary_frequency>" with "Full" contribution
+    And I submit my details
     Then I should see the salary between thresholds "<message>"
 
     Examples:


### PR DESCRIPTION
for non-JS that have a low salary (<£5876) there should be a message telling them that they won't be automatically be enrolled and employers aren't obliged to contribute.
This wasn't appearing.

This PR addresses this and corrects tests that weren't working properly.
Before:
![your_contributions_-_workplace_pension_contribution_calculator_-_money_advice_service](https://user-images.githubusercontent.com/7126705/33326708-8fa6b8ce-d44d-11e7-9914-877547168db1.png)

After:
![wpcc](https://user-images.githubusercontent.com/7126705/33326639-6ad3d8ec-d44d-11e7-8722-eb50396559da.png)
