### PR TITLE
Use bundled image for Jenkins

### DIFF
--- a/jenkins/Dockerfile
+++ b/jenkins/Dockerfile
@@ -1,9 +1,9 @@
-FROM masdevtestregistry.azurecr.io/jenkins/ruby2.5.3:latest
-MAINTAINER development.team@moneyadviceservice.org.uk
+FROM masdevtestregistry.azurecr.io/jenkins/sfgb-bundle-2.5.3:latest
 
 RUN apt-get -qq update > /dev/null && \
   apt-get -qq dist-upgrade > /dev/null && \
   apt-get -qq clean  > /dev/null && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-COPY . /var/tmp/app/
+WORKDIR /var/tmp/app/
+COPY . .

--- a/jenkins/test
+++ b/jenkins/test
@@ -5,12 +5,12 @@ set -e
 if [ -f /.dockerenv ]; then
     source ~/.bashrc
     rvm use default
+    rvm gemset list
+    rvm gemset use wpcc
 fi
 
 export RAILS_ENV=test
 export BUNDLE_WITHOUT=development:build
-
-exit_code=0
 
 function run {
     declare -a tests_command=("$@")
@@ -19,7 +19,7 @@ function run {
     echo "=== Running \`${tests_command[*]}\`"
     if ! ${tests_command[*]}; then
         echo "=== These tests failed."
-        exit_code=1
+        exit 1
     fi
 }
 
@@ -33,8 +33,8 @@ function info {
 }
 
 # (re)install node packages to local dir before tests run
-run npm install
 run bundle install
+run npm install
 run bundle update brakeman --quiet
 run bundle exec bowndler install --allow-root
 run bundle exec rubocop .
@@ -46,6 +46,3 @@ info brakeman -q --no-pager --ensure-latest
 if [ -f /.dockerenv ]; then
   run bundle exec danger --dangerfile=jenkins/Dangerfile --verbose
 fi
-
-
-exit "$exit_code"

--- a/wpcc.gemspec
+++ b/wpcc.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   s.test_files = Dir['spec/**/*']
 
-  s.add_dependency 'dough-ruby'
+  s.add_dependency 'dough-ruby', '< 6'
   s.add_dependency 'meta-tags'
   s.add_runtime_dependency 'modernizr-rails', '~> 2.6.2'
 


### PR DESCRIPTION
Use latest bundled image with gem sets pre-installed

- Update test script to go to error on test failure
- Reduces Jenkins test time from 6mins 40sec to 3mins 50secs