### PR TITLE
[DEV APPROVED] 8906: Remove 2018 to 2019 period contributions box

### DIFF
--- a/app/models/wpcc/period.rb
+++ b/app/models/wpcc/period.rb
@@ -22,15 +22,11 @@ module Wpcc
       end
     end
 
-    def below_user_contributions?(period_filter)
-      legal_minimum? && percents_below_user_input_percents?(period_filter)
+    def should_be_filtered_out?(period_filter)
+      percents_below_user_input_percents?(period_filter)
     end
 
     private
-
-    def legal_minimum?
-      employee_percent.present?
-    end
 
     def percents_below_user_input_percents?(period_filter)
       employee_percent <= period_filter.user_input_employee_percent &&

--- a/app/models/wpcc/period_filter.rb
+++ b/app/models/wpcc/period_filter.rb
@@ -6,9 +6,9 @@ module Wpcc
     PERIODS = ::Wpcc::ConfigLoader.load('periods_legal_percents')
 
     def filtered_periods
-      periods.reject do |legal_period|
-        legal_period.below_user_contributions?(self)
-      end
+      return current_period if periods.last.should_be_filtered_out?(self)
+
+      periods
     end
 
     def periods
@@ -22,6 +22,12 @@ module Wpcc
           user_input_employer_percent: user_input_employer_percent
         )
       end
+    end
+
+    private
+
+    def current_period
+      [periods.first]
     end
   end
 end

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -131,12 +131,10 @@ cy:
         Mae eich cyflogwr eisoes yn talu mwy na'r isafswm newydd, felly rydym wedi dangos sut fydd eich cyfraniadau chi yn cynyddu yn unig. Ni fydd cyfraniad eich cyflogwr yn newid oni bai bod eich cyflog yn cynyddu neu rydych chi neu eich cyflogwr yn dewis talu mwy.
       period_title:
         contributor_title: Cyfrannwr
-        april_2017_march_2018: Nawr
-        april_2018_march_2019: Ebrill 2018 – Mawrth 2019
+        april_2018_march_2019: Nawr
         after_april_2019: O Ebrill 2019 ymlaen
       period_percents_title:
-        april_2017_march_2018: Nawr
-        april_2018_march_2019: Ebrill 2018 – Mawrth 2019
+        april_2018_march_2019: Nawr
         after_april_2019: O Ebrill 2019 ymlaen
       period:
         contribution_heading:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -131,12 +131,10 @@ en:
         "Your employer is already paying above the new minimums so we have just shown how your contributions will increase. Your employer's contribution won't change unless your salary increases or your employer chooses to pay more."
       period_title:
         contributor_title: Contributor
-        april_2017_march_2018: Now
-        april_2018_march_2019: April 2018 - March 2019
+        april_2018_march_2019: Now
         after_april_2019: April 2019 onwards
       period_percents_title:
-        april_2017_march_2018: Now
-        april_2018_march_2019: April 2018 - March 2019
+        april_2018_march_2019: Now
         after_april_2019: April 2019 onwards
       period:
         contribution_heading:

--- a/config/periods_legal_percents.yml
+++ b/config/periods_legal_percents.yml
@@ -1,5 +1,3 @@
-april_2017_march_2018:
-  tax_relief: 20
 april_2018_march_2019:
   employee: 3
   employer: 2

--- a/features/_your_results/calculating_different_salary_frequencies.feature
+++ b/features/_your_results/calculating_different_salary_frequencies.feature
@@ -16,11 +16,11 @@ Feature: displaying different salary frequencies
         | 1                 | 1                     |
       When I move on to the results page
       Then I should see the values on the results page as:
-      |                         | Now    | April 2018 - March 2019 | Apr 2019 onwards |
-      | Employee Contributions  | £9.97  | £29.92                  | £49.87           |
-      | Including tax relief of | £1.99  | £5.98                   | £9.97            |
-      | Employer Contributions  | £9.97  | £19.95                  | £29.92           |
-      | TOTAL Contributions     | £19.94 | £49.87                  | £79.79           |
+      |                         | Now    | Apr 2019 onwards |
+      | Employee Contributions  | £29.92 | £49.87           |
+      | Including tax relief of | £5.98  | £9.97            |
+      | Employer Contributions  | £19.95 | £29.92           |
+      | TOTAL Contributions     | £49.87 | £79.79           |
 
 
 
@@ -44,18 +44,14 @@ Feature: displaying different salary frequencies
       And I should see my employer contributions for second period as "<employer_second_period>"
       And I should see my tax relief for second period as "<tax_relief_second_period>"
       And I should see my total contributions for second period as "<total_second_period>"
-      And I should see my employee contributions for third period as "<employee_third_period>"
-      And I should see my employer contributions for third period as "<employer_third_period>"
-      And I should see my tax relief for third period as "<tax_relief_third_period>"
-      And I should see my total contributions for third period as "<total_third_period>"
       And I should see "<selected_frequency>" in the Recalculate Salary Frequency selector dropdown
     Examples:
