### PR TITLE
Bump version to 2.0.0

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,10 @@
+## 2.0.0
+
+* Tax year changes for April 2018
+* Refactor wpcc config yaml files
+* Refactor javascript to be flexible with the threshold values that changes
+each year.
+
 ## 1.14
 
 * Refactoring settings to use a yaml file (including Javascript).

--- a/lib/wpcc/version.rb
+++ b/lib/wpcc/version.rb
@@ -1,7 +1,7 @@
 module Wpcc
   module Version
-    MAJOR = 1
-    MINOR = 14
+    MAJOR = 2
+    MINOR = 0
     PATCH = 0
 
     STRING = [MAJOR, MINOR, PATCH].join('.')


### PR DESCRIPTION
## New version

Work done on #205 

Since it is a big release that changes structural data I decided to bump to 2.0.0.

* Tax year changes for April 2018
* Refactor wpcc config yaml files
* Refactor javascript to be flexible with the threshold values that changes
each year.