### PR TITLE
[DEV APPROVED] Updates brakeman gem version to latest

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ group :development, :test do
 end
 
 group :test do
-  gem 'brakeman', '~> 4.1.1', require: false
+  gem 'brakeman', '~> 4.2.0', require: false
   gem 'capybara'
   gem 'cucumber-rails', require: false
   gem 'poltergeist'


### PR DESCRIPTION
When running `test.sh`, brakeman currently fails as below

``` 
bundle exec brakeman -q --no-pager --ensure-latest
Brakeman 4.1.1 is not the latest version 4.2.0
```

This PR updates to the latest version