-      | age | gender | salary | salary_frequency | contribution_preference | employee_percent | employer_percent | employee_current_period | tax_relief_current_period | employer_current_period | total_current_period | employee_second_period | employer_second_period | tax_relief_second_period | total_second_period | employee_third_period | employer_third_period | tax_relief_third_period | total_third_period | selected_frequency |
-      | 25  | male   | 25000  | per year         | Minimum                 | 1                | 1                | £15.81                  | £3.16                     | £15.81                  | £31.62               | £47.42                 | £31.61                 | £9.48                    | £79.03              | £79.03                | £47.42                | £15.81                  | £126.45            | per month          |
-      | 25  | male   | 18000  | per year         | Minimum                 | 1                | 1                | £9.97                   | £1.99                     | £9.97                   | £19.94               | £29.92                 | £19.95                 | £5.98                    | £49.87              | £49.87                | £29.92                | £9.97                   | £79.79             | per month          |
-      | 25  | male   | 1500   | per month        | Minimum                 | 1                | 1                | £9.97                   | £1.99                     | £9.97                   | £19.94               | £29.92                 | £19.95                 | £5.98                    | £49.87              | £49.87                | £29.92                | £9.97                   | £79.79             | per month          |
-      | 30  | female | 1000   | per month        | Full                    | 1                | 2                | £10.00                  | £2.00                     | £20.00                  | £30.00               | £30.00                 | £20.00                 | £6.00                    | £50.00              | £50.00                | £30.00                | £10.00                  | £80.00             | per month          |
-      | 24  | male   | 380    | per week         | Minimum                 | 1                | 2                | £2.64                   | £0.53                     | £5.28                   | £7.92                | £7.92                  | £5.28                  | £1.58                    | £13.20              | £13.20                | £7.92                 | £2.64                   | £21.12             | per week           |
-      | 32  | female | 400    | per week         | Minimum                 | 3                | 2                | £8.52                   | £1.70                     | £5.68                   | £14.20               |                        |                        |                          |                     | £14.20                | £8.52                 | £2.84                   | £22.72             | per week           |
-      | 24  | male   | 300    | per week         | Full                    | 2                | 2                | £6.00                   | £1.20                     | £6.00                   | £12.00               | £9.00                  | £6.00                  | £1.80                    | £15.00              | £15.00                | £9.00                 | £3.00                   | £24.00             | per week           |
-      | 18  | male   | 1900   | per 4 weeks      | Minimum                 | 2                | 1                | £28.72                  | £5.74                     | £14.36                  | £43.08               | £43.08                 | £28.72                 | £8.62                    | £71.80              | £71.80                | £43.08                | £14.36                  | £114.88            | per 4 weeks        |
+      | age | gender | salary | salary_frequency | contribution_preference | employee_percent | employer_percent | employee_current_period | employer_current_period | tax_relief_current_period | total_current_period | employee_second_period | employer_second_period | tax_relief_second_period | total_second_period | selected_frequency |
+      | 25  | male   | 25000  | per year         | Minimum                 | 1                | 1                | £47.42                  | £31.61                  | £9.48                     | £79.03               | £79.03                 | £47.42                 | £15.81                   | £126.45             | per month          |
+      | 25  | male   | 18000  | per year         | Minimum                 | 1                | 1                | £29.92                  | £19.95                  | £5.98                     | £49.87               | £49.87                 | £29.92                 | £9.97                    | £79.79              | per month          |
+      | 25  | male   | 1500   | per month        | Minimum                 | 1                | 1                | £29.92                  | £19.95                  | £5.98                     | £49.87               | £49.87                 | £29.92                 | £9.97                    | £79.79              | per month          |
+      | 30  | female | 1000   | per month        | Full                    | 1                | 2                | £30.00                  | £20.00                  | £6.00                     | £50.00               | £50.00                 | £30.00                 | £10.00                   | £80.00              | per month          |
+      | 24  | male   | 380    | per week         | Minimum                 | 1                | 2                | £7.92                   | £5.28                   | £1.58                     | £13.20               | £13.20                 | £7.92                  | £2.64                    | £21.12              | per week           |
+      | 32  | female | 400    | per week         | Minimum                 | 3                | 2                | £8.52                   | £5.68                   | £1.70                     | £14.20               | £14.20                 | £8.52                  | £2.84                    | £22.72              | per week           |
+      | 24  | male   | 300    | per week         | Full                    | 2                | 2                | £9.00                   | £6.00                   | £1.80                     | £15.00               | £15.00                 | £9.00                  | £3.00                    | £24.00              | per week           |
+      | 18  | male   | 1900   | per 4 weeks      | Minimum                 | 2                | 1                | £43.08                  | £28.72                  | £8.62                     | £71.80               | £71.80                 | £43.08                 | £14.36                   | £114.88             | per 4 weeks        |

