### PR TITLE
replaces 'Money Advice Service' to 'Money Helper' everywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Wpcc
 
-All the things for Money Advice Service's Workplace Pension Contribution Calculator.
+All the things for Money Helper's Workplace Pension Contribution Calculator.
 
 ## Prerequisites
 

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -20,7 +20,7 @@ cy:
     meta:
       title: Cyfrifiannell cyfraniadau pensiwn gweithle
       description: Bydd y gyfrifiannell hon yn dangos faint fydd yn cael ei dalu i mewn i'ch pensiwn gennych chi a'ch cyflogwr. 
-      canonical_url: https://www.moneyadviceservice.org.uk/cy/tools/cyfrifiannell-cyfraniadau-pensiwn-gweithle
+      canonical_url: https://www.moneyhelper.org/cy/tools/cyfrifiannell-cyfraniadau-pensiwn-gweithle
     tooltip_show: sioe help
     tooltip_hide: cuddio cymorth
     tooltip_qualifying_earnings:
@@ -138,9 +138,9 @@ cy:
           employers_fourweeks_html: Cyfraniad y cyflogwr <span data-wpcc-title-frequency>%{salary_frequency}</span>
           total_html: Cyfanswm y cyfraniad <span data-wpcc-title-frequency>%{salary_frequency}</span>
         tax_relief_html: (yn cynnwys gostyngiad treth o <span data-wpcc-tax-relief-value>%{formatted_tax_relief}</span>)
-      tax_relief_warning_html: Os nad ydych chi'n talu treth incwm ar eich enillion, cewch ostyngiad treth yn unig ar eich cyfraniadau pensiwn os bydd eich cynllun pensiwn yn casglu cyfraniadau yn defnyddio’r hyn a elwir yn ostyngiad treth ar y cychwyn. Rydym wedi tybio bod eich cynllun yn gwneud hyn. Darllenwch ragor yn ein canllaw am <a href="https://www.moneyadviceservice.org.uk/cy/articles/gostyngiad-treth-ach-pensiwn-gweithle" target="_blank">ostyngiadau treth ar eich pensiwn gweithle<span class="visually-hidden"> (Yn agor mewn ffenestr newydd)</span></a>.
+      tax_relief_warning_html: Os nad ydych chi'n talu treth incwm ar eich enillion, cewch ostyngiad treth yn unig ar eich cyfraniadau pensiwn os bydd eich cynllun pensiwn yn casglu cyfraniadau yn defnyddio’r hyn a elwir yn ostyngiad treth ar y cychwyn. Rydym wedi tybio bod eich cynllun yn gwneud hyn. Darllenwch ragor yn ein canllaw am <a href="https://www.moneyhelper.org/cy/articles/gostyngiad-treth-ach-pensiwn-gweithle" target="_blank">ostyngiadau treth ar eich pensiwn gweithle<span class="visually-hidden"> (Yn agor mewn ffenestr newydd)</span></a>.
       tax_relief_warning: Os nad ydych chi'n talu treth incwm ar eich enillion, cewch ostyngiad treth yn unig ar eich cyfraniadau pensiwn os bydd eich cynllun pensiwn yn casglu cyfraniadau yn defnyddio’r hyn a elwir yn ostyngiad treth ar y cychwyn. Rydym wedi tybio bod eich cynllun yn gwneud hyn. Darllenwch ragor yn ein canllaw am ostyngiadau treth ar eich pensiwn gweithle.
-      tax_relief_tooltip_html: Byddwch yn cael gostyngiad treth ar eich cyfraniadau pensiwn sy'n golygu y rhoddir peth o’r arian o'ch cyflog a fyddai wedi mynd i’r llywodraeth fel treth tuag at eich pensiwn yn hytrach. <a href="https://www.moneyadviceservice.org.uk/cy/articles/gostyngiad-treth-ach-pensiwn-gweithle" target="_blank">Darllenwch fwy am sut i gael gostyngiad treth <span class="visually-hidden">(Yn agor mewn ffenestr newydd)</span></a>.
+      tax_relief_tooltip_html: Byddwch yn cael gostyngiad treth ar eich cyfraniadau pensiwn sy'n golygu y rhoddir peth o’r arian o'ch cyflog a fyddai wedi mynd i’r llywodraeth fel treth tuag at eich pensiwn yn hytrach. <a href="https://www.moneyhelper.org/cy/articles/gostyngiad-treth-ach-pensiwn-gweithle" target="_blank">Darllenwch fwy am sut i gael gostyngiad treth <span class="visually-hidden">(Yn agor mewn ffenestr newydd)</span></a>.
       contribution_table_link: Darllen tabl sy’n dangos sut mae isafswm cyfraniadau cyfreithlon yn newid
       print_link: Argraffu eich canlyniadau
       email_link: E-bostio eich canlyniadau
