### PR TITLE
[DEV APPROVED] 10508 Improvements to Step 2 display

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ group :development, :test do
 end
 
 group :test do
-  gem 'brakeman', '~> 4.5.0', require: false
+  gem 'brakeman', '~> 4.5.1', require: false
   gem 'capybara', '< 3.0'
   gem 'cucumber-rails', require: false
   gem 'danger', require: false

--- a/app/assets/stylesheets/wpcc/components/_popup-tip.scss
+++ b/app/assets/stylesheets/wpcc/components/_popup-tip.scss
@@ -1,7 +1,3 @@
-.popup-tip__container.details__helper {
-  z-index: 2;
-}
-
 .popup-tip__button {
   margin: 0;
 

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -9,7 +9,7 @@ cy:
               less_than_or_equal_to: Nid ydych yn gymwys i ymuno â phensiwn gweithle gan eich bod yn hŷn na’r uchafswm oed.
         wpcc/your_contributions_form:
           attributes:
-            employer_percent: Rhaid i gyfraniad y cyflogwr fod yn 3% o leiaf
+            employer_percent: Rhaid i gyfraniad y cyflogwr fod yn yr ystod 3 - 100%
   minimum_combined_contribution: Rhaid i gyfanswm y cyfraniad fod yn 8% o leia
   dough:
     forms:
@@ -114,7 +114,7 @@ cy:
         out_of_range: Rhaid i'ch cyfraniad fod yn yr ystod 0 - 100%
       employer_validation:
         blank: Rhowch gyfraniad eich cyflogwr
-        out_of_range: Rhaid i gyfraniad y cyflogwr fod yn 3% o leiaf
+        out_of_range: Rhaid i gyfraniad y cyflogwr fod yn yr ystod 3 - 100%
       manually_opt_in: |
         Ni fydd eich cyflogwr yn eich cofrestru yn awtomatig am gynllun pensiwn
         gweithle, ond gallwch ddewis ymuno. Os felly, bydd eich cyflogwr yn

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -9,7 +9,7 @@ en:
               less_than_or_equal_to: You are not eligible to join a workplace pension because you are above the maximum age.
         wpcc/your_contributions_form:
           attributes:
-            employer_percent: Employer contribution must be at least 3%
+            employer_percent: Employer contribution must be between 3 and 100%
   minimum_combined_contribution: Total contribution must be at least 8%
   dough:
     forms:
@@ -114,7 +114,7 @@ en:
         out_of_range: Your contribution must be in the range 0% - 100%
       employer_validation:
         blank: Please enter your employer’s contribution
-        out_of_range: Employer contribution must be at least 3%
+        out_of_range: Employer contribution must be in the range 3% - 100%
       manually_opt_in: |
         Your employer will not automatically enrol you into a workplace pension
         scheme but you can choose to join. If you do so, your employer will make

--- a/lib/wpcc/version.rb
+++ b/lib/wpcc/version.rb
@@ -1,7 +1,7 @@
 module Wpcc
   module Version
     MAJOR = 2
-    MINOR = 7
+    MINOR = 8
     PATCH = 0
 
     STRING = [MAJOR, MINOR, PATCH].join('.')

--- a/wpcc.gemspec
+++ b/wpcc.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   s.test_files = Dir['spec/**/*']
 
-  s.add_dependency 'dough-ruby', '~> 5.37'
+  s.add_dependency 'dough-ruby', '~> 5.38'
   s.add_dependency 'meta-tags'
   s.add_runtime_dependency 'modernizr-rails', '~> 2.6.2'
 

--- a/wpcc.gemspec
+++ b/wpcc.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   s.test_files = Dir['spec/**/*']
 
-  s.add_dependency 'dough-ruby', '~> 5.36'
+  s.add_dependency 'dough-ruby', '~> 5.37'
   s.add_dependency 'meta-tags'
   s.add_runtime_dependency 'modernizr-rails', '~> 2.6.2'
 


### PR DESCRIPTION
[TP 10508](https://moneyadviceservice.tpondemand.com/restui/board.aspx#page=board/5682182231901749200&appConfig=eyJhY2lkIjoiRkRBMzk3RTBGNjU3NDg1RDM4QzczMTJFNzI5MDFBN0MifQ==&boardPopup=userstory/10508/silent)

1. Change the Employer contributions error message to be more reflective of what's required.
2. Adjust the tooltips to display on top of any conditional callout messages that may be displayed.

**MERGE/DEPLOY NOTES**
This pr is dependent on [dough pr 329](https://github.com/moneyadviceservice/dough/pull/329).