--- a/features/_your_results/contribution_above_legal_minimum.feature
+++ b/features/_your_results/contribution_above_legal_minimum.feature
@@ -14,19 +14,19 @@ Feature:
       And my employee contribution is "4"
       When I move on to the results page
       Then I should see the values on the results page as:
-        |                         | Now    | April 2018 - March 2019 | Apr 2019 onwards |
-        | Employee Contributions  | £46.56 | £46.56                  | £58.20           |
-        | Including tax relief of | £9.31  | £9.31                   | £11.64           |
-        | Employer Contributions  | £23.28 | £23.28                  | £34.92           |
-        | TOTAL Contributions     | £69.84 | £69.84                  | £93.12           |
+        |                         | Now    | Apr 2019 onwards |
+        | Employee Contributions  | £46.56 | £58.20           |
+        | Including tax relief of | £9.31  | £11.64           |
+        | Employer Contributions  | £23.28 | £34.92           |
+        | TOTAL Contributions     | £69.84 | £93.12           |
 
 
     Scenario: When employer contribution is above default
       And my employer contribution is "5"
       When I move on to the results page
       Then I should see the values on the results page as:
-        |                         | Now    | April 2018 - March 2019 | Apr 2019 onwards |
-        | Employee Contributions  | £34.92 | £34.92                  | £58.20           |
-        | Including tax relief of | £6.98  | £6.98                   | £11.64           |
-        | Employer Contributions  | £58.20 | £58.20                  | £58.20           |
-        | TOTAL Contributions     | £93.12 | £93.12                  | £116.40          |
+        |                         | Now    | Apr 2019 onwards |
+        | Employee Contributions  | £34.92 | £58.20           |
+        | Including tax relief of | £6.98  | £11.64           |
+        | Employer Contributions  | £58.20 | £58.20           |
+        | TOTAL Contributions     | £93.12 | £116.40          |

--- a/features/_your_results/limit_tax_relief.feature
+++ b/features/_your_results/limit_tax_relief.feature
@@ -14,11 +14,11 @@ Feature: Limit Tax Relief
       And my contribution is "60" percent
       When I move on to the results page
       Then I should see the values on the results page as:
-        |                         | Now        | April 2018 - March 2019 | Apr 2019 onwards |
-        | Employee Contributions  | £4,000.00  | £4,000.00               | £4,000.00        |
-        | Including tax relief of | £666.67    | £666.67                 | £666.67          |
-        | Employer Contributions  | £66.67     | £133.33                 | £200.00          |
-        | TOTAL Contributions     | £4,066.67  | £4,133.33               | £4,200.00        |
+        |                         | Now        | Apr 2019 onwards |
+        | Employee Contributions  | £4,000.00  | £4,000.00        |
+        | Including tax relief of | £666.67    | £666.67          |
+        | Employer Contributions  | £133.33    | £200.00          |
+        | TOTAL Contributions     | £4,133.33  | £4,200.00        |
 
     Scenario: Employee contributing more than £769.23 per week to pension
       Given my salary is "1200" "per week" with "Full" contribution
@@ -26,11 +26,11 @@ Feature: Limit Tax Relief
       And my contribution is "65" percent
       When I move on to the results page
       Then I should see the values on the results page as:
-        |                         | Now     | April 2018 - March 2019 | Apr 2019 onwards |
-        | Employee Contributions  | £780.00 | £780.00                 | £780.00          |
-        | Including tax relief of | £153.85 | £153.85                 | £153.85          |
-        | Employer Contributions  | £12.00  | £24.00                  | £36.00           |
-        | TOTAL Contributions     | £792.00 | £804.00                 | £816.00          |
+        |                         | Now     | Apr 2019 onwards |
+        | Employee Contributions  | £780.00 | £780.00          |
+        | Including tax relief of | £153.85 | £153.85          |
+        | Employer Contributions  | £24.00  | £36.00           |
+        | TOTAL Contributions     | £804.00 | £816.00          |
 
     Scenario: Employee contributing more than £3,333.33 per month to pension
       Given my salary is "4000" "per month" with "Full" contribution
@@ -38,11 +38,11 @@ Feature: Limit Tax Relief
       And my contribution is "90" percent
       When I move on to the results page
       Then I should see the values on the results page as:
