### PR TITLE
[DEV APPROVED] 8908: Remove conditional messaging on results page

### DIFF
--- a/app/presenters/wpcc/period_filter_presenter.rb
+++ b/app/presenters/wpcc/period_filter_presenter.rb
@@ -1,17 +1,14 @@
 module Wpcc
   class PeriodFilterPresenter < Presenter
     def contribution_percents_explanation
-      @second_period = periods[1]
       @last_period = periods.last
 
       if user_inputs_greater_than_legal_minimums?
-        t('wpcc.results.large_contribution_percent_for_two_periods')
-      elsif user_inputs_between_2nd_and_3rd_period_legal_minimums?
-        t('wpcc.results.large_contribution_percent_for_middle_period')
+        t('wpcc.results.contribution_percentages_over_minimum')
       elsif user_input_for_employee_percent_greater_than_legal_minimums?
-        t('wpcc.results.employee_large_contribution_percent_for_two_periods')
+        t('wpcc.results.employee_contribution_percentage_over_minimum')
       elsif user_input_for_employer_percent_greater_than_legal_minimums?
-        t('wpcc.results.employer_large_contribution_percent_for_two_periods')
+        t('wpcc.results.employer_contribution_percentage_over_minimum')
       end
     end
 
@@ -20,13 +17,6 @@ module Wpcc
     def user_inputs_greater_than_legal_minimums?
       user_input_for_employee_percent_greater_than_legal_minimums? &&
         user_input_for_employer_percent_greater_than_legal_minimums?
-    end
-
-    def user_inputs_between_2nd_and_3rd_period_legal_minimums?
-      user_input_employee_percent >= @second_period.employee_percent &&
-        user_input_employee_percent < @last_period.employee_percent &&
-        user_input_employer_percent >= @second_period.employer_percent &&
-        user_input_employer_percent < @last_period.employer_percent
     end
 
     def user_input_for_employee_percent_greater_than_legal_minimums?

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -121,13 +121,11 @@ cy:
         Bydd cyfraniadau yn seiliedig ar eich cyflog o <span data-wpcc-eligible-salary>%{eligible_salary}</span> y flwyddyn.
       description_minimum_html:
         Bydd cyfraniadau yn seiliedig ar eich enillion cymwys%{tooltip_html} o <span data-wpcc-eligible-salary>%{eligible_salary}</span> y flwyddyn.
-      large_contribution_percent_for_two_periods:
+      contribution_percentages_over_minimum:
         Rydych chi a'ch cyflogwr eisoes yn talu mwy na'r isafswm newydd, felly rydym wedi dangos y cyfraniadau cyfredol yn unig. Ni fydd y rhain yn newid oni bai bod eich cyflog yn cynyddu neu rydych chi ac/neu eich cyflogwr yn dewis talu mwy.
-      large_contribution_percent_for_middle_period:
-        Rydych chi a'ch cyflogwr eisoes yn talu mwy na'r isafswm newydd ar gyfer Ebrill 2018 felly rydym wedi dangos y cynnydd ar gyfer Ebrill 2019 yn unig.
-      employee_large_contribution_percent_for_two_periods:
+      employee_contribution_percentage_over_minimum:
         Rydych chi eisoes yn talu mwy na'r isafswm newydd, felly rydym wedi dangos sut fydd cyfraniadau eich cyflogwr yn cynyddu yn unig. Ni fydd eich cyfraniadau yn newid oni bai bod eich cyflog yn cynyddu neu os ydych yn dewis talu mwy.
-      employer_large_contribution_percent_for_two_periods:
+      employer_contribution_percentage_over_minimum:
         Mae eich cyflogwr eisoes yn talu mwy na'r isafswm newydd, felly rydym wedi dangos sut fydd eich cyfraniadau chi yn cynyddu yn unig. Ni fydd cyfraniad eich cyflogwr yn newid oni bai bod eich cyflog yn cynyddu neu rydych chi neu eich cyflogwr yn dewis talu mwy.
       period_title:
         contributor_title: Cyfrannwr

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -121,13 +121,11 @@ en:
         Contributions will be based on your salary of <span data-wpcc-eligible-salary>%{eligible_salary}</span> per year.
       description_minimum_html:
         Contributions will be based on your qualifying earnings%{tooltip_html} of <span data-wpcc-eligible-salary>%{eligible_salary}</span> per year.
-      large_contribution_percent_for_two_periods:
+      contribution_percentages_over_minimum:
         "Both you and your employer are already paying above the new minimums so we have just shown the current contributions. These won't change unless your salary increases or you and/or your employer choose to pay more."
-      large_contribution_percent_for_middle_period:
-        "Both you and your employer are already paying above the new minimum for April 2018 so we have only shown the increase for April 2019."
-      employee_large_contribution_percent_for_two_periods:
+      employee_contribution_percentage_over_minimum:
         "You are already paying above the new minimums so we have just shown how your employer's contributions will increase. Your contributions won't change unless your salary increases or you choose to pay more."