@@ -148,9 +148,9 @@ cy:
       next_steps:
         heading: Y Camau Nesaf
         list:
-          pension_calculator_html: Defnyddiwch ein <a href="https://www.moneyadviceservice.org.uk/cy/tools/cyfrifiannell-pensiwn" target="_blank">Cyfrifiannell Pensiwn <span class="visually-hidden">(Yn agor mewn ffenestr newydd)</span></a> i weld faint o bensiwn y bydd eich cronfa yn ei chronni dros amser.
-          workplace_pensions_html: Dysgwch ragor am <a href="https://www.moneyadviceservice.org.uk/cy/categories/automatic-enrolment" target="_blank">bensiynau gweithle <span class="visually-hidden">(Yn agor mewn ffenestr newydd)</span></a>.
-          budget_planner_html: Defnyddiwch ein <a href="https://www.moneyadviceservice.org.uk/cy/tools/cynllunydd-cyllideb/start" target="_blank">cynllunydd cyllideb <span class="visually-hidden">(Yn agor mewn ffenestr newydd)</span></a> i weld pa effaith y bydd eich cyfraniadau yn eu cael ar eich incwm.
+          pension_calculator_html: Defnyddiwch ein <a href="https://www.moneyhelper.org/cy/tools/cyfrifiannell-pensiwn" target="_blank">Cyfrifiannell Pensiwn <span class="visually-hidden">(Yn agor mewn ffenestr newydd)</span></a> i weld faint o bensiwn y bydd eich cronfa yn ei chronni dros amser.
+          workplace_pensions_html: Dysgwch ragor am <a href="https://www.moneyhelper.org/cy/categories/automatic-enrolment" target="_blank">bensiynau gweithle <span class="visually-hidden">(Yn agor mewn ffenestr newydd)</span></a>.
+          budget_planner_html: Defnyddiwch ein <a href="https://www.moneyhelper.org/cy/tools/cynllunydd-cyllideb/start" target="_blank">cynllunydd cyllideb <span class="visually-hidden">(Yn agor mewn ffenestr newydd)</span></a> i weld pa effaith y bydd eich cyfraniadau yn eu cael ar eich incwm.
       edit_frequency:
         label: Dangos fy nghyfraniadau
         button: Al-gyfrifo

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -20,7 +20,7 @@ en:
     meta:
       title: Workplace pension contribution calculator
       description: Our workplace pension contribution calculator will show how much will be paid into your pension by you and your employer.
-      canonical_url: https://www.moneyadviceservice.org.uk/en/tools/workplace-pension-contribution-calculator
+      canonical_url: https://www.moneyhelper.org/en/tools/workplace-pension-contribution-calculator
     tooltip_show: show help
     tooltip_hide: hide help
     tooltip_qualifying_earnings:
@@ -137,9 +137,9 @@ en:
           employers_html: Employer's <span data-wpcc-title-frequency>%{salary_frequency}</span> contribution
           total_html: Total <span data-wpcc-title-frequency>%{salary_frequency}</span> contributions
         tax_relief_html: (includes tax relief of <span data-wpcc-tax-relief-value>%{formatted_tax_relief}</span>)
-      tax_relief_warning_html: If you don’t pay income tax on your earnings, you will only receive tax relief on your pension contributions if your pension scheme collects contributions using a method known as <em>tax relief at source</em>. We have assumed your scheme does. Read more in our guide about <a href="https://www.moneyadviceservice.org.uk/en/articles/tax-relief-and-your-workplace-pension" target="_blank">tax relief and your workplace pension<span class="visually-hidden"> (opens in a new window)</span></a>.
+      tax_relief_warning_html: If you don’t pay income tax on your earnings, you will only receive tax relief on your pension contributions if your pension scheme collects contributions using a method known as <em>tax relief at source</em>. We have assumed your scheme does. Read more in our guide about <a href="https://www.moneyhelper.org/en/articles/tax-relief-and-your-workplace-pension" target="_blank">tax relief and your workplace pension<span class="visually-hidden"> (opens in a new window)</span></a>.
       tax_relief_warning: If you don’t pay income tax on your earnings, you will only receive tax relief on your pension contributions if your pension scheme collects contributions using a method known as tax relief at source. We have assumed your scheme does. Read more in our guide about tax relief and your workplace pension.
