### PR TITLE
[DEV APPROVED] 8985: Generalise variables and translations

### DIFF
--- a/app/assets/javascripts/wpcc/components/SalaryConditions.js
+++ b/app/assets/javascripts/wpcc/components/SalaryConditions.js
@@ -10,11 +10,11 @@ define(['jquery', 'DoughBaseComponent'], function($, DoughBaseComponent) {
     // Step 1 - Details
     this.$salaryField = this.$el.find('[data-wpcc-salary-input]');
     this.$salaryFrequency = this.$el.find('[data-wpcc-frequency-select]');
-    this.$callout_below_lower_threshold = this.$el.find('[data-wpcc-callout-lt6032]');
-    this.$callout_btwn_lower_and_auto_enrol_threshold = this.$el.find('[data-wpcc-callout-gt6032_lt10000]');
+    this.$callout_below_lower_threshold = this.$el.find('[data-wpcc-callout-below-lower-threshold]');
+    this.$callout_btwn_lower_and_auto_enrol_threshold = this.$el.find('[data-wpcc-callout-btwn-lower-and-auto-enrol-threshold]');
     this.$callout_near_pension_threshold = this.$el.find('[data-wpcc-callout-near_pension_threshold]');
     this.$callout_near_auto_enrollment_threshold = this.$el.find('[data-wpcc-callout-near_auto_enrollment_threshold]');
-    this.$callout_below_part_contributions_threshold = this.$el.find('[data-wpcc-callout-lt6032-min-contribution]');
+    this.$callout_below_part_contributions_threshold = this.$el.find('[data-wpcc-callout-below-part-contributions-threshold]');
     this.$employerPartRadio = this.$el.find('[data-wpcc-employer-part-radio]');
     this.$employerFullRadio = this.$el.find('[data-wpcc-employer-full-radio]');
     this.contribution = 'part';

--- a/app/assets/javascripts/wpcc/components/SalaryConditions.js
+++ b/app/assets/javascripts/wpcc/components/SalaryConditions.js
@@ -21,9 +21,6 @@ define(['jquery', 'DoughBaseComponent'], function($, DoughBaseComponent) {
 
     // Step 2 - Contributions
     this.optInTriggers = config;
-    this.$employeeTip = this.$el.find('[data-wpcc-employee-tip]');
-    this.$employeeTip_lt6032 = this.$el.find('[data-wpcc-employee-tip-lt6032]');
-    this.$employerTip = this.$el.find('[data-wpcc-employer-tip]');
     this.$employeeContributions = this.$el.find('[data-wpcc-employee-contributions]');
     this.$employerContributions = this.$el.find('[data-wpcc-employer-contributions]');
   };

--- a/app/assets/javascripts/wpcc/components/SalaryConditions.js
+++ b/app/assets/javascripts/wpcc/components/SalaryConditions.js
@@ -10,11 +10,11 @@ define(['jquery', 'DoughBaseComponent'], function($, DoughBaseComponent) {
     // Step 1 - Details
     this.$salaryField = this.$el.find('[data-wpcc-salary-input]');
     this.$salaryFrequency = this.$el.find('[data-wpcc-frequency-select]');
-    this.$callout_lt6032 = this.$el.find('[data-wpcc-callout-lt6032]');
-    this.$callout_gt6032_lt10000 = this.$el.find('[data-wpcc-callout-gt6032_lt10000]');
+    this.$callout_below_lower_threshold = this.$el.find('[data-wpcc-callout-lt6032]');
+    this.$callout_btwn_lower_and_auto_enrol_threshold = this.$el.find('[data-wpcc-callout-gt6032_lt10000]');
     this.$callout_near_pension_threshold = this.$el.find('[data-wpcc-callout-near_pension_threshold]');
     this.$callout_near_auto_enrollment_threshold = this.$el.find('[data-wpcc-callout-near_auto_enrollment_threshold]');
-    this.$callout_lt6032_min_contribution = this.$el.find('[data-wpcc-callout-lt6032-min-contribution]');
+    this.$callout_below_part_contributions_threshold = this.$el.find('[data-wpcc-callout-lt6032-min-contribution]');
     this.$employerPartRadio = this.$el.find('[data-wpcc-employer-part-radio]');
     this.$employerFullRadio = this.$el.find('[data-wpcc-employer-full-radio]');
     this.contribution = 'part';
@@ -123,23 +123,23 @@ define(['jquery', 'DoughBaseComponent'], function($, DoughBaseComponent) {
     var $this          = this,
 
         // salary is below the manual opt limit
-        lt6032         = belowManualOptIn,
+        below_lower_threshold = belowManualOptIn,
 
         // salary is between the manual opt-in limits for the salary frequency
-        gt6032_lt10000 = manualOptInRequired,
+        btwn_lower_and_auto_enrol_threshold = manualOptInRequired,
 
-        // salary is near the pension threshold of 6032
+        // salary is near the lower pension threshold
         nearLowerThreshold = nearPensionThreshold,
 
-        // salary is near the pension threshold of 10000
+        // salary is near the auto enrollment threshold
         nearUpperThreshold = nearAutoEnrollThreshold;
 
-    if (!lt6032 && !gt6032_lt10000){
+    if (!below_lower_threshold && !btwn_lower_and_auto_enrol_threshold){
       $this._defaultRange($this);
-    } else if (lt6032) {
-      $this._lessThan6032($this);
-    } else if (gt6032_lt10000) {
-      $this._between6032and10000($this);
+    } else if (below_lower_threshold) {
+      $this._belowLowerThreshold($this);
+    } else if (btwn_lower_and_auto_enrol_threshold) {
+      $this._btwnLowerandAutoEnrolThreshold($this);
     };
 
     if (nearLowerThreshold){
@@ -162,12 +162,12 @@ define(['jquery', 'DoughBaseComponent'], function($, DoughBaseComponent) {
   // Function for salary outside any conditions
   SalaryConditions.prototype._defaultRange = function($this) {
     // Hide any callouts which are displayed
-    $this.$callout_lt6032.addClass('details__callout--inactive');
-    $this.$callout_lt6032.removeClass('details__callout--active');
-    $this.$callout_gt6032_lt10000.removeClass('details__callout--active');
-    $this.$callout_gt6032_lt10000.addClass('details__callout--inactive');
-    $this.$callout_lt6032_min_contribution.removeClass('details__callout--active');
-    $this.$callout_lt6032_min_contribution.addClass('details__callout--inactive');
+    $this.$callout_below_lower_threshold.addClass('details__callout--inactive');
+    $this.$callout_below_lower_threshold.removeClass('details__callout--active');
+    $this.$callout_btwn_lower_and_auto_enrol_threshold.removeClass('details__callout--active');
+    $this.$callout_btwn_lower_and_auto_enrol_threshold.addClass('details__callout--inactive');
+    $this.$callout_below_part_contributions_threshold.removeClass('details__callout--active');
+    $this.$callout_below_part_contributions_threshold.addClass('details__callout--inactive');
     $this.$callout_near_pension_threshold.removeClass('details__callout--active');
     $this.$callout_near_pension_threshold.addClass('details__callout--inactive');
     $this.$callout_near_auto_enrollment_threshold.removeClass('details__callout--active');
@@ -182,34 +182,34 @@ define(['jquery', 'DoughBaseComponent'], function($, DoughBaseComponent) {
     }
   }
 
-  // Function for salary less than £6032
-  SalaryConditions.prototype._lessThan6032 = function($this) {
+  // Function for salary below lower threshold
+  SalaryConditions.prototype._belowLowerThreshold = function($this) {
     // Show relevant callouts
-    $this.$callout_lt6032.removeClass('details__callout--inactive');
-    $this.$callout_lt6032.addClass('details__callout--active');
-    $this.$callout_lt6032_min_contribution.removeClass('details__callout--inactive');
-    $this.$callout_lt6032_min_contribution.addClass('details__callout--active');
+    $this.$callout_below_lower_threshold.removeClass('details__callout--inactive');
+    $this.$callout_below_lower_threshold.addClass('details__callout--active');
+    $this.$callout_below_part_contributions_threshold.removeClass('details__callout--inactive');
+    $this.$callout_below_part_contributions_threshold.addClass('details__callout--active');
 
     // Hide other callouts if visible
-    $this.$callout_gt6032_lt10000.addClass('details__callout--inactive');
-    $this.$callout_gt6032_lt10000.removeClass('details__callout--active');
+    $this.$callout_btwn_lower_and_auto_enrol_threshold.addClass('details__callout--inactive');
+    $this.$callout_btwn_lower_and_auto_enrol_threshold.removeClass('details__callout--active');
 
     // Disable Employer contributions checkbox
     $this.$employerPartRadio.attr('disabled', true);
     $this.$employerFullRadio.prop('checked', true);
   };
 
-  // Function for salary between £6032 and £10000
-  SalaryConditions.prototype._between6032and10000 = function($this) {
+  // Function for salary between lower and auto enrol thresholds
+  SalaryConditions.prototype._btwnLowerandAutoEnrolThreshold = function($this) {
     // Display relevant callout
-    $this.$callout_gt6032_lt10000.removeClass('details__callout--inactive');
-    $this.$callout_gt6032_lt10000.addClass('details__callout--active');
+    $this.$callout_btwn_lower_and_auto_enrol_threshold.removeClass('details__callout--inactive');
+    $this.$callout_btwn_lower_and_auto_enrol_threshold.addClass('details__callout--active');
 
     // Hide previous callout if active
-    $this.$callout_lt6032.addClass('details__callout--inactive');
-    $this.$callout_lt6032.removeClass('details__callout--active');
-    $this.$callout_lt6032_min_contribution.removeClass('details__callout--active');
-    $this.$callout_lt6032_min_contribution.addClass('details__callout--inactive');
+    $this.$callout_below_lower_threshold.addClass('details__callout--inactive');
+    $this.$callout_below_lower_threshold.removeClass('details__callout--active');
+    $this.$callout_below_part_contributions_threshold.removeClass('details__callout--active');
+    $this.$callout_below_part_contributions_threshold.addClass('details__callout--inactive');
 
     // Enable radio button if disabled
     // And recheck inital option if full not already selected
@@ -220,14 +220,14 @@ define(['jquery', 'DoughBaseComponent'], function($, DoughBaseComponent) {
     }
   }
 
-  // Function for salary close to £6032 callout_near_pension_threshold
+  // Function for salary close to callout_near_pension_threshold
   SalaryConditions.prototype._nearPensionThresholdMessage = function($this) {
     // Show relevant callouts
     $this.$callout_near_pension_threshold.removeClass('details__callout--inactive');
     $this.$callout_near_pension_threshold.addClass('details__callout--active');
   };
 
-  // Function for salary close to £1000 callout-near_auto_enrollment_threshold
+  // Function for salary close to callout-near_auto_enrollment_threshold
   SalaryConditions.prototype._nearAutoEnrollThresholdMessage = function($this) {
     // Show relevant callouts
     $this.$callout_near_auto_enrollment_threshold.removeClass('details__callout--inactive');

--- a/app/presenters/wpcc/message_presenter.rb
+++ b/app/presenters/wpcc/message_presenter.rb
@@ -26,7 +26,7 @@ module Wpcc
     end
 
     def salary_below_pension_limit_message
-      t('wpcc.details.callout__lt6032')
+      t('wpcc.details.callout__below_lower_threshold')
     end
 
     def tax_relief_warning?
@@ -84,7 +84,7 @@ module Wpcc
 
     def employee_contribution_tip
       if salary_below_pension_limit?
-        t('wpcc.contributions.your_contribution_tip_lt6032')
+        t('wpcc.contributions.your_contribution_tip_below_lower_threshold')
       else
         t(
           'wpcc.contributions.your_contribution_tip',

--- a/app/views/wpcc/your_details/new.html.erb
+++ b/app/views/wpcc/your_details/new.html.erb
@@ -115,12 +115,12 @@
           <div class="details__callouts">
             <div class="form__row details__callout details__callout--inactive" data-wpcc-callout-below-lower-threshold>
               <div class="callout">
-                <p><%= t('wpcc.details.callout__lt6032') %></p>
+                <p><%= t('wpcc.details.callout__below_lower_threshold') %></p>
               </div>
             </div>
             <div class="form__row details__callout details__callout--inactive" data-wpcc-callout-btwn-lower-and-auto-enrol-threshold>
               <div class="callout">
-                <p><%= t('wpcc.details.callout__gt6032_lt10000') %></p>
+                <p><%= t('wpcc.details.callout__btwn_lower_and_auto_enrol_threshold') %></p>
               </div>
             </div>
             <div class="form__row details__callout details__callout--inactive" data-wpcc-callout-near_pension_threshold>
@@ -162,7 +162,7 @@
             <div class="details__callouts">
               <div class="form__row details__callout <%= @your_details_form.activate_disabled_callout %>" data-wpcc-callout-below-part-contributions-threshold>
                 <div class="callout">
-                  <p><%= t('wpcc.details.callout__lt6032_min_contribution') %></p>
+                  <p><%= t('wpcc.details.callout__below_part_contributions_threshold') %></p>
                 </div>
               </div>
             </div>

--- a/app/views/wpcc/your_details/new.html.erb
+++ b/app/views/wpcc/your_details/new.html.erb
@@ -113,12 +113,12 @@
             <% end %>
           </div>
           <div class="details__callouts">
-            <div class="form__row details__callout details__callout--inactive" data-wpcc-callout-lt6032>
+            <div class="form__row details__callout details__callout--inactive" data-wpcc-callout-below-lower-threshold>
               <div class="callout">
                 <p><%= t('wpcc.details.callout__lt6032') %></p>
               </div>
             </div>
-            <div class="form__row details__callout details__callout--inactive" data-wpcc-callout-gt6032_lt10000>
+            <div class="form__row details__callout details__callout--inactive" data-wpcc-callout-btwn-lower-and-auto-enrol-threshold>
               <div class="callout">
                 <p><%= t('wpcc.details.callout__gt6032_lt10000') %></p>
               </div>
@@ -160,7 +160,7 @@
               tooltip_hide: t('wpcc.tooltip_hide')
             } %>
             <div class="details__callouts">
-              <div class="form__row details__callout <%= @your_details_form.activate_disabled_callout %>" data-wpcc-callout-lt6032-min-contribution>
+              <div class="form__row details__callout <%= @your_details_form.activate_disabled_callout %>" data-wpcc-callout-below-part-contributions-threshold>
                 <div class="callout">
                   <p><%= t('wpcc.details.callout__lt6032_min_contribution') %></p>
                 </div>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -71,9 +71,9 @@ cy:
       callout__lt16: Rydych yn rhy ifanc i ymuno â phensiwn gweithle. Pan gyrhaeddwch 16 oed gallwch ofyn i’ch cyflogwr eich cofrestru. Os felly, bydd eich cyflogwr yn gwneud cyfraniadau.
       callout__optIn: Ni fydd eich cyflogwr yn eich cofrestru yn awtomatig am bensiwn, ond gallwch ddewis ymuno.
       callout__gt74: Nid ydych yn gymwys i ymuno â phensiwn gweithle gan eich bod yn hŷn na’r uchafswm oed.
-      callout__lt6032: Ni fydd eich cyflogwr yn eich cofrestru yn awtomatig am gynllun pensiwn gweithle, ond gallwch ddewis ymuno. Os felly, ni fydd yn ofynnol i'ch cyflogwr wneud cyfraniadau.
-      callout__lt6032_min_contribution: Ar eich lefel enillion, bydd rhaid i chi wneud cyfraniadau yn seiliedig ar eich cyflog llawn.
-      callout__gt6032_lt10000: Ni fydd eich cyflogwr yn eich cofrestru yn awtomatig am gynllun pensiwn gweithle, ond gallwch ddewis ymuno. Os felly, bydd eich cyflogwr yn gwneud cyfraniadau.
+      callout__below_lower_threshold: Ni fydd eich cyflogwr yn eich cofrestru yn awtomatig am gynllun pensiwn gweithle, ond gallwch ddewis ymuno. Os felly, ni fydd yn ofynnol i'ch cyflogwr wneud cyfraniadau.
+      callout__below_part_contributions_threshold: Ar eich lefel enillion, bydd rhaid i chi wneud cyfraniadau yn seiliedig ar eich cyflog llawn.
+      callout__btwn_lower_and_auto_enrol_threshold: Ni fydd eich cyflogwr yn eich cofrestru yn awtomatig am gynllun pensiwn gweithle, ond gallwch ddewis ymuno. Os felly, bydd eich cyflogwr yn gwneud cyfraniadau.
 
       near_pension_limit_message_html: "Sylwer: Mae eich enillion yn agos iawn at y trothwy lle nad oes raid i’ch cyflogwr gyfrannu at eich pensiwn os dewiswch gofrestru. Dylech wirio i gadarnhau a fydd eich cyflogwr yn cyfrannu neu beidio oherwydd mae’r trothwy hwn yn amrywio yn ddibynnol ar a ydych yn cael eich talu’n fisol, wythnosol neu bob 4 wythnos. <a href='/cy/articles/gall-cofrestru-awtomatig-ennill-hyd-at-10000-i-chi'>Darllenwch fwy am y trothwyon cyflog ar gyfer pensiynau gweithle.</a>"
       near_manual_opt_in_limit_message_html: "Sylwer: Mae eich enillion yn agos iawn at y trothwy cyflog cofrestru awtomatig. Dylech wirio gyda’ch cyflogwr i gadarnhau a ydych yn gymwys neu beidio i gael eich cofrestru’n awtomatig gan fod y trothwyon yn amrywio yn ddibynnol ar a ydych yn cael eich talu’n fisol, wythnosol neu bob 4 wythnos. <a href='/cy/articles/gall-cofrestru-awtomatig-ennill-hyd-at-10000-i-chi'>Darllenwch fwy am y trothwyon cyflog ar gyfer pensiynau gweithle.</a>"
@@ -95,7 +95,7 @@ cy:
       description_full_html: Gwneir cyfraniadau ar eich cyflog o %{eligible_salary} y flwyddyn.
       your_contribution_title: Nodwch eich cyfraniad
       your_contribution_tip: Yr isafswm cyfreithiol yw %{percentage}%
-      your_contribution_tip_lt6032: Ar eich lefel cyflog, nid oes isafswm cyfreithiol o gyfraniad ond efallai y bydd eich cynllun pensiwn gweithlu wedi gosod isafswm. Holwch eich cyflogwr.
+      your_contribution_tip_below_lower_threshold: Ar eich lefel cyflog, nid oes isafswm cyfreithiol o gyfraniad ond efallai y bydd eich cynllun pensiwn gweithlu wedi gosod isafswm. Holwch eich cyflogwr.
       employer_contribution_title: Nodwch gyfraniad eich cyflogwr
       employer_contribution_tip: Yr isafswm cyfreithiol yw %{percentage}%
       input_of_label: '% o'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -71,9 +71,9 @@ en:
       callout__lt16: You are too young to join a workplace pension. When you reach the age of 16 you may ask your employer to enrol you. If you do so, your employer will make contributions.
       callout__optIn: Your employer will not automatically enrol you into a pension but you can choose to join.
       callout__gt74: You are not eligible to join a workplace pension because you are above the maximum age.
-      callout__lt6032: Your employer will not automatically enrol you into a workplace pension scheme but you can choose to join. If you do so, your employer will not be obliged to make contributions.
-      callout__lt6032_min_contribution: At your earnings level, you will have to make contributions based on your full salary.
-      callout__gt6032_lt10000: Your employer will not automatically enrol you into a workplace pension scheme but you can choose to join. If you do so, your employer will make contributions.
+      callout__below_lower_threshold: Your employer will not automatically enrol you into a workplace pension scheme but you can choose to join. If you do so, your employer will not be obliged to make contributions.
+      callout__below_part_contributions_threshold: At your earnings level, you will have to make contributions based on your full salary.
+      callout__btwn_lower_and_auto_enrol_threshold: Your employer will not automatically enrol you into a workplace pension scheme but you can choose to join. If you do so, your employer will make contributions.
 
       near_pension_limit_message_html: "Please note: Your earnings are very close to the threshold at which your employer does not have to contribute to your pension if you choose to enrol. You should check to confirm whether or not your employer will contribute as this threshold varies depending on whether you are paid monthly, weekly or 4-weekly.  <a href='/en/articles/automatic-enrolment-if-you-earn-up-to-10000'>Read more about the salary thresholds for workplace pensions.</a>"
       near_manual_opt_in_limit_message_html: "Please Note: Your earnings are very close to the automatic enrolment salary threshold. You should check with your employer to confirm whether or not you are eligible to be automatically enrolled as the thresholds vary depending on whether you are paid monthly, weekly or 4-weekly. <a href='/en/articles/automatic-enrolment-if-you-earn-up-to-10000'>Read more about the salary thresholds for workplace pensions.</a>"
@@ -95,7 +95,7 @@ en:
       description_full_html:  Contributions will be made on your salary of %{eligible_salary} per year.
       your_contribution_title: Enter your contribution
       your_contribution_tip: The legal minimum is %{percentage}%
-      your_contribution_tip_lt6032: At your salary level there is no legal minimum contribution but your workplace pension scheme may have a set minimum. Check with your employer.
+      your_contribution_tip_below_lower_threshold: At your salary level there is no legal minimum contribution but your workplace pension scheme may have a set minimum. Check with your employer.
       employer_contribution_title: Enter your employer’s contribution
       employer_contribution_tip: The legal minimum is %{percentage}%
       input_of_label: '% of'

--- a/features/_your_contributions/your_contributions_calculating_qualifying_earnings.feature
+++ b/features/_your_contributions/your_contributions_calculating_qualifying_earnings.feature
@@ -20,7 +20,7 @@ Scenario: Calculate minimum contribution for salary equal to or less than the Up
   And I proceed to the next step
   Then the Your Contributions step should tell me my qualifying earnings
 
-Scenario: Calculate on full pay equal to or more than £6032
+Scenario: Calculate on full pay equal to or more than the lower earnings threshold
   And I choose to make full contributions
   And I proceed to the next step
   Then the Your Contributions step should tell me my qualifying earnings are my salary

--- a/features/_your_results/salary_below_minimum_threshold.feature
+++ b/features/_your_results/salary_below_minimum_threshold.feature
@@ -1,6 +1,6 @@
 Feature: Employer contributions do not increase when user's salary is less than the minimum threshold
   In order to understand that there is no requirement for employer contributions to increase over time
-  As an employee earning under £6032 per year
+  As an employee earning under the lower threshold per year
   I need to see employer contributions stay static
 
   Scenario Outline: For monthly, 4-weekly and weekly salary frequencies below the minimum threshold

--- a/features/manually_opt_in_message.feature
+++ b/features/manually_opt_in_message.feature
@@ -1,6 +1,6 @@
-Feature: Conditional messaging for users earning £6032 - £10,000 (inclusive)
+Feature: Conditional messaging for users earning between lower and enrolment thresholds (inclusive)
   In order to understand that I will need to actively opt-in to my workplace's workplace pension scheme,
-  As a worker earning between £6032 and £10,000 (inclusive)
+  As a worker earning between lower and enrolment thresholds (inclusive)
   I want to be notified that I won't be automatically enrolled like my higher earning colleagues
     so that I can take the appropriate action with my employer.
 

--- a/features/near_lowest_pension_messages.feature
+++ b/features/near_lowest_pension_messages.feature
@@ -1,6 +1,6 @@
-Feature: Near limit messaging for users earning close to £6032 per year
-  In order to understand that I am close to the pension threshold of £6032
-  As a worker earning £6032 ± 10
+Feature: Near limit messaging for users earning close to lower salary threshold
+  In order to understand that I am close to the pension threshold
+  As a worker earning the lower salary threshold ± 10
   I want to be notified that my calculation might not be correct
 
   Background:

--- a/features/support/ui/your_details.rb
+++ b/features/support/ui/your_details.rb
@@ -11,7 +11,7 @@ module UI
     element :salary_frequencies, "select[name='your_details_form[salary_frequency]']"
     element :minimum_contribution_button, '#your_details_form_contribution_preference_minimum'
     element :full_contribution_button, '#your_details_form_contribution_preference_full'
-    element :salary_below_threshold_callout, '[data-wpcc-callout-lt6032-min-contribution]'
+    element :salary_below_threshold_callout, '[data-wpcc-callout-below-part-contributions-threshold]'
     element :next_button, "input[type='submit']"
   end
 end

--- a/spec/javascripts/fixtures/SalaryConditions.html
+++ b/spec/javascripts/fixtures/SalaryConditions.html
@@ -9,12 +9,12 @@
       <option value="fourweeks">per 4 weeks</option>
       <option value="week">per Week</option>
     </select>
-    <div class="details__callout--inactive" data-wpcc-callout-lt6032>
+    <div class="details__callout--inactive" data-wpcc-callout-below-lower-threshold>
     </div>
 
-    <div class="details__callout--inactive" data-wpcc-callout-gt6032_lt10000>
+    <div class="details__callout--inactive" data-wpcc-callout-btwn-lower-and-auto-enrol-threshold>
     </div>
-    <div class="details__callout--inactive" data-wpcc-callout-lt6032-min-contribution>
+    <div class="details__callout--inactive" data-wpcc-callout-below-part-contributions-threshold>
     </div>
     <div class="details__callout--inactive" data-wpcc-callout-near_pension_threshold>
     </div>

--- a/spec/javascripts/fixtures/SalaryConditions.html
+++ b/spec/javascripts/fixtures/SalaryConditions.html
@@ -24,10 +24,6 @@
     <input data-wpcc-employer-part-radio="true" name="your_details_form[contribution_preference]" type="radio" value="minimum" checked="true">
     <input data-wpcc-employer-full-radio="true" name="your_details_form[contribution_preference]" type="radio" value="full">
 
-    <p data-wpcc-employee-tip-lt6032 class="is-hidden"></p>
-    <p data-wpcc-employee-tip></p>
-    <p data-wpcc-employer-tip></p>
-
     <input data-wpcc-employee-contributions type="number" value="1" />
     <input data-wpcc-employer-contributions type="number" value="1" />
 

--- a/spec/javascripts/tests/SalaryConditions_spec.js
+++ b/spec/javascripts/tests/SalaryConditions_spec.js
@@ -27,11 +27,11 @@ describe('Salary Conditions', function() {
     beforeEach(function() {
       this.salaryField = this.component.find('[data-wpcc-salary-input]');
       this.salaryFrequency = this.component.find('[data-wpcc-frequency-select]');
-      this.callout_below_lower_threshold = this.component.find('[data-wpcc-callout-lt6032]');
-      this.callout_btwn_lower_and_auto_enrol_threshold = this.component.find('[data-wpcc-callout-gt6032_lt10000]');
+      this.callout_below_lower_threshold = this.component.find('[data-wpcc-callout-below-lower-threshold]');
+      this.callout_btwn_lower_and_auto_enrol_threshold = this.component.find('[data-wpcc-callout-btwn-lower-and-auto-enrol-threshold]');
       this.callout_near_pension_threshold = this.component.find('[data-wpcc-callout-near_pension_threshold]');
       this.callout_near_auto_enrollment_threshold = this.component.find('[data-wpcc-callout-near_auto_enrollment_threshold]');
-      this.callout_below_part_contributions_threshold = this.component.find('[data-wpcc-callout-lt6032-min-contribution]');
+      this.callout_below_part_contributions_threshold = this.component.find('[data-wpcc-callout-below-part-contributions-threshold]');
       this.employerPartRadio = this.component.find('[data-wpcc-employer-part-radio]');
       this.employerFullRadio = this.component.find('[data-wpcc-employer-full-radio]');
 
@@ -254,9 +254,9 @@ describe('Salary Conditions', function() {
 
       this.salaryField = this.component.find('[data-wpcc-salary-input]');
       this.salaryFrequency = this.component.find('[data-wpcc-frequency-select]');
-      this.callout_below_lower_threshold = this.component.find('[data-wpcc-callout-lt6032]');
-      this.callout_btwn_lower_and_auto_enrol_threshold = this.component.find('[data-wpcc-callout-gt6032_lt10000]');
-      this.callout_below_part_contributions_threshold = this.component.find('[data-wpcc-callout-lt6032-min-contribution]');
+      this.callout_below_lower_threshold = this.component.find('[data-wpcc-callout-below-lower-threshold]');
+      this.callout_btwn_lower_and_auto_enrol_threshold = this.component.find('[data-wpcc-callout-btwn-lower-and-auto-enrol-threshold]');
+      this.callout_below_part_contributions_threshold = this.component.find('[data-wpcc-callout-below-part-contributions-threshold]');
       clock = sinon.useFakeTimers();
       this.obj.init();
     });

--- a/spec/javascripts/tests/SalaryConditions_spec.js
+++ b/spec/javascripts/tests/SalaryConditions_spec.js
@@ -65,7 +65,7 @@ describe('Salary Conditions', function() {
       ).to.be.true;
     });
 
-    describe('When salary is less than £6032', function() {
+    describe('When salary is less than the lower threshold', function() {
       it('Shows the correct callout and checks the correct radio control', function(done) {
         this.salaryFrequency.val('year');
         this.salaryField.val('3000');
@@ -117,7 +117,7 @@ describe('Salary Conditions', function() {
       });
     });
 
-    describe('When yearly salary is between £6032 and £10000', function() {
+    describe('When yearly salary is between lower and auto enrol thresholds', function() {
       it('Shows the correct callout and checks the correct radio control', function(done) {
         this.salaryFrequency.val('year')
         this.salaryField.val('7000');
@@ -133,7 +133,7 @@ describe('Salary Conditions', function() {
       });
     });
 
-    describe('When monthly salary is between £503 and £833', function() {
+    describe('When monthly salary is between lower and auto enrol thresholds', function() {
       it('Shows the correct callout and checks the correct radio control', function(done) {
         this.salaryFrequency.val('month')
         this.salaryField.val('503');
@@ -149,7 +149,7 @@ describe('Salary Conditions', function() {
       });
     });
 
-    describe('When 4-weekly salary is between £464 and £768', function() {
+    describe('When 4-weekly salary is between lower and auto enrol thresholds', function() {
       it('Shows the correct callout and checks the correct radio control', function(done) {
         this.salaryFrequency.val('fourweeks')
         this.salaryField.val('500');
@@ -165,7 +165,7 @@ describe('Salary Conditions', function() {
       });
     });
 
-    describe('When weekly salary is between £116 and £192', function() {
+    describe('When weekly salary is between lower and auto enrol thresholds', function() {
       it('Shows the correct callout and checks the correct radio control', function(done) {
         this.salaryFrequency.val('week')
         this.salaryField.val('116');
@@ -181,7 +181,7 @@ describe('Salary Conditions', function() {
       });
     });
 
-    describe('When salary is equal to or greater than £10000', function() {
+    describe('When yearly salary is equal to or greater than the auto enrol threshold', function() {
       it('Does not display any callouts and checks the correct radio control', function(done) {
         this.salaryField.val('22000');
         this.salaryField.trigger('keyup');
@@ -194,7 +194,7 @@ describe('Salary Conditions', function() {
       });
     });
 
-    describe('When yearly salary is within ±£10 of £6032', function() {
+    describe('When yearly salary is within ±£10 of the lower threshold', function() {
       it('Shows the correct callout', function(done) {
         this.salaryFrequency.val('year');
         this.salaryField.val('6022');
@@ -205,7 +205,7 @@ describe('Salary Conditions', function() {
       });
     });
 
-    describe('When yearly salary is NOT within ±£10 of £6032', function() {
+    describe('When yearly salary is NOT within ±£10 of the lower threshold', function() {
       it('Shows the correct callout', function(done) {
         this.salaryFrequency.val('year');
         this.salaryField.val('5865');
@@ -217,7 +217,7 @@ describe('Salary Conditions', function() {
       });
     });
 
-    describe('When yearly salary is within ±£10 of £10,000', function() {
+    describe('When yearly salary is within ±£10 of the auto enrol threshold', function() {
       it('Shows the correct callout', function(done) {
         this.salaryFrequency.val('year');
         this.salaryField.val('9990');
@@ -228,7 +228,7 @@ describe('Salary Conditions', function() {
       });
     });
 
-    describe('When yearly salary is NOT within ±£10 of 10,000', function() {
+    describe('When yearly salary is NOT within ±£10 of the auto enrol threshold', function() {
       it('Shows the correct callout', function(done) {
         this.salaryFrequency.val('year');
         this.salaryField.val('9989');
@@ -298,7 +298,7 @@ describe('Salary Conditions', function() {
       done();
     });
 
-    it('Hides the callout if frequency is changed equalling a salary over £6032', function() {
+    it('Hides the callout if frequency is changed equalling a salary over lower threshold', function() {
       this.salaryField.val('5000');
       this.salaryFrequency.val('year');
       this.salaryField.trigger('keyup');
@@ -315,7 +315,7 @@ describe('Salary Conditions', function() {
 
   });
 
-  describe('When user proceeds to step 2 with salary of £6032 or above', function() {
+  describe('When user proceeds to step 2 with salary of lower threshold or above', function() {
     var clock;
 
     beforeEach(function() {

--- a/spec/javascripts/tests/SalaryConditions_spec.js
+++ b/spec/javascripts/tests/SalaryConditions_spec.js
@@ -27,11 +27,11 @@ describe('Salary Conditions', function() {
     beforeEach(function() {
       this.salaryField = this.component.find('[data-wpcc-salary-input]');
       this.salaryFrequency = this.component.find('[data-wpcc-frequency-select]');
-      this.callout_lt6032 = this.component.find('[data-wpcc-callout-lt6032]');
-      this.callout_gt6032_lt10000 = this.component.find('[data-wpcc-callout-gt6032_lt10000]');
+      this.callout_below_lower_threshold = this.component.find('[data-wpcc-callout-lt6032]');
+      this.callout_btwn_lower_and_auto_enrol_threshold = this.component.find('[data-wpcc-callout-gt6032_lt10000]');
       this.callout_near_pension_threshold = this.component.find('[data-wpcc-callout-near_pension_threshold]');
       this.callout_near_auto_enrollment_threshold = this.component.find('[data-wpcc-callout-near_auto_enrollment_threshold]');
-      this.callout_lt6032_min_contribution = this.component.find('[data-wpcc-callout-lt6032-min-contribution]');
+      this.callout_below_part_contributions_threshold = this.component.find('[data-wpcc-callout-lt6032-min-contribution]');
       this.employerPartRadio = this.component.find('[data-wpcc-employer-part-radio]');
       this.employerFullRadio = this.component.find('[data-wpcc-employer-full-radio]');
 
@@ -53,15 +53,15 @@ describe('Salary Conditions', function() {
       this.salaryFrequency.val('year');
 
       expect(
-        this.callout_lt6032.hasClass('details__callout--inactive')
+        this.callout_below_lower_threshold.hasClass('details__callout--inactive')
       ).to.be.true;
 
       expect(
-        this.callout_gt6032_lt10000.hasClass('details__callout--inactive')
+        this.callout_btwn_lower_and_auto_enrol_threshold.hasClass('details__callout--inactive')
       ).to.be.true;
 
       expect(
-        this.callout_lt6032_min_contribution.hasClass('details__callout--inactive')
+        this.callout_below_part_contributions_threshold.hasClass('details__callout--inactive')
       ).to.be.true;
     });
 
@@ -72,7 +72,7 @@ describe('Salary Conditions', function() {
         this.salaryField.trigger('keyup');
         clock.tick(this.delay);
         expect(
-          this.callout_lt6032.hasClass('details__callout--active')
+          this.callout_below_lower_threshold.hasClass('details__callout--active')
         ).to.be.true;
         expect(
           this.component.find('input[name="your_details_form[contribution_preference]"]:checked').val()
@@ -98,7 +98,7 @@ describe('Salary Conditions', function() {
         this.salaryField.trigger('keyup');
         clock.tick(this.delay);
         expect(
-          this.callout_lt6032_min_contribution.hasClass('details__callout--active')
+          this.callout_below_part_contributions_threshold.hasClass('details__callout--active')
         ).to.be.true;
         expect(
           this.component.find('input[name="your_details_form[contribution_preference]"]:checked').val()
@@ -124,7 +124,7 @@ describe('Salary Conditions', function() {
         this.salaryField.trigger('keyup');
         clock.tick(this.delay);
         expect(
-          this.callout_gt6032_lt10000.hasClass('details__callout--active')
+          this.callout_btwn_lower_and_auto_enrol_threshold.hasClass('details__callout--active')
         ).to.be.true;
         expect(
           this.component.find('input[name="your_details_form[contribution_preference]"]:checked').val()
@@ -140,7 +140,7 @@ describe('Salary Conditions', function() {
         this.salaryField.trigger('keyup');
         clock.tick(this.delay);
         expect(
-          this.callout_gt6032_lt10000.hasClass('details__callout--active')
+          this.callout_btwn_lower_and_auto_enrol_threshold.hasClass('details__callout--active')
         ).to.be.true;
         expect(
           this.component.find('input[name="your_details_form[contribution_preference]"]:checked').val()
@@ -156,7 +156,7 @@ describe('Salary Conditions', function() {
         this.salaryField.trigger('keyup');
         clock.tick(this.delay);
         expect(
-          this.callout_gt6032_lt10000.hasClass('details__callout--active')
+          this.callout_btwn_lower_and_auto_enrol_threshold.hasClass('details__callout--active')
         ).to.be.true;
         expect(
           this.component.find('input[name="your_details_form[contribution_preference]"]:checked').val()
@@ -172,7 +172,7 @@ describe('Salary Conditions', function() {
         this.salaryField.trigger('keyup');
         clock.tick(this.delay);
         expect(
-          this.callout_gt6032_lt10000.hasClass('details__callout--active')
+          this.callout_btwn_lower_and_auto_enrol_threshold.hasClass('details__callout--active')
         ).to.be.true;
         expect(
           this.component.find('input[name="your_details_form[contribution_preference]"]:checked').val()
@@ -186,7 +186,7 @@ describe('Salary Conditions', function() {
         this.salaryField.val('22000');
         this.salaryField.trigger('keyup');
         clock.tick(this.delay);
-        expect(this.callout_gt6032_lt10000.hasClass('details__callout--inactive')).to.be.true;
+        expect(this.callout_btwn_lower_and_auto_enrol_threshold.hasClass('details__callout--inactive')).to.be.true;
         expect(
           this.component.find('input[name="your_details_form[contribution_preference]"]:checked').val()
         ).to.equal('minimum');
@@ -254,9 +254,9 @@ describe('Salary Conditions', function() {
 
       this.salaryField = this.component.find('[data-wpcc-salary-input]');
       this.salaryFrequency = this.component.find('[data-wpcc-frequency-select]');
-      this.callout_lt6032 = this.component.find('[data-wpcc-callout-lt6032]');
-      this.callout_gt6032_lt10000 = this.component.find('[data-wpcc-callout-gt6032_lt10000]');
-      this.callout_lt6032_min_contribution = this.component.find('[data-wpcc-callout-lt6032-min-contribution]');
+      this.callout_below_lower_threshold = this.component.find('[data-wpcc-callout-lt6032]');
+      this.callout_btwn_lower_and_auto_enrol_threshold = this.component.find('[data-wpcc-callout-gt6032_lt10000]');
+      this.callout_below_part_contributions_threshold = this.component.find('[data-wpcc-callout-lt6032-min-contribution]');
       clock = sinon.useFakeTimers();
       this.obj.init();
     });
@@ -271,7 +271,7 @@ describe('Salary Conditions', function() {
       this.salaryField.trigger('keyup');
       clock.tick(this.delay);
       expect(
-        this.callout_lt6032.hasClass('details__callout--active')
+        this.callout_below_lower_threshold.hasClass('details__callout--active')
       ).to.be.true;
       done();
     });
@@ -282,7 +282,7 @@ describe('Salary Conditions', function() {
       this.salaryField.trigger('keyup');
       clock.tick(this.delay);
       expect(
-        this.callout_lt6032.hasClass('details__callout--active')
+        this.callout_below_lower_threshold.hasClass('details__callout--active')
       ).to.be.true;
       done();
     });
@@ -293,7 +293,7 @@ describe('Salary Conditions', function() {
       this.salaryField.trigger('keyup');
       clock.tick(this.delay);
       expect(
-        this.callout_lt6032.hasClass('details__callout--active')
+        this.callout_below_lower_threshold.hasClass('details__callout--active')
       ).to.be.true;
       done();
     });
@@ -304,12 +304,12 @@ describe('Salary Conditions', function() {
       this.salaryField.trigger('keyup');
       clock.tick(this.delay);
       expect(
-        this.callout_lt6032.hasClass('details__callout--active')
+        this.callout_below_lower_threshold.hasClass('details__callout--active')
       ).to.be.true;
 
       this.triggerChange(this.salaryFrequency, 'month');
       expect(
-        this.callout_lt6032.hasClass('details__callout--inactive')
+        this.callout_below_lower_threshold.hasClass('details__callout--inactive')
       ).to.be.true;
     });
 

--- a/spec/javascripts/tests/SalaryConditions_spec.js
+++ b/spec/javascripts/tests/SalaryConditions_spec.js
@@ -322,9 +322,6 @@ describe('Salary Conditions', function() {
       this.salaryField = this.component.find('[data-wpcc-salary-input]');
       this.employeeContributions = this.component.find('[data-wpcc-employee-contributions]');
       this.employerContributions = this.component.find('[data-wpcc-employer-contributions]');
-      this.employeeTip = this.component.find('[data-wpcc-employee-tip]');
-      this.employeeTip_lt6032 = this.component.find('[data-wpcc-employee-tip-lt6032]');
-      this.employerTip = this.component.find('[data-wpcc-employer-tip]');
       clock = sinon.useFakeTimers();
       this.obj.init();
     });
@@ -335,16 +332,6 @@ describe('Salary Conditions', function() {
       clock.tick(this.delay);
       expect(this.employeeContributions.val()).to.equal('1');
       expect(this.employerContributions.val()).to.equal('1');
-      done();
-    });
-
-    it('Displays the correct contribution tips', function(done) {
-      this.salaryField.val('6035');
-      this.salaryField.trigger('keyup');
-      clock.tick(this.delay);
-      expect(this.employeeTip.hasClass('is-hidden')).to.be.false;
-      expect(this.employeeTip_lt6032.hasClass('is-hidden')).to.be.true;
-      expect(this.employerTip.text()).to.not.equal(null);
       done();
     });
   });


### PR DESCRIPTION
[TP 8985](https://moneyadviceservice.tpondemand.com/entity/8985-refactorclean-wpcc-to-allow-for-easier)

#### Summary

This is the first part of some refactoring work in wpcc, being done as part of the new tax year changes.

This PR handles renaming js variables, wpcc-data attributes and translations to avoid referencing specific threshold values and instead use more generic references alluding to the use of the variables.

Additionally, removes `employeeTip` and `employerTip` from the js as the functionality for showing/hiding the correct tips is handled in `MessagePresenter`