### PR TITLE
[DEV APPROVED] - Updates Brakeman gem to prevent test scripts from failing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ group :development, :test do
 end
 
 group :test do
-  gem 'brakeman', require: false
+  gem 'brakeman', '~> 4.1.1', require: false
   gem 'capybara'
   gem 'cucumber-rails', require: false
   gem 'poltergeist'

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,6 @@
+## 1.13.2:
+* Updates Brakeman gem to version 4.1.1
+
 ## 1.13.0:
 * TP-8618 Add 'near threshold' warnings when user salary is close
 

--- a/lib/wpcc/version.rb
+++ b/lib/wpcc/version.rb
@@ -2,7 +2,7 @@ module Wpcc
   module Version
     MAJOR = 1
     MINOR = 13
-    PATCH = 1
+    PATCH = 2
 
     STRING = [MAJOR, MINOR, PATCH].join('.')
   end


### PR DESCRIPTION
```  
[jonesagyemang:~/Projects/MAS/wpcc] add-dangerfile(+16/-4)+* 1h56m55s ± ./test.sh
      export RAILS_ENV=test
      RAILS_ENV=test
      export BUNDLE_WITHOUT=development
      BUNDLE_WITHOUT=development
      npm install -q
      bundle install --quiet
      bundle exec brakeman -q --no-pager --ensure-latest
      Brakeman 4.0.1 is not the latest version 4.1.1
```
Brakeman is failing, as expected for, as it's not using the latest gem `4.1.1`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moneyadviceservice/wpcc/187)
<!-- Reviewable:end -->
