### PR TITLE
[DEV APPROVED] 9256 Callout overlapped bug

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ end
 
 group :test do
   gem 'brakeman', '~> 4.3.0', require: false
-  gem 'capybara'
+  gem 'capybara', '< 3.0'
   gem 'cucumber-rails', require: false
   gem 'poltergeist'
   gem 'simplecov', require: false

--- a/app/assets/stylesheets/wpcc/components/_popup-tip.scss
+++ b/app/assets/stylesheets/wpcc/components/_popup-tip.scss
@@ -1,3 +1,7 @@
+.popup-tip__container.details__helper {
+  z-index: 2;
+}
+
 .popup-tip__button {
   margin: 0;
 

--- a/lib/wpcc/version.rb
+++ b/lib/wpcc/version.rb
@@ -2,7 +2,7 @@ module Wpcc
   module Version
     MAJOR = 2
     MINOR = 1
-    PATCH = 0
+    PATCH = 1
 
     STRING = [MAJOR, MINOR, PATCH].join('.')
   end


### PR DESCRIPTION
# 9256 Callout overlapped bug
[TP9256](https://moneyadviceservice.tpondemand.com/entity/9256-bug-wpcc-callout-overlap)

The PR fixes a bug where the popup/callout was getting overlapped by updating the zindex

## Screenshots
Before:
<img width="504" alt="screen shot 2018-06-20 at 15 30 39" src="https://user-images.githubusercontent.com/3898629/41665117-22c41dda-749f-11e8-8e42-883ca5a8c1a2.png">

After:
<img width="503" alt="screen shot 2018-06-20 at 15 32 06" src="https://user-images.githubusercontent.com/3898629/41665131-27a4d402-749f-11e8-8fcf-d655ea1577a6.png">