-        |                         | Now       | April 2018 - March 2019 | Apr 2019 onwards |
-        | Employee Contributions  | £3,600.00 | £3,600.00               | £3,600.00        |
-        | Including tax relief of | £666.67   | £666.67                 | £666.67          |
-        | Employer Contributions  | £40.00    | £80.00                  | £120.00          |
-        | TOTAL Contributions     | £3,640.00 | £3,680.00               | £3,720.00        |
+        |                         | Now       | Apr 2019 onwards |
+        | Employee Contributions  | £3,600.00 | £3,600.00        |
+        | Including tax relief of | £666.67   | £666.67          |
+        | Employer Contributions  | £80.00    | £120.00          |
+        | TOTAL Contributions     | £3,680.00 | £3,720.00        |
 
     Scenario: Employee contributing more than £3,076.92 per 4 weeks to pension
       Given my salary is "5000" "per 4 weeks" with "Full" contribution
@@ -50,8 +50,8 @@ Feature: Limit Tax Relief
       And my contribution is "90" percent
       When I move on to the results page
       Then I should see the values on the results page as:
-        |                         | Now       | April 2018 - March 2019 | Apr 2019 onwards |
-        | Employee Contributions  | £4,500.00 | £4,500.00               | £4,500.00        |
-        | Including tax relief of | £615.38   | £615.38                 | £615.38          |
-        | Employer Contributions  | £50.00    | £100.00                 | £150.00          |
-        | TOTAL Contributions     | £4,550.00 | £4,600.00               | £4,650.00        |
+        |                         | Now       | Apr 2019 onwards |
+        | Employee Contributions  | £4,500.00 | £4,500.00        |
+        | Including tax relief of | £615.38   | £615.38          |
+        | Employer Contributions  | £100.00   | £150.00          |
+        | TOTAL Contributions     | £4,600.00 | £4,650.00        |

--- a/features/_your_results/message_based_on_contribution_percents.feature
+++ b/features/_your_results/message_based_on_contribution_percents.feature
@@ -22,21 +22,21 @@ Feature: Display messaging based on results table shown in results
       | message |
       | Rydych chi a'ch cyflogwr eisoes yn talu mwy na'r isafswm newydd, felly rydym wedi dangos y cyfraniadau cyfredol yn unig. Ni fydd y rhain yn newid oni bai bod eich cyflog yn cynyddu neu rydych chi ac/neu eich cyflogwr yn dewis talu mwy. |
 
-  Scenario Outline: Employee and Employer contributions are greater than the minimum for 2018 but NOT for 2019
-    Given I fill in my contributions:
-      | your_contribution | employer_contribution |
-      | 3                 | 2.99                  |
-    When I move on to the results page
-    Then I should see a contribution explanation "<message>"
-
-    Examples:
-      | message |
-      | Both you and your employer are already paying above the new minimum for April 2018 so we have only shown the increase for April 2019. |
-
-    @welsh
-    Examples:
-      | message |
-      | Rydych chi a'ch cyflogwr eisoes yn talu mwy na'r isafswm newydd ar gyfer Ebrill 2018 felly rydym wedi dangos y cynnydd ar gyfer Ebrill 2019 yn unig. |
+  # Scenario Outline: Employee and Employer contributions are greater than the minimum for 2018 but NOT for 2019
+  #   Given I fill in my contributions:
+  #     | your_contribution | employer_contribution |
+  #     | 3                 | 2.99                  |
+  #   When I move on to the results page
+  #   Then I should see a contribution explanation "<message>"
+  #
+  #   Examples:
+  #     | message |
+  #     | Both you and your employer are already paying above the new minimum for April 2018 so we have only shown the increase for April 2019. |
+  #
+  #   @welsh
+  #   Examples:
+  #     | message |
+  #     | Rydych chi a'ch cyflogwr eisoes yn talu mwy na'r isafswm newydd ar gyfer Ebrill 2018 felly rydym wedi dangos y cynnydd ar gyfer Ebrill 2019 yn unig. |
 
   Scenario Outline: Only Employee contribution is greater than the minimum for 2018 AND 2019
     Given I fill in my contributions:

--- a/features/_your_results/period_percent_table.feature
+++ b/features/_your_results/period_percent_table.feature
@@ -11,8 +11,8 @@ Feature: Period Percents Information Table
     When I move on to the results page
     Then I should see a link to the legal minimum contributions table
     And I should see the percents information:
-        | You           | 1% | 3% | 5% |
-        | Your employer | 1% | 2% | 3% |
+        | You           | 3% | 5% |
+        | Your employer | 2% | 3% |
 
     Examples:
         | my_contribution | employer_contribution |

--- a/features/_your_results/salary_below_minimum_threshold.feature
+++ b/features/_your_results/salary_below_minimum_threshold.feature
@@ -39,16 +39,16 @@ Feature: Employer contributions do not increase when user's salary is less than 
     And my employee contribution is "1"
     And my employer contribution is "<employer_percent>"
     When I move on to the results page
-    Then I should see employer_contributions for "<period_1>", "<period_2>" and "<period_3>" increase as per the legal minimums
+    Then I should see employer_contributions for "<period_1>" and "<period_2>" increase as per the legal minimums
 
     Examples:
