### PR TITLE
Bug/tp 11267 reset link 404

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,7 @@ group :development, :test do
   gem 'rb-readline'
   gem 'rspec-rails', '~> 3.5'
   gem 'shoulda-matchers', '~> 3.1'
+  gem 'sprockets', '~> 3.7.2'
 end
 
 group :test do

--- a/app/controllers/wpcc/your_details_controller.rb
+++ b/app/controllers/wpcc/your_details_controller.rb
@@ -2,7 +2,7 @@ module Wpcc
   class YourDetailsController < EngineController
     protect_from_forgery
 
-    before_action SessionResetter, only: :destroy
+    before_action SessionResetter, only: :reset
 
     def new
       @your_details_form = present(Wpcc::YourDetailsForm.new(session_params))
@@ -21,7 +21,7 @@ module Wpcc
       end
     end
 
-    def destroy; end
+    def reset; end
 
     private
 

--- a/app/views/wpcc/your_results/index.html.erb
+++ b/app/views/wpcc/your_results/index.html.erb
@@ -40,7 +40,7 @@
 
     <p><a href="#" data-dough-component="Print"><%= t('wpcc.results.print_link') %></a></p>
     <p><a href="mailto:?body=" data-wpcc-email-link><%= t('wpcc.results.email_link') %></a></p>
-    <p><%= link_to(t('wpcc.results.reset_calculator'), your_detail_path(session), method: :delete) %></p>
+    <p><%= link_to(t('wpcc.results.reset_calculator'), reset_your_detail_path) %></p>
   </div>
 
   <div class="next-steps">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,8 @@
 Wpcc::Engine.routes.draw do
-  resources :your_details, only: %i[new create destroy]
+  resources :your_details, only: %i[new create ]
   resources :your_contributions, only: %i[new create]
   resources :your_results, only: %i[index]
 
   root to: 'your_details#new', as: 'wpcc_root'
+  get 'your_details/reset', to: 'your_details#reset', as: 'reset_your_detail'
 end

--- a/lib/wpcc/version.rb
+++ b/lib/wpcc/version.rb
@@ -2,7 +2,7 @@ module Wpcc
   module Version
     MAJOR = 2
     MINOR = 8
-    PATCH = 1
+    PATCH = 2
 
     STRING = [MAJOR, MINOR, PATCH].join('.')
   end


### PR DESCRIPTION
TP_11267 (fix the reset link)
There are no automated tests that can prove this considering that the google analytics link tracking is only enabled for `production`. 