-      tax_relief_tooltip_html: You get tax relief on pension contributions which means some of the money from your pay that would have gone to the government as tax goes towards your pension instead. <a href="https://www.moneyadviceservice.org.uk/en/articles/tax-relief-and-your-workplace-pension" target="_blank">Read more about how you get tax relief <span class="visually-hidden">(opens in a new window)</span></a>.
+      tax_relief_tooltip_html: You get tax relief on pension contributions which means some of the money from your pay that would have gone to the government as tax goes towards your pension instead. <a href="https://www.moneyhelper.org/en/articles/tax-relief-and-your-workplace-pension" target="_blank">Read more about how you get tax relief <span class="visually-hidden">(opens in a new window)</span></a>.
       contribution_table_link: View a table of how legal minimum contributions change
       print_link: Print your results
       email_link: Email your results
@@ -147,9 +147,9 @@ en:
       next_steps:
         heading: Next steps
         list:
-          pension_calculator_html: Use our <a href="https://www.moneyadviceservice.org.uk/en/tools/pension-calculator" target="_blank">Pension Calculator <span class="visually-hidden">(opens in a new window)</span></a> to see how much pension pot you will build over time.
-          workplace_pensions_html: Find out more about <a href="https://www.moneyadviceservice.org.uk/en/categories/automatic-enrolment" target="_blank">workplace pensions <span class="visually-hidden">(opens in a new window)</span></a>.
-          budget_planner_html: Use our <a href="https://www.moneyadviceservice.org.uk/en/tools/budget-planner" target="_blank">budget planner <span class="visually-hidden">(opens in a new window)</span></a> to see what effect your contributions will have on your income.
+          pension_calculator_html: Use our <a href="https://www.moneyhelper.org/en/tools/pension-calculator" target="_blank">Pension Calculator <span class="visually-hidden">(opens in a new window)</span></a> to see how much pension pot you will build over time.
+          workplace_pensions_html: Find out more about <a href="https://www.moneyhelper.org/en/categories/automatic-enrolment" target="_blank">workplace pensions <span class="visually-hidden">(opens in a new window)</span></a>.
+          budget_planner_html: Use our <a href="https://www.moneyhelper.org/en/tools/budget-planner" target="_blank">budget planner <span class="visually-hidden">(opens in a new window)</span></a> to see what effect your contributions will have on your income.
       edit_frequency:
         label: Show my contributions
         button: Recalculate

--- a/features/step_definitions/your_results_steps.rb
+++ b/features/step_definitions/your_results_steps.rb
@@ -56,7 +56,7 @@ Then(/^I should( not| NOT)? see tax relief "([^"]*)"$/) do |should_not, warning_
 end
 
 Then(/^I should see a link to "([^"]*)" which reads "([^"]*)"$/) do |tax_relief_link, tax_relief_link_text|
-  link = "https://www.moneyadviceservice.org.uk/#{@language}/articles/#{tax_relief_link}"
+  link = "https://www.moneyhelper.org/#{@language}/articles/#{tax_relief_link}"
   expect(your_results_page).to have_link(tax_relief_link_text, href: link)
 end
 

--- a/wpcc.gemspec
+++ b/wpcc.gemspec
@@ -7,9 +7,9 @@ require 'wpcc/version'
 Gem::Specification.new do |s|
   s.name        = 'wpcc'
   s.version     = Wpcc::Version::STRING
-  s.authors     = ['Money Advice Service']
+  s.authors     = ['Money Helper']
   s.email       = ['development.team@moneyadviceservice.org.uk']
-  s.homepage    = 'https://www.moneyadviceservice.org.uk'
+  s.homepage    = 'https://www.moneyhelper.org'
   s.summary     = 'Workplace Pensions Cost Calculator'
   s.description = 'Workplace Pensions Cost Calculator'
   s.license     = 'MIT'


### PR DESCRIPTION
Rename occurrences of:
1: 'Money Advice Service' to 'Money Helper'
2: www.moneyadviceservice.org.uk to www.moneyhelper.org


https://dev.azure.com/moneyandpensionsservice/Digital%20Experience%20Platform%20-%20AEM/_sprints/taskboard/NTT%20Data/Digital%20Experience%20Platform%20-%20AEM/Iteration%203%20-%20Readiness/Sprint%2018?workitem=1472