-        | salary | salary_frequency | part_or_full | employer_percent | period_1   | period_2 | period_3 |
-        | 1500   | per month        | Minimum      | 0                | £0.00      | £19.95   | £29.92   |
-        | 1500   | per month        | Minimum      | 1                | £9.97      | £19.95   | £29.92   |
-        | 1200   | per 4 weeks      | Minimum      | 0                | £0.00      | £14.72   | £22.08   |
-        | 1200   | per 4 weeks      | Minimum      | 1                | £7.36      | £14.72   | £22.08   |
-        | 350    | per week         | Minimum      | 0                | £0.00      | £4.68    | £7.02    |
-        | 350    | per week         | Minimum      | 1                | £2.34      | £4.68    | £7.02    |
+        | salary | salary_frequency | part_or_full | employer_percent | period_1 | period_2 |
+        | 1500   | per month        | Minimum      | 0                | £19.95   | £29.92   |
+        | 1500   | per month        | Minimum      | 1                | £19.95   | £29.92   |
+        | 1200   | per 4 weeks      | Minimum      | 0                | £14.72   | £22.08   |
+        | 1200   | per 4 weeks      | Minimum      | 1                | £14.72   | £22.08   |
+        | 350    | per week         | Minimum      | 0                | £4.68    | £7.02    |
+        | 350    | per week         | Minimum      | 1                | £4.68    | £7.02    |
 
   Scenario Outline: For annual salary frequency above the minimum threshold
     Given my "<salary>" "<salary_frequency>", regardless of "<part_or_full>" contribution, is above the minimum threshold
@@ -57,9 +57,9 @@ Feature: Employer contributions do not increase when user's salary is less than 
     When I move on to the results page
     And I select "<salary_frequency>" to change the calculations
     And I press recalculate
-    Then I should see employer_contributions for "<period_1>", "<period_2>" and "<period_3>" increase as per the legal minimums
+    Then I should see employer_contributions for "<period_1>" and "<period_2>" increase as per the legal minimums
 
     Examples:
-        | salary  | salary_frequency | part_or_full | employer_percent | period_1   | period_2 | period_3 |
-        | 11100   | per year         | Minimum      | 0                | £0.00      | £101.36  | £152.04  |
-        | 11100   | per year         | Minimum      | 1                | £50.68     | £101.36  | £152.04  |
+        | salary  | salary_frequency | part_or_full | employer_percent | period_1 | period_2 |
+        | 11100   | per year         | Minimum      | 0                | £101.36  | £152.04  |
+        | 11100   | per year         | Minimum      | 1                | £101.36  | £152.04  |

--- a/features/step_definitions/your_results_steps.rb
+++ b/features/step_definitions/your_results_steps.rb
@@ -48,43 +48,19 @@ Then(/^I should see my total contributions for current period as "([^"]*)"$/) do
 end
 
 Then(/^I should see my employee contributions for second period as "([^"]*)"$/) do |employee_contribution|
-  next if your_results_page.has_no_second_period?
-
   expect(your_results_page.second_period.employee_contribution.text).to eq(employee_contribution)
 end
 
 Then(/^I should see my employer contributions for second period as "([^"]*)"$/) do |employer_contribution|
-  next if your_results_page.has_no_second_period?
-
   expect(your_results_page.second_period.employer_contribution.text).to eq(employer_contribution)
 end
 
 Then(/^I should see my tax relief for second period as "([^"]*)"$/) do |tax_relief|
-  next if your_results_page.has_no_second_period?
-
   expect(your_results_page.second_period.tax_relief.text).to eq("(includes tax relief of #{tax_relief})")
 end
 
 Then(/^I should see my total contributions for second period as "([^"]*)"$/) do |total_contributions|
-  next if your_results_page.has_no_second_period?
-
   expect(your_results_page.second_period.total_contributions.text).to eq(total_contributions)
-end
-
-Then(/^I should see my employee contributions for third period as "([^"]*)"$/) do |employee_contribution|
-  expect(your_results_page.third_period.employee_contribution.text).to eq(employee_contribution)
-end
-
-Then(/^I should see my employer contributions for third period as "([^"]*)"$/) do |employer_contribution|
-  expect(your_results_page.third_period.employer_contribution.text).to eq(employer_contribution)
-end
-
-Then(/^I should see my tax relief for third period as "([^"]*)"$/) do |tax_relief|
-  expect(your_results_page.third_period.tax_relief.text).to eq("(includes tax relief of #{tax_relief})")
-end
-
-Then(/^I should see my total contributions for third period as "([^"]*)"$/) do |total_contributions|
-  expect(your_results_page.third_period.total_contributions.text).to eq(total_contributions)
 end
 
 Then(/^I should( not| NOT)? see tax relief "([^"]*)"$/) do |should_not, warning_message|
@@ -128,7 +104,7 @@ end
 
 Then(/^I should see the percents information:$/) do |table|
   data = table.raw.flatten
