### PR TITLE
[DEV APPROVED]WPCC | A11y - Results table heading

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,6 @@
+## 1.12.1:
+* TP-8694 Adds visually hidden table heading for accessibility 
+
 ## 1.12.0:
 * Adds Dough helpers across all views for tooltips
 

--- a/app/views/wpcc/your_results/_period_percents_table.html.erb
+++ b/app/views/wpcc/your_results/_period_percents_table.html.erb
@@ -10,7 +10,7 @@
     <table class="table--full-width contribution-changes__table">
       <thead>
         <tr>
-          <th>&nbsp;</th>
+          <th><span class="visually-hidden"><%= t('wpcc.results.period_title.contributor_title') %></span></th>
           <% period_legal_percents.each do |period| %>
             <th><%= period.title %></th>
           <% end %>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -131,6 +131,7 @@ cy:
       employer_large_contribution_percent_for_two_periods:
         Mae eich cyflogwr eisoes yn talu mwy na'r isafswm newydd, felly rydym wedi dangos sut fydd eich cyfraniadau chi yn cynyddu yn unig. Ni fydd cyfraniad eich cyflogwr yn newid oni bai bod eich cyflog yn cynyddu neu rydych chi neu eich cyflogwr yn dewis talu mwy.
       period_title:
+        contributor_title: Cyfrannwr
         april_2017_march_2018: Nawr
         april_2018_march_2019: Ebrill 2018 – Mawrth 2019
         after_april_2019: O Ebrill 2019 ymlaen

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -131,6 +131,7 @@ en:
       employer_large_contribution_percent_for_two_periods:
         "Your employer is already paying above the new minimums so we have just shown how your contributions will increase. Your employer's contribution won't change unless your salary increases or your employer chooses to pay more."
       period_title:
+        contributor_title: Contributor
         april_2017_march_2018: Now
         april_2018_march_2019: April 2018 - March 2019
         after_april_2019: April 2019 onwards

--- a/features/step_definitions/your_results_steps.rb
+++ b/features/step_definitions/your_results_steps.rb
@@ -128,7 +128,7 @@ end
 
 Then(/^I should see the percents information:$/) do |table|
   data = table.raw.flatten
-  headings = ['', 'Now', 'April 2018 - March 2019', 'April 2019 onwards']
+  headings = ['Contributor', 'Now', 'April 2018 - March 2019', 'April 2019 onwards']
   expect(your_results_page.percent_table_headings.map{|cell| cell.text}).to eq(headings)
   expect(your_results_page.table_cells.map{|cell| cell.text}).to eq(data)
 end

--- a/lib/wpcc/version.rb
+++ b/lib/wpcc/version.rb
@@ -2,7 +2,7 @@ module Wpcc
   module Version
     MAJOR = 1
     MINOR = 12
-    PATCH = 0
+    PATCH = 1
 
     STRING = [MAJOR, MINOR, PATCH].join('.')
   end


### PR DESCRIPTION
# WPCC | A11y - Results table heading

[TP Ticket 8694](https://moneyadviceservice.tpondemand.com/entity/8694)

Tables must be made using appropriate mark-up to ensure that they are rendered properly by assistive technologies. 

Table headers should never be empty. This caused confusion for DAC screen reader analysts as it was not clear what the column was displaying without reading all of the content in the table.

The offending table is on the results step:

![image](https://user-images.githubusercontent.com/13165846/33876724-3b13ded2-df1e-11e7-8a00-8054f4aa3ce4.png)

This PR adds a visually-hidden span which displays the correct header for both English and Welsh