### PR TITLE
[DEV APPROVED] 8446 store app specific settings

### DIFF
--- a/app/assets/javascripts/wpcc/components/SalaryConditions.js
+++ b/app/assets/javascripts/wpcc/components/SalaryConditions.js
@@ -3,24 +3,6 @@ define(['jquery', 'DoughBaseComponent'], function($, DoughBaseComponent) {
 
   var SalaryConditions;
   var defaultConfig = {};
-  var optInTriggers = {
-      year: {
-        lower: 5876.00,
-        upper: 10000.00
-      },
-      month: {
-        lower: 490.00,
-        upper: 833.00
-      },
-      fourweeks: {
-        lower: 452.00,
-        upper: 768.00
-      },
-      week: {
-        lower: 113.00,
-        upper: 192.00
-      }
-    };
 
   SalaryConditions = function($el, config) {
     SalaryConditions.baseConstructor.call(this, $el, config, defaultConfig);
@@ -38,6 +20,7 @@ define(['jquery', 'DoughBaseComponent'], function($, DoughBaseComponent) {
     this.contribution = 'full';
 
     // Step 2 - Contributions
+    this.optInTriggers = config;
     this.$employeeTip = this.$el.find('[data-wpcc-employee-tip]');
     this.$employeeTip_lt5876 = this.$el.find('[data-wpcc-employee-tip-lt5876]');
     this.$employerTip = this.$el.find('[data-wpcc-employer-tip]');
@@ -95,24 +78,24 @@ define(['jquery', 'DoughBaseComponent'], function($, DoughBaseComponent) {
   }
 
   SalaryConditions.prototype._belowManualOptIn = function(salary, frequency) {
-    var thresholds = optInTriggers[frequency];
+    var thresholds = this.optInTriggers[frequency];
     if (salary < thresholds.lower) return true;
   };
 
   SalaryConditions.prototype._manualOptInRequired = function(salary, frequency) {
-    var thresholds = optInTriggers[frequency];
+    var thresholds = this.optInTriggers[frequency];
     if (this._salaryInRange(salary, thresholds.lower, thresholds.upper)) return true;
   };
 
   SalaryConditions.prototype._nearPensionThreshold = function(salary, frequency) {
-    var thresholds = optInTriggers[frequency];
+    var thresholds = this.optInTriggers[frequency];
     var bottomOfRange = thresholds.lower - 10;
     var topOfRange = thresholds.lower + 10;
     if (this._salaryInRange(salary, bottomOfRange, topOfRange)) return true;
   };
 
   SalaryConditions.prototype._nearAutoEnrollThreshold = function(salary, frequency) {
-    var thresholds = optInTriggers[frequency];
+    var thresholds = this.optInTriggers[frequency];
     var bottomOfRange = thresholds.upper - 10;
     var topOfRange = thresholds.upper + 10;
     if (this._salaryInRange(salary, bottomOfRange, topOfRange)) return true;

--- a/app/concerns/wpcc/salary_threshold.rb
+++ b/app/concerns/wpcc/salary_threshold.rb
@@ -1,9 +1,0 @@
-module Wpcc
-  module SalaryThreshold
-    extend ActiveSupport::Concern
-
-    def load_config(file:)
-      YAML.load_file(Wpcc::Engine.root.join('config', "#{file}.yml"))
-    end
-  end
-end

--- a/app/filters/wpcc/session_expirer.rb
+++ b/app/filters/wpcc/session_expirer.rb
@@ -1,6 +1,7 @@
 module Wpcc
   class SessionExpirer < ::Wpcc::BaseFilter
-    WPCC_SESSION_EXPIRY_LIMIT = 30.minutes
+    WPCC_SESSION_EXPIRY_LIMIT =
+      ::Wpcc::ConfigLoader.load('session')['expiry_limit'].minutes
 
     SESSION_KEYS = [
       YourContributionsSessionVerifier::SESSION_KEYS,

--- a/app/models/wpcc/config_loader.rb
+++ b/app/models/wpcc/config_loader.rb
@@ -1,0 +1,9 @@
+module Wpcc
+  class ConfigLoader
+    def self.load(filename)
+      hash = YAML.load_file(Wpcc::Engine.root.join('config', "#{filename}.yml"))
+
+      HashWithIndifferentAccess.new(hash).freeze
+    end
+  end
+end

--- a/app/models/wpcc/contribution_calculator.rb
+++ b/app/models/wpcc/contribution_calculator.rb
@@ -1,7 +1,6 @@
 module Wpcc
   class ContributionCalculator
-    THRESHOLDS_FILE = Wpcc::Engine.root.join('config', 'earning_thresholds.yml')
-    THRESHOLDS = YAML.load_file(THRESHOLDS_FILE)
+    THRESHOLDS = ::Wpcc::ConfigLoader.load('earning_thresholds')
 
     attr_accessor :salary_per_year, :contribution_preference
 

--- a/app/models/wpcc/period_contribution_calculator.rb
+++ b/app/models/wpcc/period_contribution_calculator.rb
@@ -9,9 +9,9 @@ module Wpcc
                   :tax_relief_percent,
                   :name
 
-    SALARY_FREQUENCY_CONVERSIONS = YAML.load_file(
-      Wpcc::Engine.root.join('config', 'salary_frequency_conversions.yml')
-    )
+    SALARY_FREQUENCY_CONVERSIONS =
+      ::Wpcc::ConfigLoader.load('salary_frequency_conversions')
+
     TAX_RELIEF_LIMIT_BY_FREQUENCY =
       SALARY_FREQUENCY_CONVERSIONS['tax_relief_limit_by_frequency']
 

--- a/app/models/wpcc/period_filter.rb
+++ b/app/models/wpcc/period_filter.rb
@@ -3,11 +3,7 @@ module Wpcc
     include ActiveModel::Model
     attr_accessor :user_input_employee_percent, :user_input_employer_percent
 
-    PERIODS_FILE = Wpcc::Engine.root.join(
-      'config',
-      'periods_legal_percents.yml'
-    )
-    PERIODS = HashWithIndifferentAccess.new(YAML.load_file(PERIODS_FILE))
+    PERIODS = ::Wpcc::ConfigLoader.load('periods_legal_percents')
 
     def filtered_periods
       periods.reject do |legal_period|

--- a/app/models/wpcc/salary_frequency_converter.rb
+++ b/app/models/wpcc/salary_frequency_converter.rb
@@ -1,8 +1,6 @@
 module Wpcc
   class SalaryFrequencyConverter
-    CONVERSIONS = YAML.load_file(
-      Wpcc::Engine.root.join('config', 'salary_frequency_conversions.yml')
-    )
+    CONVERSIONS = ::Wpcc::ConfigLoader.load('salary_frequency_conversions')
     SALARY_FREQUENCIES = CONVERSIONS['salary_frequencies']
 
     def self.convert(salary_frequency)

--- a/app/models/wpcc/salary_message.rb
+++ b/app/models/wpcc/salary_message.rb
@@ -3,11 +3,8 @@ module Wpcc
     include ActiveModel::Model
     attr_accessor :salary, :salary_frequency, :employee_percent, :text
 
-    THRESHOLDS_FILE = Wpcc::Engine.root.join(
-      'config', 'salary_frequency_conversions.yml'
-    ).freeze
-
-    FREQUENCY_THRESHOLDS = YAML.load_file(THRESHOLDS_FILE).freeze
+    FREQUENCY_THRESHOLDS =
+      ::Wpcc::ConfigLoader.load('salary_frequency_conversions')
 
     OPT_IN_THRESHOLDS = FREQUENCY_THRESHOLDS[
       'manual_opt_in_by_frequency'

--- a/app/models/wpcc/your_details_form.rb
+++ b/app/models/wpcc/your_details_form.rb
@@ -1,6 +1,5 @@
 module Wpcc
   class YourDetailsForm
-    extend Wpcc::SalaryThreshold
     include ActiveModel::Model
 
     attr_accessor :age, :gender, :salary
@@ -8,8 +7,9 @@ module Wpcc
 
     AGE = { minimum: 16, maximum: 74 }.freeze
     GENDERS = %w[male female].freeze
-    SALARY_FREQUENCIES = load_config(file: 'salary_threshold').keys.map(&:to_s)
     CONTRIBUTIONS = %w[full minimum].freeze
+    SALARY_FREQUENCIES =
+      ::Wpcc::ConfigLoader.load('salary_threshold').keys.map(&:to_s)
 
     validates :age, presence: true
     validates :age, numericality: {

--- a/app/presenters/wpcc/message_presenter.rb
+++ b/app/presenters/wpcc/message_presenter.rb
@@ -1,5 +1,18 @@
 module Wpcc
   class MessagePresenter < Presenter
+    def self.opt_in_thresholds
+      config = {}
+
+      ::Wpcc::SalaryMessage::OPT_IN_THRESHOLDS.each do |threshold, frequencies|
+        frequencies.each do |frequency, frequency_threshold_value|
+          config[frequency] ||= {}
+          config[frequency][threshold] = frequency_threshold_value
+        end
+      end
+
+      config.to_json
+    end
+
     def manually_opt_in_message?
       text == :manually_opt_in && manually_opt_in?
     end

--- a/app/validators/wpcc/salary_threshold_validator.rb
+++ b/app/validators/wpcc/salary_threshold_validator.rb
@@ -1,8 +1,7 @@
 module Wpcc
   class SalaryThresholdValidator < ActiveModel::Validator
-    extend Wpcc::SalaryThreshold
-
-    LOW_SALARY_THRESHOLDS = load_config(file: 'salary_threshold').stringify_keys
+    LOW_SALARY_THRESHOLDS =
+      ::Wpcc::ConfigLoader.load('salary_threshold').stringify_keys
 
     def validate(record)
       record.errors.add(:contribution_preference) if

--- a/app/views/wpcc/your_contributions/new.html.erb
+++ b/app/views/wpcc/your_contributions/new.html.erb
@@ -35,7 +35,7 @@
       'data-dough-validation-config': '{"showValidationSummary": false}',
       'novalidate': true
     }) do |f| %>
-    <div data-dough-component="SalaryConditions ContributionConditions">
+    <div data-dough-component="SalaryConditions ContributionConditions" data-dough-salary-conditions-config="<%= ::Wpcc::MessagePresenter.opt_in_thresholds %>">
       <div class="contributions__row">
         <div class="contributions__source contributions__source--employee form__row">
           <h3 class="contributions__source-title">

--- a/app/views/wpcc/your_details/new.html.erb
+++ b/app/views/wpcc/your_details/new.html.erb
@@ -85,7 +85,7 @@
           </div>
         </div>
       </div>
-      <div class="details__row" data-dough-component="SalaryConditions">
+      <div class="details__row" data-dough-component="SalaryConditions" data-dough-salary-conditions-config="<%= ::Wpcc::MessagePresenter.opt_in_thresholds %>">
         <div data-dough-component="PopupTip">
           <div class="details__field">
             <%= f.form_row :salary do %>

--- a/config/session.yml
+++ b/config/session.yml
@@ -1,0 +1,1 @@
+expiry_limit: 30

--- a/spec/javascripts/fixtures/SalaryConditions.html
+++ b/spec/javascripts/fixtures/SalaryConditions.html
@@ -1,5 +1,6 @@
 <div>
-  <div data-dough-component="SalaryConditions">
+  <div data-dough-component="SalaryConditions"
+    data-dough-salary-conditions-config='{"year":{"lower":5876,"upper":10000},"month":{"lower":490,"upper":833},"fourweeks":{"lower":452,"upper":768},"week":{"lower":113,"upper":192}}'>
 
     <input data-wpcc-salary-input type="text" />
     <select data-wpcc-frequency-select>

--- a/spec/javascripts/tests/SalaryConditions_spec.js
+++ b/spec/javascripts/tests/SalaryConditions_spec.js
@@ -10,7 +10,7 @@ describe('Salary Conditions', function() {
         _this.$html = $(window.__html__['spec/javascripts/fixtures/SalaryConditions.html']).appendTo('body');
         _this.component = _this.$html.find('[data-dough-component="SalaryConditions"]');
         _this.salaryConditions = SalaryConditions;
-        _this.obj = new _this.salaryConditions(_this.component);
+        _this.obj = new _this.salaryConditions(_this.component, _this.component.data('dough-salary-conditions-config'));
         _this.delay = 550;
         done();
       }, done);

--- a/spec/models/your_details_form_spec.rb
+++ b/spec/models/your_details_form_spec.rb
@@ -5,15 +5,7 @@ describe Wpcc::YourDetailsForm, type: :model do
   let(:salary_frequency) { 'year' }
   let(:contribution_preference) { 'full' }
 
-  describe '.load_config' do
-    context 'file exists' do
-      let(:salary_threshold_config_file) do
-        Wpcc::Engine.root.join('config', 'salary_threshold.yml')
-      end
-
-      specify { expect(salary_threshold_config_file).to exist }
-    end
-
+  describe 'load configuration' do
     it 'returns salary frequencies' do
       expect(Wpcc::YourDetailsForm::SALARY_FREQUENCIES).to eq(
         %w[year month fourweeks week]


### PR DESCRIPTION
Tp: https://moneyadviceservice.tpondemand.com/entity/8446-wpcc-store-app-specific-settings

## Context

The Workplace Pension Contribution Calculator uses different approaches to store app-specific settings. This PR seeks to define and use one approach. 

- [x] Rename app/concerns/wpcc/salary_threshold.rb to a more generic file name.
- [x] Replace direct loading of YAML config file from app/models/wpcc with some sort of config_loader.
- [x] Convert wpcc_session_expiry_limit to use a yml file.
- [x] Convert Javascript auto-enrol salary thresholds to use a yml file.

Dough convention when loading components is every time
you have a component (e.g data-dough-component=SalaryConditions)
Dough will try to find an html attribute called 'data-dough' PLUS
the name of the component PLUS config (e.g data-dough-salary-conditions-config)
and parse the object and store in the config variable as the second
argument of the initialize function.
This PR uses that convention.

## Documentation

I decided to write the documentation task below to the technical docs repo. I will post the link soon.

- [ ] Add documentation on how to change values for application configs.