### PR TITLE
12632 state pension age triggers

### DIFF
--- a/app/assets/javascripts/wpcc/components/ConditionalMessaging.js
+++ b/app/assets/javascripts/wpcc/components/ConditionalMessaging.js
@@ -57,8 +57,7 @@ define(['jquery', 'DoughBaseComponent'], function($, DoughBaseComponent) {
         this.$callout_lt16.addClass('details__callout--active');
         this.$submit.attr('disabled', true);
       } else if (age > 15 && age < 22 ||
-                 age > 64 && age <= 74 && gender == 'male' ||
-                 age > 63 && age <= 74 && gender == 'female') {
+                 age > 65 && age <= 74) {
         this.$callout_optIn.removeClass('details__callout--inactive');
         this.$callout_optIn.addClass('details__callout--active');
       } else if (age >= 75) {

--- a/app/views/wpcc/your_details/new.html.erb
+++ b/app/views/wpcc/your_details/new.html.erb
@@ -40,7 +40,7 @@
           tooltip_hide: t('wpcc.tooltip_hide')
         } %>
       </div>
-      <div class="details__row" data-dough-component="PopupTip">
+      <div class="details__row">
         <div class="details__field">
           <%= f.form_row :gender do %>
             <div class="details__field-label">

--- a/app/views/wpcc/your_details/new.html.erb
+++ b/app/views/wpcc/your_details/new.html.erb
@@ -45,9 +45,6 @@
           <%= f.form_row :gender do %>
             <div class="details__field-label">
               <%= f.label :gender, t('wpcc.details.gender.label'), class: 'form__label-heading' %>
-              <%= popup_tip_trigger options: {
-                text: t('wpcc.tooltip_show')
-              } %>
             </div>
             <%= f.errors_for :gender %>
             <%= f.select :gender,
@@ -59,11 +56,6 @@
             %>
           <% end %>
         </div>
-        <%= popup_tip_content options: {
-          text: t('wpcc.details.gender.tooltip'),
-          classname: 'details__helper',
-          tooltip_hide: t('wpcc.tooltip_hide')
-        } %>
       </div>
       <div class="details__row">
         <div class="details__callouts">

--- a/config/config.yml
+++ b/config/config.yml
@@ -1,5 +1,5 @@
 salary_thresholds:
-  upper: 50_000
+  upper: 50_270
   lower: 6_240
 
 contribution_percentages:

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -76,9 +76,9 @@ cy:
       next: Nesaf
       prompt: os gwelwch yn dda dewiswch
 
-      callout__lt16: Rydych yn rhy ifanc i ymuno â phensiwn gweithle. Pan gyrhaeddwch 16 oed gallwch ofyn i’ch cyflogwr eich cofrestru. Os felly, bydd eich cyflogwr yn gwneud cyfraniadau.
-      callout__optIn: Ni fydd eich cyflogwr yn eich cofrestru yn awtomatig am bensiwn, ond gallwch ddewis ymuno.
-      callout__gt74: Nid ydych yn gymwys i ymuno â phensiwn gweithle gan eich bod yn hŷn na’r uchafswm oed.
+      callout__lt16: Rydych yn rhy ifanc i ymuno â phensiwn gweithle. Pan gyrhaeddwch 16 oed gallwch ddewis ymuno.  Os gwnewch hynny, gallai eich cyflogwr wneud cyfraniadau hefyd yn dibynnu ar faint rydych yn ei ennill.
+      callout__optIn: Ni fydd eich cyflogwr yn eich ymrestru'n awtomatig i mewn i bensiwn ond gallwch ddewis ymuno. Os ydych yn ennill mwy na'r lefel is o enillion cymwys, rhaid i'ch cyflogwr gyfrannu hefyd.
+      callout__gt74: Nid oes gennych hawl i gael eich ymrestru'n awtomatig mewn pensiwn gweithle. Mae llawer o'r buddion treth o gynilo i mewn i gynllun pensiwn yn stopio yn 75 oed.
       callout__below_lower_threshold: Ni fydd eich cyflogwr yn eich cofrestru yn awtomatig am gynllun pensiwn gweithle, ond gallwch ddewis ymuno. Os felly, ni fydd yn ofynnol i'ch cyflogwr wneud cyfraniadau.
       callout__below_part_contributions_threshold: Ar eich lefel enillion, bydd rhaid i chi wneud cyfraniadau yn seiliedig ar eich cyflog llawn.
       callout__btwn_lower_and_auto_enrol_threshold: Ni fydd eich cyflogwr yn eich cofrestru yn awtomatig am gynllun pensiwn gweithle, ond gallwch ddewis ymuno. Os felly, bydd eich cyflogwr yn gwneud cyfraniadau.

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -49,7 +49,7 @@ cy:
 
       salary:
         label: Eich cyflog
-        tooltip_html: Rhowch eich cyflog cyn i’r dreth nag unrhyw ddidyniadau eraill gael eu tynnu. Gelwir hyn yn gyflog gros. <a href="/cy/articles/cofrestriad-awtomatig-ar-bensiwn-man-gwaith#cofrestru-awtomatig-pam-fydd-gennych-fwy-nag-un-swydd" target="_blank">Os oes gennych fwy nag un swydd<span class="visually-hidden"> (Yn agor mewn ffenestr newydd)</span></a>, bydd raid i chi roi pob cyflog ar wahân.
+        tooltip_html: Rhowch eich cyflog cyn i’r dreth nag unrhyw ddidyniadau eraill gael eu tynnu. Gelwir hyn yn gyflog gros. <a href="https://www.moneyhelper.org.uk/cy/pensions-and-retirement/auto-enrolment/i-have-more-than-one-job-how-does-this-affect-my-pension" target="_blank">Os oes gennych fwy nag un swydd<span class="visually-hidden"> (Yn agor mewn ffenestr newydd)</span></a>, bydd raid i chi roi pob cyflog ar wahân.
         validation: Nodwch eich cyflog
         frequency:
           label: Frequency

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -44,7 +44,6 @@ en:
 
       gender:
         label: Your gender
-        tooltip: We need to know your gender because the contribution rules vary slightly due to current differences in State Pension retirement dates for men and women.
         validation: Please select your gender
 
       salary:
@@ -76,10 +75,10 @@ en:
       next: Next
       prompt: Please choose
 
-      callout__lt16: You are too young to join a workplace pension. When you reach the age of 16 you may ask your employer to enrol you. If you do so, your employer will make contributions.
-      callout__optIn: Your employer will not automatically enrol you into a pension but you can choose to join.
-      callout__gt74: You are not eligible to join a workplace pension because you are above the maximum age.
-      callout__below_lower_threshold: Your employer will not automatically enrol you into a workplace pension scheme but you can choose to join. If you do so, your employer will not be obliged to make contributions.
+      callout__lt16: You are too young to join a workplace pension. When you reach the age of 16 you can choose to join. If you do so, your employer might make contributions too depending on how much you earn.
+      callout__optIn: Your employer will not automatically enrol you into a pension but you can choose to join. If you earn more than the lower level of qualifying earnings, your employer must also contribute.
+      callout__gt74: You are not entitled to be automatically enrolled into a workplace pension. Many of the tax benefits of saving into a pension stop at age 75.
+      callout__below_lower_threshold: Your employer will not automatically enrol you into a pension but you can choose to join. If you earn more than the lower level of qualifying earnings, your employer must also contribute.
       callout__below_part_contributions_threshold: At your earnings level, you will have to make contributions based on your full salary.
       callout__btwn_lower_and_auto_enrol_threshold: Your employer will not automatically enrol you into a workplace pension scheme but you can choose to join. If you do so, your employer will make contributions.
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -48,7 +48,7 @@ en:
 
       salary:
         label: Your salary
-        tooltip_html: Enter your salary before tax or other deductions are taken off. This is known as your gross salary. <a href="/en/articles/automatic-enrolment-into-a-workplace-pension#automatic-enrolment-when-you-have-more-than-one-job" target="_blank">If you have more than one job<span class="visually-hidden"> (opens in a new window)</span></a>, you will have to enter each salary separately.
+        tooltip_html: Enter your salary before tax or other deductions are taken off. This is known as your gross salary. <a href=" https://www.moneyhelper.org.uk/en/pensions-and-retirement/auto-enrolment/i-have-more-than-one-job-how-does-this-affect-my-pension" target="_blank">If you have more than one job<span class="visually-hidden"> (opens in a new window)</span></a>, you will have to enter each salary separately.
         validation: Please enter your salary
         frequency:
           label: Frequency

--- a/features/_your_contributions/your_contributions_calculating_qualifying_earnings.feature
+++ b/features/_your_contributions/your_contributions_calculating_qualifying_earnings.feature
@@ -12,7 +12,7 @@ Scenario: Calculate on minimum contribution for salary greater than the Upper Ea
   And my salary per year is greater than the upper earnings threshold of £45,000
   And I choose to make minimum contributions
   And I proceed to the next step
-  Then I should see that my qualifying earnings is the limit of "£43,760"
+  Then I should see that my qualifying earnings is the limit of "£44,030"
 
 Scenario: Calculate minimum contribution for salary equal to or less than the Upper Earnings Threshold
   And my salary per year is equal to or less than the upper earnings threshold of £45,000

--- a/features/_your_details/age_validation.feature
+++ b/features/_your_details/age_validation.feature
@@ -32,9 +32,9 @@ Feature: Display validation messages for age
 
     Examples:
       | language | age | validation_message |
-      | English  | 75  | You are not eligible to join a workplace pension because you are above the maximum age |
+      | English  | 75  | You are not entitled to be automatically enrolled into a workplace pension. Many of the tax benefits of saving into a pension stop at age 75. |
 
     @welsh
     Examples:
       | language | age | validation_message |
-      | Welsh    | 80  | Nid ydych yn gymwys i ymuno â phensiwn gweithle gan eich bod yn hŷn na’r uchafswm oed |
+      | Welsh    | 80  | Nid oes gennych hawl i gael eich ymrestru'n awtomatig mewn pensiwn gweithle. Mae llawer o'r buddion treth o gynilo i mewn i gynllun pensiwn yn stopio yn 75 oed. |

--- a/features/manually_opt_in_message.feature
+++ b/features/manually_opt_in_message.feature
@@ -16,10 +16,10 @@ Feature: Conditional messaging for users earning between lower and enrolment thr
 
     Examples:
       | salary  | salary_frequency | message                                                                                                                                                                           |
-      | 6130.99 | per year         | Your employer will not automatically enrol you into a workplace pension scheme but you can choose to join. If you do so, your employer will not be obliged to make contributions. |
-      | 511.99  | per month        | Your employer will not automatically enrol you into a workplace pension scheme but you can choose to join. If you do so, your employer will not be obliged to make contributions. |
-      | 471.99  | per 4 weeks      | Your employer will not automatically enrol you into a workplace pension scheme but you can choose to join. If you do so, your employer will not be obliged to make contributions. |
-      | 115.99  | per week         | Your employer will not automatically enrol you into a workplace pension scheme but you can choose to join. If you do so, your employer will not be obliged to make contributions. |
+      | 6130.99 | per year         | Your employer will not automatically enrol you into a pension but you can choose to join. If you earn more than the lower level of qualifying earnings, your employer must also contribute. |
+      | 511.99  | per month        | Your employer will not automatically enrol you into a pension but you can choose to join. If you earn more than the lower level of qualifying earnings, your employer must also contribute. |
+      | 471.99  | per 4 weeks      | Your employer will not automatically enrol you into a pension but you can choose to join. If you earn more than the lower level of qualifying earnings, your employer must also contribute. |
+      | 115.99  | per week         | Your employer will not automatically enrol you into a pension but you can choose to join. If you earn more than the lower level of qualifying earnings, your employer must also contribute. |
 
     @welsh
     Examples:

--- a/spec/javascripts/tests/ConditionalMessaging_spec.js
+++ b/spec/javascripts/tests/ConditionalMessaging_spec.js
@@ -128,7 +128,7 @@ describe('Conditional Messaging', function() {
         expect(this.callout_gt74.hasClass('details__callout--active')).to.be.false;
         expect(this.callout_gt74.hasClass('details__callout--inactive')).to.be.true;
 
-        // age: 22-63; gender: female
+        // age: 22-65; gender: female
         this.triggerKeyUp(this.ageField, 63);
 
         expect(this.callout_lt16.hasClass('details__callout--active')).to.be.false;
@@ -166,8 +166,8 @@ describe('Conditional Messaging', function() {
         expect(this.callout_gt74.hasClass('details__callout--active')).to.be.false;
         expect(this.callout_gt74.hasClass('details__callout--inactive')).to.be.true;
 
-        // age: 65-74; gender: male
-        this.triggerKeyUp(this.ageField, 65);
+        // age: 66-74; gender: male
+        this.triggerKeyUp(this.ageField, 66);
 
         expect(this.callout_lt16.hasClass('details__callout--active')).to.be.false;
         expect(this.callout_lt16.hasClass('details__callout--inactive')).to.be.true;
@@ -185,7 +185,7 @@ describe('Conditional Messaging', function() {
         expect(this.callout_gt74.hasClass('details__callout--active')).to.be.false;
         expect(this.callout_gt74.hasClass('details__callout--inactive')).to.be.true;
 
-        // age: 64-74; gender: female
+        // age: 66-74; gender: female
         this.triggerChange(this.genderField, 'female');
 
         expect(this.callout_lt16.hasClass('details__callout--active')).to.be.false;
@@ -195,7 +195,7 @@ describe('Conditional Messaging', function() {
         expect(this.callout_gt74.hasClass('details__callout--active')).to.be.false;
         expect(this.callout_gt74.hasClass('details__callout--inactive')).to.be.true;
 
-        this.triggerKeyUp(this.ageField, 64);
+        this.triggerKeyUp(this.ageField, 66);
 
         expect(this.callout_lt16.hasClass('details__callout--active')).to.be.false;
         expect(this.callout_lt16.hasClass('details__callout--inactive')).to.be.true;

--- a/spec/models/minimum_contribution_calculator_spec.rb
+++ b/spec/models/minimum_contribution_calculator_spec.rb
@@ -13,7 +13,7 @@ describe Wpcc::MinimumContributionCalculator, type: :model do
       let(:salary_per_year) { 51_000 }
 
       it 'returns the upper threshold minus the lower threshold' do
-        expect(subject.eligible_salary).to eq(43_760)
+        expect(subject.eligible_salary).to eq(44_030)
       end
     end
     context 'yearly salary less than or equal to Upper Earnings Threshold' do

--- a/spec/presenters/presenter_spec.rb
+++ b/spec/presenters/presenter_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Wpcc::Presenter do
 
   describe '#formatted_upper_earnings' do
     it 'gets the upper earnings threshold and formats it' do
-      expect(subject.formatted_upper_earnings).to eq('£50,000')
+      expect(subject.formatted_upper_earnings).to eq('£50,270')
     end
   end
 


### PR DESCRIPTION
Ticket [TP-12632](https://maps.tpondemand.com/RestUI/Board.aspx#page=board/5175634625349962976&appConfig=eyJhY2lkIjoiREI5QTI2RDFCNTJDN0JFNTQxMDRDRDIyN0ZFNDIzRDYifQ==&boardPopup=userstory/12632/silent)

Removed the tooltip from the gender field
Updated the messages related to the age and gender
Changed the rule for the age to 66 so the correct messages apply to age groups 15-21 & 66-74, <15, 74>
Removed the rules that was checking the gender to display the message
Updated the tests 

Ticket [TP-12642](https://maps.tpondemand.com/RestUI/Board.aspx#page=board/5175634625349962976&appConfig=eyJhY2lkIjoiREI5QTI2RDFCNTJDN0JFNTQxMDRDRDIyN0ZFNDIzRDYifQ==&boardPopup=userstory/12642/silent)

Updated the links in salary tooltip as per the ticket

Also includes TP-12597.