-  headings = ['Contributor', 'Now', 'April 2018 - March 2019', 'April 2019 onwards']
+  headings = ['Contributor', 'Now', 'April 2019 onwards']
   expect(your_results_page.percent_table_headings.map{|cell| cell.text}).to eq(headings)
   expect(your_results_page.table_cells.map{|cell| cell.text}).to eq(data)
 end
@@ -136,13 +112,11 @@ end
 Then(/^I should see that the "([^"]*)" is the same for each period$/) do |employer_contribution|
   step %{I should see my employer contributions for current period as "#{employer_contribution}"}
   step %{I should see my employer contributions for second period as "#{employer_contribution}"}
-  step %{I should see my employer contributions for third period as "#{employer_contribution}"}  
 end
 
-Then(/^I should see employer_contributions for "([^"]*)", "([^"]*)" and "([^"]*)" increase as per the legal minimums$/) do |period_1, period_2, period_3|
+Then(/^I should see employer_contributions for "([^"]*)" and "([^"]*)" increase as per the legal minimums$/) do |period_1, period_2|
   step %{I should see my employer contributions for current period as "#{period_1}"}
   step %{I should see my employer contributions for second period as "#{period_2}"}
-  step %{I should see my employer contributions for third period as "#{period_3}"}
 end
 
 Then(/^I should see that the employer_contributions is the same for each period at the "([^"]*)"$/) do |employer_contribution|
@@ -168,7 +142,6 @@ Then(/^I should see the values on the results page as:$/) do |table|
   data = table.transpose.raw
   current_period = data[1]
   second_period = data[2]
-  third_period = data[3]
 
   step %{I should see my employee contributions for current period as "#{current_period[1]}"}
   step %{I should see my tax relief for current period as "#{current_period[2]}"}
@@ -179,11 +152,6 @@ Then(/^I should see the values on the results page as:$/) do |table|
   step %{I should see my tax relief for second period as "#{second_period[2]}"}
   step %{I should see my employer contributions for second period as "#{second_period[3]}"}
   step %{I should see my total contributions for second period as "#{second_period[4]}"}
-
-  step %{I should see my employee contributions for third period as "#{third_period[1]}"}
-  step %{I should see my tax relief for third period as "#{third_period[2]}"}
-  step %{I should see my employer contributions for third period as "#{third_period[3]}"}
-  step %{I should see my total contributions for third period as "#{third_period[4]}"}
 end
 
 Then(/^I should see a contribution explanation "([^"]*)"$/) do |message|

--- a/features/support/ui/your_results.rb
+++ b/features/support/ui/your_results.rb
@@ -27,8 +27,7 @@ module UI
     elements :table_cells, 'table.contribution-changes__table tbody tr td'
 
     elements :results_period_headings, '.results__period-heading'
-    section :current_period, PeriodSection, '.results__period-april_2017_march_2018'
-    section :second_period, PeriodSection, '.results__period-april_2018_march_2019'
-    section :third_period, PeriodSection, '.results__period-after_april_2019'
+    section :current_period, PeriodSection, '.results__period-april_2018_march_2019'
+    section :second_period, PeriodSection, '.results__period-after_april_2019'
   end
 end

--- a/features/your_results_frequency_selector.feature
+++ b/features/your_results_frequency_selector.feature
@@ -15,61 +15,61 @@ Feature:
   Scenario: Recalculate results changing to monthly frequency
     When I select "per month" to change the calculations
     Then I should see the values on the results page as:
-      |                         | Now     | April 2018 - March 2019 | Apr 2019 onwards |
-      | Employee Contributions  | £666.67 | £666.67                 | £666.67          |
-      | Including tax relief of | £133.33 | £133.33                 | £133.33          |
-      | Employer Contributions  | £66.67  | £133.33                 | £200.00          |
-      | TOTAL contributions     | £733.34 | £800.00                 | £866.67          |
+      |                         | Now     | Apr 2019 onwards |
+      | Employee Contributions  | £666.67 | £666.67          |
+      | Including tax relief of | £133.33 | £133.33          |
+      | Employer Contributions  | £133.33 | £200.00          |
+      | TOTAL contributions     | £800.00 | £866.67          |
 
   @no-javascript
   Scenario: Recalculate results changing to monthly frequency
     When I select "per month" to change the calculations
     And I press recalculate
     Then I should see the values on the results page as:
-      |                         | Now     | April 2018 - March 2019 | Apr 2019 onwards |
-      | Employee Contributions  | £666.67 | £666.67                 | £666.67          |
-      | Including tax relief of | £133.33 | £133.33                 | £133.33          |
-      | Employer Contributions  | £66.67  | £133.33                 | £200.00          |
-      | TOTAL contributions     | £733.34 | £800.00                 | £866.67          |
+      |                         | Now     | Apr 2019 onwards |
+      | Employee Contributions  | £666.67 | £666.67          |
+      | Including tax relief of | £133.33 | £133.33          |
+      | Employer Contributions  | £133.33 | £200.00          |
+      | TOTAL contributions     | £800.00 | £866.67          |
 
   @javascript
   Scenario: Recalculate results changing to weekly frequency
     When I select "per week" to change the calculations
     Then I should see the values on the results page as:
-      |                         | Now     | April 2018 - March 2019 | Apr 2019 onwards |
-      | Employee Contributions  | £153.85 | £153.85                 | £153.85          |
-      | Including tax relief of | £30.77  | £30.77                  | £30.77           |
-      | Employer Contributions  | £15.38  | £30.77                  | £46.15           |
-      | TOTAL contributions     | £169.23 | £184.62                 | £200.00          |
+      |                         | Now     | Apr 2019 onwards |
+      | Employee Contributions  | £153.85 | £153.85          |
+      | Including tax relief of | £30.77  | £30.77           |
+      | Employer Contributions  | £30.77  | £46.15           |
+      | TOTAL contributions     | £184.62 | £200.00          |
 
   @no-javascript
   Scenario: Recalculate results changing to weekly frequency
     When I select "per week" to change the calculations
     And I press recalculate
     Then I should see the values on the results page as:
-      |                         | Now     | April 2018 - March 2019 | Apr 2019 onwards |
-      | Employee Contributions  | £153.85 | £153.85                 | £153.85          |
-      | Including tax relief of | £30.77  | £30.77                  | £30.77           |
-      | Employer Contributions  | £15.38  | £30.77                  | £46.15           |
-      | TOTAL contributions     | £169.23 | £184.62                 | £200.00          |
+      |                         | Now     | Apr 2019 onwards |
+      | Employee Contributions  | £153.85 | £153.85          |
+      | Including tax relief of | £30.77  | £30.77           |
+      | Employer Contributions  | £30.77  | £46.15           |
+      | TOTAL contributions     | £184.62 | £200.00          |
 
   @javascript
   Scenario: Recalculate results changing to weekly frequency
     When I select "per 4 weeks" to change the calculations
     Then I should see the values on the results page as:
-      |                         | Now     | April 2018 - March 2019 | Apr 2019 onwards |
-      | Employee Contributions  | £615.38 | £615.38                 | £615.38          |
-      | Including tax relief of | £123.08 | £123.08                 | £123.08          |
-      | Employer Contributions  | £61.54  | £123.08                 | £184.62          |
-      | TOTAL contributions     | £676.92 | £738.46                 | £800.00          |
+      |                         | Now     | Apr 2019 onwards |
+      | Employee Contributions  | £615.38 | £615.38          |
+      | Including tax relief of | £123.08 | £123.08          |
+      | Employer Contributions  | £123.08 | £184.62          |
+      | TOTAL contributions     | £738.46 | £800.00          |
 
   @no-javascript
   Scenario: Recalculate results changing to weekly frequency
     When I select "per 4 weeks" to change the calculations
     And I press recalculate
     Then I should see the values on the results page as:
-      |                         | Now     | April 2018 - March 2019 | Apr 2019 onwards |
-      | Employee Contributions  | £615.38 | £615.38                 | £615.38          |
-      | Including tax relief of | £123.08 | £123.08                 | £123.08          |
-      | Employer Contributions  | £61.54  | £123.08                 | £184.62          |
-      | TOTAL contributions     | £676.92 | £738.46                 | £800.00          |
+      |                         | Now     | Apr 2019 onwards |
+      | Employee Contributions  | £615.38 | £615.38          |
+      | Including tax relief of | £123.08 | £123.08          |
+      | Employer Contributions  | £123.08 | £184.62          |
+      | TOTAL contributions     | £738.46 | £800.00          |

--- a/spec/models/period_filter_spec.rb
+++ b/spec/models/period_filter_spec.rb
@@ -1,7 +1,4 @@
 RSpec.describe Wpcc::PeriodFilter do