-      employer_large_contribution_percent_for_two_periods:
+      employer_contribution_percentage_over_minimum:
         "Your employer is already paying above the new minimums so we have just shown how your contributions will increase. Your employer's contribution won't change unless your salary increases or your employer chooses to pay more."
       period_title:
         contributor_title: Contributor

--- a/features/_your_results/message_based_on_contribution_percents.feature
+++ b/features/_your_results/message_based_on_contribution_percents.feature
@@ -6,7 +6,7 @@ Feature: Display messaging based on results table shown in results
   Background:
     Given I have valid details
 
-  Scenario Outline: Employee and Employer contributions are greater than the minimum for 2018 AND 2019
+  Scenario Outline: Employee and Employer contributions are greater than the minimum for 2019
     Given I fill in my contributions:
       | your_contribution | employer_contribution |
       | 5                 | 3                     |
@@ -22,23 +22,7 @@ Feature: Display messaging based on results table shown in results
       | message |
       | Rydych chi a'ch cyflogwr eisoes yn talu mwy na'r isafswm newydd, felly rydym wedi dangos y cyfraniadau cyfredol yn unig. Ni fydd y rhain yn newid oni bai bod eich cyflog yn cynyddu neu rydych chi ac/neu eich cyflogwr yn dewis talu mwy. |
 
-  # Scenario Outline: Employee and Employer contributions are greater than the minimum for 2018 but NOT for 2019
-  #   Given I fill in my contributions:
-  #     | your_contribution | employer_contribution |
-  #     | 3                 | 2.99                  |
-  #   When I move on to the results page
-  #   Then I should see a contribution explanation "<message>"
-  #
-  #   Examples:
-  #     | message |
-  #     | Both you and your employer are already paying above the new minimum for April 2018 so we have only shown the increase for April 2019. |
-  #
-  #   @welsh
-  #   Examples:
-  #     | message |
-  #     | Rydych chi a'ch cyflogwr eisoes yn talu mwy na'r isafswm newydd ar gyfer Ebrill 2018 felly rydym wedi dangos y cynnydd ar gyfer Ebrill 2019 yn unig. |
-
-  Scenario Outline: Only Employee contribution is greater than the minimum for 2018 AND 2019
+  Scenario Outline: Only Employee contribution is greater than the minimum for 2019
     Given I fill in my contributions:
       | your_contribution | employer_contribution |
       | 5                 | 1                     |
@@ -54,7 +38,7 @@ Feature: Display messaging based on results table shown in results
       | message |
       | Rydych chi eisoes yn talu mwy na'r isafswm newydd, felly rydym wedi dangos sut fydd cyfraniadau eich cyflogwr yn cynyddu yn unig. Ni fydd eich cyfraniadau yn newid oni bai bod eich cyflog yn cynyddu neu os ydych yn dewis talu mwy. |
 
-  Scenario Outline: Only Employer contribution is greater than the minimum for 2018 AND 2019
+  Scenario Outline: Only Employer contribution is greater than the minimum for 2019
     Given I fill in my contributions:
       | your_contribution | employer_contribution |
       | 1                 | 3                     |

--- a/spec/presenters/period_filter_presenter_spec.rb
+++ b/spec/presenters/period_filter_presenter_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Wpcc::PeriodFilterPresenter do
 
       it 'returns message' do
         expect(contribution_percents_explanation).to eq(
-          I18n.t('wpcc.results.large_contribution_percent_for_two_periods')
+          I18n.t('wpcc.results.contribution_percentages_over_minimum')
         )
       end
     end
@@ -44,7 +44,7 @@ RSpec.describe Wpcc::PeriodFilterPresenter do
       it 'returns message' do
         expect(contribution_percents_explanation).to eq(
           I18n.t(
-            'wpcc.results.employee_large_contribution_percent_for_two_periods'
+            'wpcc.results.employee_contribution_percentage_over_minimum'
           )
         )
       end
@@ -57,7 +57,7 @@ RSpec.describe Wpcc::PeriodFilterPresenter do
       it 'returns message' do
         expect(contribution_percents_explanation).to eq(
           I18n.t(
-            'wpcc.results.employer_large_contribution_percent_for_two_periods'
+            'wpcc.results.employer_contribution_percentage_over_minimum'
           )
         )
       end


### PR DESCRIPTION
[TP 8908](https://moneyadviceservice.tpondemand.com/entity/8908-wpcc-remove-conditional-messaging-on-the)

#### Summary

Updates the conditional messaging on the results page in line with the removal of the 2018-2019 contributions box. Includes:
* Removal of logic branch, translation and spec for scenario where users input percentage was above the 2018 minimum but NOT the 2019 minimum. 
* Renaming of translations and specs for the other scenarios to remove references to 2018 and the third contributions box which was removed in [8906](https://moneyadviceservice.tpondemand.com/entity/8906-wpcc-remove-the-april-2018-19)