### PR TITLE
[DEV APPROVED] - 8994: Update default contribution percentages for pension contributions based on full salary

### DIFF
--- a/config/contribution_calculations.yml
+++ b/config/contribution_calculations.yml
@@ -4,14 +4,12 @@ salary_thresholds:
 full:
   employee:
     below_threshold: 3
-    above_threshold: 1
-  employer:
-    below_threshold: 0
-    above_threshold: 1
-minimum:
-  employee:
-    below_threshold: 3
     above_threshold: 3
   employer:
-    below_threshold: 2
+    below_threshold: 0
+    above_threshold: 2
+minimum:
+  employee:
+    above_threshold: 3
+  employer:
     above_threshold: 2

--- a/spec/models/full_contribution_calculator_spec.rb
+++ b/spec/models/full_contribution_calculator_spec.rb
@@ -26,8 +26,8 @@ describe Wpcc::FullContributionCalculator, type: :model do
     context 'yearly salary greater than or equal to Lower Earnings Threshold' do
       let(:salary_per_year) { 6_032 }
 
-      it 'returns 1' do
-        expect(subject.employee_percent).to eq(1)
+      it 'returns 3' do
+        expect(subject.employee_percent).to eq(3)
       end
     end
   end
@@ -45,7 +45,7 @@ describe Wpcc::FullContributionCalculator, type: :model do
       let(:salary_per_year) { 6_032 }
 
       it 'returns 1' do
-        expect(subject.employer_percent).to eq(1)
+        expect(subject.employer_percent).to eq(2)
       end
     end
   end


### PR DESCRIPTION
[TP 8994](https://moneyadviceservice.tpondemand.com/entity/8994-wpcc-update-contribution-percentages-for-full)

#### Summary

Updates the default contribution percentages for a user with a salary above the lower threshold who has selected to make contributions based on their full salary, to bring them in line with the legal minimum percentages for 2018-2019.

#### _Notes_

Also removes default contribution percentages for a user with a salary below the lower threshold based on minimum salary, as this is not a valid use case. A user can only select the 'part' salary option if their salary is above the threshold.