### PR TITLE
[DEV APPROVED] TP: 9280, Comment: Updates page title

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ group :development, :test do
 end
 
 group :test do
-  gem 'brakeman', '~> 4.2.0', require: false
+  gem 'brakeman', '~> 4.3.0', require: false
   gem 'capybara'
   gem 'cucumber-rails', require: false
   gem 'poltergeist'

--- a/app/views/wpcc/your_details/new.html.erb
+++ b/app/views/wpcc/your_details/new.html.erb
@@ -1,5 +1,4 @@
-<% set_meta_tags title: [t("wpcc.meta.title"), t("wpcc.details.title")],
-                 reverse: true %>
+<% set_meta_tags title: t("wpcc.meta.title") %>
 
 <section class="section section--details details" data-dough-component="ConditionalMessaging">
   <%= form_for(

--- a/lib/wpcc/version.rb
+++ b/lib/wpcc/version.rb
@@ -1,7 +1,7 @@
 module Wpcc
   module Version
     MAJOR = 2
-    MINOR = 0
+    MINOR = 1
     PATCH = 0
 
     STRING = [MAJOR, MINOR, PATCH].join('.')


### PR DESCRIPTION
[TP9280](https://moneyadviceservice.tpondemand.com/RestUI/Board.aspx#page=board/5624876525867731357&appConfig=eyJhY2lkIjoiREI4ODcwRjkxMDNDRTM2NTlBMzhDNTRBRTVBNUU1N0UifQ==&searchPopup=userstory/9280)

For SEO purposes the page title on the landing page of the WPCC tool is updated from "Your Details - Workplace pension contribution calculator - Money Advice Service" to "Workplace pension contribution calculator - Money Advice Service".