### PR TITLE
presenter method for popup content options

### DIFF
--- a/app/presenters/wpcc/presenter.rb
+++ b/app/presenters/wpcc/presenter.rb
@@ -43,6 +43,14 @@ module Wpcc
       number_to_currency(currency_value, unit: '£', precision: precision)
     end
 
+    def popup_tip_content_options(text, classname)
+      {
+        text: text,
+        classname: classname,
+        tooltip_hide: t('wpcc.tooltip_hide')
+      }
+    end
+
     private
 
     def text_for(option, value)

--- a/app/presenters/wpcc/your_details_form_presenter.rb
+++ b/app/presenters/wpcc/your_details_form_presenter.rb
@@ -18,14 +18,6 @@ module Wpcc
       end
     end
 
-    def popup_tip_content_options(text)
-      {
-        text: text,
-        classname: 'details__helper',
-        tooltip_hide: t('wpcc.tooltip_hide')
-      }
-    end
-
     private
 
     def disable_minimum_contribution_option?

--- a/app/presenters/wpcc/your_details_form_presenter.rb
+++ b/app/presenters/wpcc/your_details_form_presenter.rb
@@ -18,6 +18,14 @@ module Wpcc
       end
     end
 
+    def popup_tip_content_options(text)
+      {
+        text: text,
+        classname: 'details__helper',
+        tooltip_hide: t('wpcc.tooltip_hide')
+      }
+    end
+
     private
 
     def disable_minimum_contribution_option?

--- a/app/views/wpcc/your_details/new.html.erb
+++ b/app/views/wpcc/your_details/new.html.erb
@@ -35,11 +35,7 @@
             %>
           <% end %>
         </div>
-        <%= popup_tip_content options: {
-          text: t('wpcc.details.age.tooltip'),
-          classname: 'details__helper',
-          tooltip_hide: t('wpcc.tooltip_hide')
-        } %>
+        <%= popup_tip_content options: @your_details_form.popup_tip_content_options(t('wpcc.details.age.tooltip')) %>
       </div>
       <div class="details__row" data-dough-component="PopupTip">
         <div class="details__field">
@@ -60,11 +56,7 @@
             %>
           <% end %>
         </div>
-        <%= popup_tip_content options: {
-          text: t('wpcc.details.gender.tooltip'),
-          classname: 'details__helper',
-          tooltip_hide: t('wpcc.tooltip_hide')
-        } %>
+        <%= popup_tip_content options: @your_details_form.popup_tip_content_options(t('wpcc.details.gender.tooltip')) %>
       </div>
       <div class="details__row">
         <div class="details__callouts">
@@ -124,11 +116,7 @@
               </div>
             </div>
           </div>
-          <%= popup_tip_content options: {
-            text: t('wpcc.details.salary.tooltip_html'),
-            classname: 'details__helper',
-            tooltip_hide: t('wpcc.tooltip_hide')
-          } %>
+          <%= popup_tip_content options: @your_details_form.popup_tip_content_options(t('wpcc.details.salary.tooltip_html')) %>
         </div>
         <div class="details__row--group" data-dough-component="PopupTip">
           <fieldset>

--- a/app/views/wpcc/your_details/new.html.erb
+++ b/app/views/wpcc/your_details/new.html.erb
@@ -35,7 +35,10 @@
             %>
           <% end %>
         </div>
-        <%= popup_tip_content options: @your_details_form.popup_tip_content_options(t('wpcc.details.age.tooltip')) %>
+        <%= popup_tip_content options: @your_details_form.popup_tip_content_options(
+          t('wpcc.details.age.tooltip'),
+          'details__helper'
+        ) %>
       </div>
       <div class="details__row" data-dough-component="PopupTip">
         <div class="details__field">
@@ -56,7 +59,10 @@
             %>
           <% end %>
         </div>
-        <%= popup_tip_content options: @your_details_form.popup_tip_content_options(t('wpcc.details.gender.tooltip')) %>
+        <%= popup_tip_content options: @your_details_form.popup_tip_content_options(
+          t('wpcc.details.gender.tooltip'),
+          'details__helper',
+        ) %>
       </div>
       <div class="details__row">
         <div class="details__callouts">
@@ -116,7 +122,10 @@
               </div>
             </div>
           </div>
-          <%= popup_tip_content options: @your_details_form.popup_tip_content_options(t('wpcc.details.salary.tooltip_html')) %>
+          <%= popup_tip_content options: @your_details_form.popup_tip_content_options(
+            t('wpcc.details.salary.tooltip_html'),
+            'details__helper'
+          ) %>
         </div>
         <div class="details__row--group" data-dough-component="PopupTip">
           <fieldset>

--- a/app/views/wpcc/your_results/_contributions_table.html.erb
+++ b/app/views/wpcc/your_results/_contributions_table.html.erb
@@ -18,11 +18,10 @@
           text: t('wpcc.tooltip_show')
         } %>
       </p>
-      <%= popup_tip_content options: {
-        text: t('wpcc.results.tax_relief_tooltip_html'),
-        classname: 'results__helper',
-        tooltip_hide: t('wpcc.tooltip_hide')
-      } %>
+      <%= popup_tip_content options: period.popup_tip_content_options(
+        t('wpcc.results.tax_relief_tooltip_html'),
+        'results__helper',
+      ) %>
       <p class="results__period-heading" data-wpcc-period-heading-employers>
         <%= period.employer_frequency_heading(salary_frequency).html_safe %>
       </p>

--- a/spec/presenters/presenter_spec.rb
+++ b/spec/presenters/presenter_spec.rb
@@ -51,4 +51,14 @@ RSpec.describe Wpcc::Presenter do
       end
     end
   end
+
+  describe '#popup_tip_content_options' do
+    it 'returns a hash of options for the popup_tip' do
+      expect(subject.popup_tip_content_options('text', 'class name')).to eq(
+        text: 'text',
+        classname: 'class name',
+        tooltip_hide: 'hide help'
+      )
+    end
+  end
 end


### PR DESCRIPTION
New presenter method to enable all views to pull in the hash of options required for the popup tip.

Requires the text and class_name to be passed.