### PR TITLE
[DEV APPROVED] 10440 Change text on Your Contributions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ group :development, :test do
 end
 
 group :test do
-  gem 'brakeman', '~> 4.4.0', require: false
+  gem 'brakeman', '~> 4.5.0', require: false
   gem 'capybara', '< 3.0'
   gem 'cucumber-rails', require: false
   gem 'danger', require: false

--- a/app/assets/stylesheets/wpcc/section/_contributions.scss
+++ b/app/assets/stylesheets/wpcc/section/_contributions.scss
@@ -39,7 +39,10 @@
   .contributions__source-title {
     @include body(16, 22);
     color: $color-black;
-    margin: $baseline-unit*2 0 0 0;
+    margin: $baseline-unit*2 0;
+    +p {
+      margin-top: 0;
+    }
   }
 
   .contributions__source-input {

--- a/app/presenters/wpcc/earnings_description.rb
+++ b/app/presenters/wpcc/earnings_description.rb
@@ -5,7 +5,6 @@ module Wpcc
     end
 
     def earnings_description(opts = {})
-      contribution_preference = session[:contribution_preference]
       description_key = earnings_description_key
 
       t(
@@ -15,8 +14,19 @@ module Wpcc
       )
     end
 
+    def legal_minimum(opts = {})
+      t(
+        "wpcc.contributions.legal_minimum_#{contribution_preference}_html",
+        tooltip_html: opts[:tooltip_html]
+      )
+    end
+
     def earnings_description_key
       raise NotImplementedError
+    end
+
+    def contribution_preference
+      session[:contribution_preference]
     end
   end
 end

--- a/app/presenters/wpcc/message_presenter.rb
+++ b/app/presenters/wpcc/message_presenter.rb
@@ -83,23 +83,9 @@ module Wpcc
     end
 
     def employee_contribution_tip
-      if salary_below_pension_limit?
-        t('wpcc.contributions.your_contribution_tip_below_lower_threshold')
-      else
-        t(
-          'wpcc.contributions.your_contribution_tip',
-          percentage: employee_percentage
-        )
-      end
-    end
+      return unless salary_below_pension_limit?
 
-    def employer_contribution_tip
-      return if salary_below_pension_limit?
-
-      t(
-        'wpcc.contributions.employer_contribution_tip',
-        percentage: employer_percentage
-      )
+      t('wpcc.contributions.your_contribution_tip_below_lower_threshold')
     end
 
     def employee_percentage

--- a/app/presenters/wpcc/message_presenter.rb
+++ b/app/presenters/wpcc/message_presenter.rb
@@ -83,8 +83,6 @@ module Wpcc
     end
 
     def employee_contribution_tip
-      return unless salary_below_pension_limit?
-
       t('wpcc.contributions.your_contribution_tip_below_lower_threshold')
     end
 

--- a/app/views/wpcc/your_contributions/new.html.erb
+++ b/app/views/wpcc/your_contributions/new.html.erb
@@ -25,9 +25,18 @@
       classname: 'contributions__helper',
       tooltip_hide: t('wpcc.tooltip_hide')
     } %>
+  </div>
+  <div class="contributions__row" data-dough-component="PopupTip">
     <p>
-      <%= t('wpcc.contributions.legal_minimum') %>
+      <% tooltip_trigger_html = popup_tip_trigger options: { text: t('wpcc.tooltip_show') } %>
+      <%= @your_contribution.legal_minimum({ tooltip_html: raw(tooltip_trigger_html) })%>
     </p>
+    <%= popup_tip_content options: {
+      title: t('wpcc.tooltip_legal_minimum.title'),
+      text: t("wpcc.tooltip_legal_minimum.text_#{@your_contribution.contribution_preference}_contribution"),
+      classname: 'contributions__helper',
+      tooltip_hide: t('wpcc.tooltip_hide')
+    } %>
   </div>
 
   <%= form_for(
@@ -46,7 +55,9 @@
               <%= t('wpcc.contributions.your_contribution_title') %>
             </label>
           </h3>
-          <p><%= @message_presenter.employee_contribution_tip %></p>
+          <% if @message_presenter.salary_below_pension_limit? %>
+            <p><%= @message_presenter.employee_contribution_tip %></p>
+          <% end %>
           <%= f.number_field :employee_percent,
             class: "contributions__source-input",
             required: true,
@@ -68,6 +79,7 @@
               <%= t('wpcc.contributions.employer_contribution_title') %>
             </label>
           </h3>
+
           <%= f.number_field :employer_percent,
             class: "contributions__source-input",
             required: true,

--- a/app/views/wpcc/your_contributions/new.html.erb
+++ b/app/views/wpcc/your_contributions/new.html.erb
@@ -25,6 +25,9 @@
       classname: 'contributions__helper',
       tooltip_hide: t('wpcc.tooltip_hide')
     } %>
