### PR TITLE
[DEV APPROVED] TP-10292: Remove "green heading block" from results

### DIFF
--- a/app/assets/stylesheets/wpcc/section/_results.scss
+++ b/app/assets/stylesheets/wpcc/section/_results.scss
@@ -19,16 +19,9 @@
   }
 }
 
-.results__period-title {
-  color: $color-white;
-  background: $color-green-primary;
-  margin: 0 -$baseline-unit*2;
-  padding: $baseline-unit*2;
-}
-
 .results__period-heading {
   font-weight: bold;
-  margin: $baseline-unit*4 0 0;
+  margin: 0;
 }
 
 .results__period-details {

--- a/app/views/wpcc/your_results/_contributions_table.html.erb
+++ b/app/views/wpcc/your_results/_contributions_table.html.erb
@@ -1,7 +1,5 @@
 <div class="results__row">
   <div class="results__period results__period-<%= schedule.name %>" data-dough-component="PopupTip" data-wpcc-results-table>
-    <h3 class="results__period-title" data-wpcc-results-period-title><%= schedule.title %></h3>
-
     <p class="results__period-heading" data-wpcc-period-heading-yours>
       <%= t('wpcc.results.period.contribution_heading.yours_html', salary_frequency: salary_frequency.to_adj) %>
     </p>


### PR DESCRIPTION
[TP-10292](https://moneyadviceservice.tpondemand.com/entity/10292-nty-wpcc-remove-results-block-for)

Results don't show an additional step up block anymore (explaining
future contributions).

As a consequence of that, the contributions block can be displayed
without a heading distinguishing between "Now" and "April 2019.."
contribution values. We have a single block containing the current
and onwards contribution values.

This work removes the green heading with the title of the block left
on the results.

## Changes Output:
### In dummy app:
![screenshot from 2019-03-06 11-15-23](https://user-images.githubusercontent.com/1227578/53877494-392e6e80-4001-11e9-8a88-25fe749ff38c.png)

### In Frontend:
![screenshot from 2019-03-06 12-09-29](https://user-images.githubusercontent.com/1227578/53880408-d345e500-4008-11e9-933d-aa9abf33de5a.png)