-  before do
-    stub_const('Wpcc::PeriodFilter::PERIODS', periods)
-  end
 
   let(:periods) do
     {
@@ -33,7 +30,7 @@ RSpec.describe Wpcc::PeriodFilter do
     end
 
     it 'returns a Period object for each period in the config file' do
-      expect(Wpcc::Period).to receive(:new).exactly(3).times
+      expect(Wpcc::Period).to receive(:new).exactly(2).times
       subject.periods
     end
   end
@@ -51,7 +48,7 @@ RSpec.describe Wpcc::PeriodFilter do
       let(:user_input_employer_percent) { 1 }
 
       it 'does not exclude the period' do
-        expect(filtered_periods.size).to eq(3)
+        expect(filtered_periods.size).to eq(2)
       end
     end
 
@@ -60,7 +57,7 @@ RSpec.describe Wpcc::PeriodFilter do
       let(:user_input_employer_percent) { 4.5 }
 
       it 'does not exclude the period' do
-        expect(filtered_periods.size).to eq(3)
+        expect(filtered_periods.size).to eq(2)
       end
     end
 
@@ -80,15 +77,6 @@ RSpec.describe Wpcc::PeriodFilter do
 
         it 'excludes the lower contribution period' do
           expect(filtered_periods.size).to eq(2)
-        end
-      end
-
-      context 'when two periods have percents lower than the user percents' do
-        let(:user_input_employee_percent) { 10 }
-        let(:user_input_employer_percent) { 10 }
-
-        it 'excludes all lower contribution periods' do
-          expect(filtered_periods.size).to eq(1)
         end
       end
     end

--- a/spec/models/period_spec.rb
+++ b/spec/models/period_spec.rb
@@ -54,22 +54,15 @@ RSpec.describe Wpcc::Period do
   describe '#below_user_contributions' do
     let(:period_filter) do
       double(Wpcc::PeriodFilter,
-             user_input_employee_percent: 1,
-             user_input_employer_percent: 1)
-    end
-
-    context 'when there are no percents' do
-      let(:employee_percent) { nil }
-      it 'returns false' do
-        expect(subject.below_user_contributions?(period_filter)).to be_falsey
-      end
+             user_input_employee_percent: 3,
+             user_input_employer_percent: 3)
     end
 
     context 'when legal percents are gte percents input by the user' do
       let(:employee_percent) { 10 }
       let(:employer_percent) { 10 }
       it 'returns false' do
-        expect(subject.below_user_contributions?(period_filter)).to be_falsey
+        expect(subject.should_be_filtered_out?(period_filter)).to be_falsey
       end
     end
 
@@ -77,7 +70,7 @@ RSpec.describe Wpcc::Period do
       let(:employee_percent) { 1 }
       let(:employer_percent) { 1 }
       it 'returns true' do
-        expect(subject.below_user_contributions?(period_filter)).to be_truthy
+        expect(subject.should_be_filtered_out?(period_filter)).to be_truthy
       end
     end
   end

--- a/spec/presenters/period_contribution_presenter_spec.rb
+++ b/spec/presenters/period_contribution_presenter_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Wpcc::PeriodContributionPresenter do
 
   describe '#title' do
     it 'converts the name to a more readable format' do
-      period_contribution.name = 'april_2017_march_2018'
+      period_contribution.name = 'april_2018_march_2019'
       expect(subject.title).to eq('Now')
     end
   end

--- a/spec/presenters/period_filter_presenter_spec.rb
+++ b/spec/presenters/period_filter_presenter_spec.rb
@@ -37,17 +37,6 @@ RSpec.describe Wpcc::PeriodFilterPresenter do
       end
     end
 
-    context 'when user inputs are between 2nd and 3rd period legal minimums' do
-      let(:user_input_employee_percent) { 4 }
-      let(:user_input_employer_percent) { 2.5 }
-
-      it 'returns message' do
-        expect(contribution_percents_explanation).to eq(
-          I18n.t('wpcc.results.large_contribution_percent_for_middle_period')
-        )
-      end
-    end
-
     context 'when user employee percent is greater than legal minimums' do
       let(:user_input_employee_percent) { 6 }
       let(:user_input_employer_percent) { 1 }

--- a/spec/presenters/period_presenter_spec.rb
+++ b/spec/presenters/period_presenter_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Wpcc::PeriodPresenter do
 
   describe '#title' do
     it 'converts the name to a more readable format' do
-      period.name = 'april_2017_march_2018'
+      period.name = 'april_2018_march_2019'
       expect(subject.title).to eq('Now')
     end
   end


### PR DESCRIPTION
[TP 8906](https://moneyadviceservice.tpondemand.com/entity/8906-wpcc-remove-the-april-2018-19)

#### Summary

* Removes the box showing contributions for the 2018-2019 period. 
* Also makes some changes to the logic for period filtering. We always want to show the box with contribution amounts for the current period, but only want to show '2019 onwards' if percentages input by the user are lower than or equal to the 2019 thresholds.

_before_

![screen shot 2018-02-19 at 16 09 05](https://user-images.githubusercontent.com/11137272/36387038-b2f2146c-158f-11e8-8d44-61c394c48faf.png)

_after_

![screen shot 2018-02-19 at 16 02 57](https://user-images.githubusercontent.com/11137272/36387044-b637f5ec-158f-11e8-995f-c73cc37a25cc.png)

#### Note

We've commented out a couple of feature specs relating to the messaging shown on the results page about which contributions figures are being shown. The piece of work that will fix these specs is going to be handled in [8908](https://moneyadviceservice.tpondemand.com/entity/8908-wpcc-remove-conditional-messaging-on-the) which we're picking up next.