+    <p>
+      <%= t('wpcc.contributions.legal_minimum') %>
+    </p>
   </div>
 
   <%= form_for(
@@ -65,7 +68,6 @@
               <%= t('wpcc.contributions.employer_contribution_title') %>
             </label>
           </h3>
-          <p><%=  @message_presenter.employer_contribution_tip %></p>
           <%= f.number_field :employer_percent,
             class: "contributions__source-input",
             required: true,

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -94,10 +94,9 @@ cy:
       description_minimum_html: Gwneir cyfraniadau ar eich enillion cymwys%{tooltip_html} o %{eligible_salary} y flwyddyn.
       description_full_html: Gwneir cyfraniadau ar eich cyflog o %{eligible_salary} y flwyddyn.
       your_contribution_title: Nodwch eich cyfraniad
-      your_contribution_tip: Yr isafswm cyfreithiol yw %{percentage}%
       your_contribution_tip_below_lower_threshold: Ar eich lefel cyflog, nid oes isafswm cyfreithiol o gyfraniad ond efallai y bydd eich cynllun pensiwn gweithlu wedi gosod isafswm. Holwch eich cyflogwr.
       employer_contribution_title: Nodwch gyfraniad eich cyflogwr
-      employer_contribution_tip: Yr isafswm cyfreithiol yw %{percentage}%
+      legal_minimum: Some text
       input_of_label: '% o'
       calculate_button: Cyfrifwch eich cyfraniadau
       contribution_gt40000_warning: Rhoddir gostyngiad treth ar gyfraniadau hyd at %{amount} y flwyddyn yn unig, neu 100% o’ch enillion, pa bynnag un sydd leiaf.

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -22,6 +22,10 @@ cy:
     tooltip_qualifying_earnings:
       title: Enillion cymhwyso
       text: Dyma’r rhan o’ch cyflog blynyddol fydd yn cael ei defnyddio i gyfrifo eich cyfraniad pensiwn dan gofrestru awtomatig. Sef eich enillion cyn treth (hyd at derfyn uchafswm o %{formatted_upper_earnings} y flwyddyn) - tynnu’r trothwy enillion isaf o %{formatted_lower_earnings}.
+    tooltip_legal_minimum:
+      title: Legal minimum
+      text_minimum_contribution: "Y ffigwr gofynnol cyffredinol sydd yn rhaid ei dalu i mewn i'ch pensiwn yw 8% o'ch enillion cymwys.  Rhaid i'ch cyflogwr dalu 3% o leiaf, ond os bydd eich cyflogwr yn talu mwy na 3% yna dim ond y balans hyd at 8% sydd angen i chi ei dalu.  Er enghraifft, os bydd eich cyflogwr yn talu 6%, yna dim ond 2% sydd angen i chi ei dalu. Fodd bynnag, po fwyaf y byddwch chi a'ch cyflogwr yn ei dalu i mewn, po uchaf fydd eich incwm ymddeol."
+      text_full_contribution: "Y ffigwr gofynnol cyffredinol sydd yn rhaid ei dalu i mewn i'ch pensiwn yw 8% o'ch enillion cymwys.  Rhaid i'ch cyflogwr dalu 3% o leiaf, ond os bydd eich cyflogwr yn talu mwy na 3% yna dim ond y balans hyd at 8% sydd angen i chi ei dalu.  Er enghraifft, os bydd eich cyflogwr yn talu 6%, yna dim ond 2% sydd angen i chi ei dalu. Fodd bynnag, po fwyaf y byddwch chi a'ch cyflogwr yn ei dalu i mewn, po uchaf fydd eich incwm ymddeol."
 
     title: Cyfrifiannell cyfraniadau pensiwn gweithle
     intro: Mae’n gyfraith erbyn hyn y dylai’r rhan fwyaf o gyflogeion gael eu cofrestru ar gynllun pensiwn gweithle gan eu cyflogwr. Bydd y gyfrifiannell hon yn dangos faint fydd yn cael ei dalu i mewn i'ch pensiwn gennych chi a'ch cyflogwr. 
@@ -96,7 +100,8 @@ cy:
       your_contribution_title: Nodwch eich cyfraniad
       your_contribution_tip_below_lower_threshold: Ar eich lefel cyflog, nid oes isafswm cyfreithiol o gyfraniad ond efallai y bydd eich cynllun pensiwn gweithlu wedi gosod isafswm. Holwch eich cyflogwr.
       employer_contribution_title: Nodwch gyfraniad eich cyflogwr
-      legal_minimum: Some text
+      legal_minimum_minimum_html: Y ffigwr gofynnol cyfreithiol sydd yn rhaid ei dalu i mewn i'ch pensiwn yw 8% y flwyddyn o'r enillion cymwys. Rhaid i'ch cyflogwr dalu 3% o leiaf. Y rhaniad fel arfer yw 5% gan gyflogeion a 3% gan gyflogwyr.%{tooltip_html}
+      legal_minimum_full_html: Y ffigwr gofynnol cyfreithiol sydd yn rhaid ei dalu i mewn i'ch pensiwn yw 8% y flwyddyn. Rhaid i'ch cyflogwr dalu 3% o leiaf ohono. Y rhaniad fel arfer yw 5% gan gyflogeion a 3% gan gyflogwyr.%{tooltip_html}
       input_of_label: '% o'
       calculate_button: Cyfrifwch eich cyfraniadau
       contribution_gt40000_warning: Rhoddir gostyngiad treth ar gyfraniadau hyd at %{amount} y flwyddyn yn unig, neu 100% o’ch enillion, pa bynnag un sydd leiaf.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -22,6 +22,10 @@ en:
     tooltip_qualifying_earnings:
       title: Qualifying earnings
       text: This is the part of your annual pay that will be used to calculate your pension contribution under automatic enrolment. It is your earnings before tax (up to a maximum limit of %{formatted_upper_earnings} per year) – less the lower earnings threshold of %{formatted_lower_earnings}.
+    tooltip_legal_minimum:
+      title: Legal minimum
+      text_minimum_contribution: The overall minimum that must be paid into your pension is 8% of your qualifying earnings.  At least 3% must be paid by your employer,  however if your employer pays more than 3% you need only pay the balance up to 8%.  For example, if your employer pays 6%, you need only pay 2%. However, the more you and your employer pay in, the better your retirement income will be.
+      text_full_contribution: The overall minimum that must be paid into your pension is 8% of your earnings.  At least 3% must be paid by your employer,  however if your employer pays more than 3% you need only pay the balance up to 8%.  For example, if your employer pays 6%, you need only pay 2%. However, the more you and your employer pay in, the better your retirement income will be.
 
     title: Workplace pension contribution calculator
     intro: It is now law that most employees must be enrolled into a workplace pension scheme by their employer. This calculator will show you how much will be paid into your pension by you and your employer.
@@ -95,7 +99,8 @@ en:
       description_full_html:  Contributions will be made on your salary of %{eligible_salary} per year.
       your_contribution_title: Enter your contribution
       your_contribution_tip_below_lower_threshold: At your salary level there is no legal minimum contribution but your workplace pension scheme may have a set minimum. Check with your employer.
-      legal_minimum: The legal minimum that must be paid into your pension is 8% a year of qualifying earnings. At least 3% must be paid by your employer. The usual split is 5% from employees and 3% from employers.
+      legal_minimum_minimum_html: The legal minimum that must be paid into your pension is 8% a year of qualifying earnings. At least 3% must be paid by your employer. The usual split is 5% from employees and 3% from employers.%{tooltip_html}
+      legal_minimum_full_html: The legal minimum that must be paid into your pension is 8% a year. At least 3% of this must be paid by your employer. The usual split is 5% from employees and 3% from employers.%{tooltip_html}
       employer_contribution_title: Enter your employer’s contribution
       input_of_label: '% of'
       calculate_button: Calculate your contributions

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -91,13 +91,12 @@ en:
 
     contributions:
       title: Your contributions
-      description_minimum_html:  Contributions will be made on your qualifying earnings%{tooltip_html} of %{eligible_salary} per year.
+      description_minimum_html:  Contributions will be made on your qualifying earnings%{tooltip_html} of %{eligible_salary} a year.
       description_full_html:  Contributions will be made on your salary of %{eligible_salary} per year.
       your_contribution_title: Enter your contribution
-      your_contribution_tip: The legal minimum is %{percentage}%
       your_contribution_tip_below_lower_threshold: At your salary level there is no legal minimum contribution but your workplace pension scheme may have a set minimum. Check with your employer.
+      legal_minimum: The legal minimum that must be paid into your pension is 8% a year of qualifying earnings. At least 3% must be paid by your employer. The usual split is 5% from employees and 3% from employers.
       employer_contribution_title: Enter your employer’s contribution
-      employer_contribution_tip: The legal minimum is %{percentage}%
       input_of_label: '% of'
       calculate_button: Calculate your contributions
       contribution_gt40000_warning: Tax relief is only applied to contributions of up to %{amount} per year or 100% of your earnings, whichever is lower.

--- a/features/_your_contributions/percent_validation.feature
+++ b/features/_your_contributions/percent_validation.feature
@@ -7,22 +7,6 @@ Background:
   Given I am on the Your Details step
   When I fill in my details
 
-Scenario Outline: minimum contribution percentage on salary greater than £6,136
-  And I enter my salary as "6137"
-  And I proceed to the next step
-  And the "employee" contribution intro should display "<employee_message>"
-  And the "employer" contribution intro should display "<employer_message>"
-
-  Examples:
-    | employee_message        | employer_message        |
-    | The legal minimum is 5% | The legal minimum is 3% |
-
-
-  @welsh
-  Examples:
-    | employee_message              | employer_message             |
-    | Yr isafswm cyfreithiol yw 5%  | Yr isafswm cyfreithiol yw 3% |
-
 Scenario Outline: minimum contribution percentage on salary less than £6,032
   And I enter a salary below the minimum threshold
   And I choose to make full contributions

--- a/lib/wpcc/version.rb
+++ b/lib/wpcc/version.rb
@@ -1,7 +1,7 @@
 module Wpcc
   module Version
     MAJOR = 2
-    MINOR = 4
+    MINOR = 5
     PATCH = 0
 
     STRING = [MAJOR, MINOR, PATCH].join('.')

--- a/spec/presenters/message_presenter_spec.rb
+++ b/spec/presenters/message_presenter_spec.rb
@@ -168,41 +168,5 @@ RSpec.describe Wpcc::MessagePresenter do
         expect(subject.employee_contribution_tip).to eq string
       end
     end
-
-    context 'when the salary is above tax relief threshold' do
-      let(:salary_below_pension_limit?) { false }
-      it 'default legal message' do
-        string = 'The legal minimum is 5%'
-        expect(subject.employee_contribution_tip).to eq string
-      end
-    end
-  end
-
-  describe '#employer_contribution_tip' do
-    before do
-      allow(context).to receive(:session).and_return(session)
-    end
-    let(:session) do
-      {
-        contribution_preference: 'minimum',
-        salary: 25_000,
-        salary_frequency: 'year'
-      }
-    end
-
-    context 'when the salary is below tax relief threshold' do
-      let(:salary_below_pension_limit?) { true }
-      it 'returns no message' do
-        expect(subject.employer_contribution_tip).to be_nil
-      end
-    end
-
-    context 'when the salary is above tax relief threshold' do
-      let(:salary_below_pension_limit?) { false }
-      it 'default legal message' do
-        string = 'The legal minimum is 3%'
-        expect(subject.employer_contribution_tip).to eq string
-      end
-    end
   end
 end

--- a/spec/shared_examples/earnings_description_shared_example.rb
+++ b/spec/shared_examples/earnings_description_shared_example.rb
@@ -32,7 +32,7 @@ RSpec.shared_examples_for 'an earnings conditional message' do
       it 'should return qualifying earnings description' do
         # rubocop:disable LineLength
         qualifying_earnings =
-          'Contributions will be made on your qualifying earnings of £19,124 per year.'
+          'Contributions will be made on your qualifying earnings of £19,124 a year.'
         # rubocop:enable LineLength
         expect(subject.earnings_description).to eq qualifying_earnings
       end


### PR DESCRIPTION
To make it clear to users they can contribute less than the minimum percentage in some circumstances, the text has been altered and an additional tooltip added.

[TP-10440](https://moneyadviceservice.tpondemand.com/entity/10440-wpcc-text-changes-on-step-2)